### PR TITLE
Add gstack as trusted external submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = trusted-external-repos/skills
 	url = https://github.com/bingran-you/skills.git
 	branch = main
+[submodule "trusted-external-repos/gstack"]
+	path = trusted-external-repos/gstack
+	url = https://github.com/bingran-you/gstack.git
+	branch = main


### PR DESCRIPTION
## Summary
- Add `trusted-external-repos/gstack` as a git submodule
- Track the upstream `main` branch in `.gitmodules`

## Testing
- `git submodule status --recursive`