### PR TITLE
Add shared curated skills submodule

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../vendor/skills/skills/.curated

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../vendor/skills/skills/.curated

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/skills"]
+	path = vendor/skills
+	url = https://github.com/bingran-you/skills.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -87,3 +87,9 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
   <a href="https://www.linkedin.com/in/bingran-you-775b4017b/"><img alt="LinkedIn" src="https://img.shields.io/badge/-LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white" /></a>
   <a href="mailto:bingran.bry@gmail.com"><img alt="Email" src="https://img.shields.io/badge/-Email-EA4335?style=flat-square&logo=gmail&logoColor=white" /></a>
 </p>
+
+## Repo Notes
+
+- Shared Codex and Claude Code skills are sourced from the `vendor/skills` git submodule and exposed through `.agents/skills` and `.claude/skills`, both of which point to `vendor/skills/skills/.curated`.
+- On a fresh clone, run `git submodule update --init --recursive` or `./scripts/sync_curated_skills.sh init`.
+- After updating `bingran-you/skills`, run `./scripts/sync_curated_skills.sh update` here and commit the submodule pointer bump so the new skills version syncs through GitHub to other machines.

--- a/scripts/sync_curated_skills.sh
+++ b/scripts/sync_curated_skills.sh
@@ -1,0 +1,68 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+SUBMODULE_PATH="vendor/skills"
+
+usage() {
+  cat <<EOF
+Manage the shared curated skills submodule used by Codex and Claude Code.
+
+Usage:
+  $0 status
+  $0 init
+  $0 update
+
+Commands:
+  status  Show the current submodule commit and both skill symlink targets.
+  init    Initialize the submodule after cloning this repo.
+  update  Move the submodule to the latest upstream main commit.
+
+After running 'update', commit the submodule pointer change in this repo so the
+new skills version syncs to GitHub and other machines.
+EOF
+}
+
+show_symlink_status() {
+  local path="$1"
+
+  if [[ -L "$path" ]]; then
+    echo "$path -> $(/usr/bin/readlink "$path")"
+  elif [[ -e "$path" ]]; then
+    echo "$path (exists but is not a symlink)"
+  else
+    echo "$path (missing)"
+  fi
+}
+
+show_status() {
+  git -C "$REPO_ROOT" submodule status -- "$SUBMODULE_PATH"
+  show_symlink_status "$REPO_ROOT/.agents/skills"
+  show_symlink_status "$REPO_ROOT/.claude/skills"
+}
+
+case "${1:-status}" in
+  status)
+    show_status
+    ;;
+  init)
+    git -C "$REPO_ROOT" submodule update --init --recursive "$SUBMODULE_PATH"
+    show_status
+    ;;
+  update)
+    git -C "$REPO_ROOT" submodule update --init --remote "$SUBMODULE_PATH"
+    show_status
+    echo
+    echo "Commit the updated $SUBMODULE_PATH pointer in this repo to share the new skills version."
+    ;;
+  --help|-h|help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add the shared skills repo as a git submodule under vendor/skills
- point both .agents/skills and .claude/skills at the curated skills directory via tracked relative symlinks
- document and script submodule init/update so skill changes can be synchronized across machines through GitHub

## Verification
- ran ./scripts/sync_curated_skills.sh status
- confirmed both loader directories resolve into curated skill entries with find -L
