### PR TITLE
Add social links to profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ I build and study systems that make agents more reliable, measurable, and useful
 - 📄 [ClawsBench: Evaluating Capability and Safety of LLM Productivity Agents in Simulated Workspaces](https://arxiv.org/abs/2604.05172)
 - 📄 [SkillsBench: Benchmarking How Well Agent Skills Work Across Diverse Tasks](https://arxiv.org/abs/2602.12670)
 
-## Contact
+## Connect
 
-- ✉️ bingran.bry@gmail.com
+[![X](https://img.shields.io/badge/-X-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/bingran_bry) [![Google Scholar](https://img.shields.io/badge/-Google%20Scholar-4285F4?style=flat-square&logo=googlescholar&logoColor=white)](https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en&authuser=2) [![Hugging Face](https://img.shields.io/badge/-Hugging%20Face-FFD21E?style=flat-square&logo=huggingface&logoColor=black)](https://huggingface.co/bingran-you) [![LinkedIn](https://img.shields.io/badge/-LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/bingran-you-775b4017b/) [![Email](https://img.shields.io/badge/-Email-EA4335?style=flat-square&logo=gmail&logoColor=white)](mailto:bingran.bry@gmail.com)


### PR DESCRIPTION
## Summary
- replace the bottom Contact section with a cleaner Connect section
- add X, Google Scholar, Hugging Face, LinkedIn, and email links
- use a compact flat-square badge layout to keep the footer clean

## Testing
- not run (README-only change)