### PR TITLE
Refresh GitHub profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
-- 👋 Hi, I’m @bingran-you
-- To reach me, use bingran.bry@gmail.com
+# Bingran You
 
-<!---
-bingran-you/bingran-you is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+PhD Candidate at UC Berkeley. I work on AI agents, evaluation benchmarks, and developer tooling.
+
+I focus on systems that make agents more reliable, measurable, and useful in real workflows. Below are a few representative projects spanning research, infrastructure, and applied AI products.
+
+## Focus Areas
+
+- Agent evaluation and skills-based benchmarking
+- Deterministic environments for testing long-horizon workflows
+- Applied AI systems that can operate across existing tools
+
+## Selected Work
+
+- [SkillsBench](https://github.com/benchflow-ai/skillsbench) - A benchmark for evaluating how well AI agents use skills.
+- [first-tree](https://github.com/agent-team-foundation/first-tree) - A Git-native context layer for decisions, ownership, and shared team knowledge.
+- [DoWhiz](https://github.com/KnoWhiz/DoWhiz) - An agent-native product for getting work done across email, chat, documents, and related tools.
+- [smolclaw](https://github.com/bingran-you/smolclaw) - Seeded mock environments for testing agent behavior in realistic workflows.
+- [SBTI CLI](https://github.com/bingran-you/sbti-cli) - An offline CLI for testing agent behavior with bundled logic and exportable results.
+- [bem](https://github.com/HaeffnerLab/bem) - Scientific computing code for boundary element and fast multipole methods in Python.
+
+## Contact
+
+- Email: bingran.bry@gmail.com


### PR DESCRIPTION
## Summary
- rewrite the profile README into a concise, professional GitHub homepage
- highlight current focus areas and selected work
- keep the page clean and easy to scan

## Testing
- not run (README-only change)