### PR TITLE
Rename skills submodule root directory

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,1 +1,1 @@
-../vendor/skills/skills/.curated
+../trusted-external-repos/skills/skills/.curated

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,1 @@
-../vendor/skills/skills/.curated
+../trusted-external-repos/skills/skills/.curated

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "vendor/skills"]
-	path = vendor/skills
+[submodule "trusted-external-repos/skills"]
+	path = trusted-external-repos/skills
 	url = https://github.com/bingran-you/skills.git
 	branch = main

--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 
 ## Repo Notes
 
-- Shared Codex and Claude Code skills are sourced from the `vendor/skills` git submodule and exposed through `.agents/skills` and `.claude/skills`, both of which point to `vendor/skills/skills/.curated`.
+- Shared Codex and Claude Code skills are sourced from the `trusted-external-repos/skills` git submodule and exposed through `.agents/skills` and `.claude/skills`, both of which point to `trusted-external-repos/skills/skills/.curated`.
 - On a fresh clone, run `git submodule update --init --recursive` or `./scripts/sync_curated_skills.sh init`.
 - After updating `bingran-you/skills`, run `./scripts/sync_curated_skills.sh update` here and commit the submodule pointer bump so the new skills version syncs through GitHub to other machines.

--- a/scripts/sync_curated_skills.sh
+++ b/scripts/sync_curated_skills.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
 REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
-SUBMODULE_PATH="vendor/skills"
+SUBMODULE_PATH="trusted-external-repos/skills"
 
 usage() {
   cat <<EOF


### PR DESCRIPTION
## Summary
- rename the shared skills submodule root from vendor/skills to trusted-external-repos/skills
- repoint both .agents/skills and .claude/skills to the renamed curated skills location
- update the helper script and README to use the new trusted-external-repos naming

## Verification
- ran ./scripts/sync_curated_skills.sh status
