### PR TITLE
Expose gstack skills in managed link farms

### DIFF
--- a/.agents/skills/gstack
+++ b/.agents/skills/gstack
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack

--- a/.agents/skills/gstack-autoplan
+++ b/.agents/skills/gstack-autoplan
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/autoplan

--- a/.agents/skills/gstack-benchmark
+++ b/.agents/skills/gstack-benchmark
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/benchmark

--- a/.agents/skills/gstack-browse
+++ b/.agents/skills/gstack-browse
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/browse

--- a/.agents/skills/gstack-canary
+++ b/.agents/skills/gstack-canary
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/canary

--- a/.agents/skills/gstack-careful
+++ b/.agents/skills/gstack-careful
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/careful

--- a/.agents/skills/gstack-checkpoint
+++ b/.agents/skills/gstack-checkpoint
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/checkpoint

--- a/.agents/skills/gstack-codex
+++ b/.agents/skills/gstack-codex
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/codex

--- a/.agents/skills/gstack-connect-chrome
+++ b/.agents/skills/gstack-connect-chrome
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/connect-chrome

--- a/.agents/skills/gstack-cso
+++ b/.agents/skills/gstack-cso
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/cso

--- a/.agents/skills/gstack-design-consultation
+++ b/.agents/skills/gstack-design-consultation
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-consultation

--- a/.agents/skills/gstack-design-html
+++ b/.agents/skills/gstack-design-html
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-html

--- a/.agents/skills/gstack-design-review
+++ b/.agents/skills/gstack-design-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-review

--- a/.agents/skills/gstack-design-shotgun
+++ b/.agents/skills/gstack-design-shotgun
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-shotgun

--- a/.agents/skills/gstack-devex-review
+++ b/.agents/skills/gstack-devex-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/devex-review

--- a/.agents/skills/gstack-document-release
+++ b/.agents/skills/gstack-document-release
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/document-release

--- a/.agents/skills/gstack-freeze
+++ b/.agents/skills/gstack-freeze
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/freeze

--- a/.agents/skills/gstack-guard
+++ b/.agents/skills/gstack-guard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/guard

--- a/.agents/skills/gstack-health
+++ b/.agents/skills/gstack-health
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/health

--- a/.agents/skills/gstack-investigate
+++ b/.agents/skills/gstack-investigate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/investigate

--- a/.agents/skills/gstack-land-and-deploy
+++ b/.agents/skills/gstack-land-and-deploy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/land-and-deploy

--- a/.agents/skills/gstack-learn
+++ b/.agents/skills/gstack-learn
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/learn

--- a/.agents/skills/gstack-office-hours
+++ b/.agents/skills/gstack-office-hours
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/office-hours

--- a/.agents/skills/gstack-open-gstack-browser
+++ b/.agents/skills/gstack-open-gstack-browser
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/open-gstack-browser

--- a/.agents/skills/gstack-openclaw-ceo-review
+++ b/.agents/skills/gstack-openclaw-ceo-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-ceo-review

--- a/.agents/skills/gstack-openclaw-investigate
+++ b/.agents/skills/gstack-openclaw-investigate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-investigate

--- a/.agents/skills/gstack-openclaw-office-hours
+++ b/.agents/skills/gstack-openclaw-office-hours
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-office-hours

--- a/.agents/skills/gstack-openclaw-retro
+++ b/.agents/skills/gstack-openclaw-retro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-retro

--- a/.agents/skills/gstack-pair-agent
+++ b/.agents/skills/gstack-pair-agent
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/pair-agent

--- a/.agents/skills/gstack-plan-ceo-review
+++ b/.agents/skills/gstack-plan-ceo-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-ceo-review

--- a/.agents/skills/gstack-plan-design-review
+++ b/.agents/skills/gstack-plan-design-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-design-review

--- a/.agents/skills/gstack-plan-devex-review
+++ b/.agents/skills/gstack-plan-devex-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-devex-review

--- a/.agents/skills/gstack-plan-eng-review
+++ b/.agents/skills/gstack-plan-eng-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-eng-review

--- a/.agents/skills/gstack-qa
+++ b/.agents/skills/gstack-qa
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/qa

--- a/.agents/skills/gstack-qa-only
+++ b/.agents/skills/gstack-qa-only
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/qa-only

--- a/.agents/skills/gstack-retro
+++ b/.agents/skills/gstack-retro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/retro

--- a/.agents/skills/gstack-review
+++ b/.agents/skills/gstack-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/review

--- a/.agents/skills/gstack-setup-browser-cookies
+++ b/.agents/skills/gstack-setup-browser-cookies
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/setup-browser-cookies

--- a/.agents/skills/gstack-setup-deploy
+++ b/.agents/skills/gstack-setup-deploy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/setup-deploy

--- a/.agents/skills/gstack-ship
+++ b/.agents/skills/gstack-ship
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/ship

--- a/.agents/skills/gstack-unfreeze
+++ b/.agents/skills/gstack-unfreeze
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/unfreeze

--- a/.agents/skills/gstack-upgrade
+++ b/.agents/skills/gstack-upgrade
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/gstack-upgrade

--- a/.claude/skills/gstack
+++ b/.claude/skills/gstack
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack

--- a/.claude/skills/gstack-autoplan
+++ b/.claude/skills/gstack-autoplan
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/autoplan

--- a/.claude/skills/gstack-benchmark
+++ b/.claude/skills/gstack-benchmark
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/benchmark

--- a/.claude/skills/gstack-browse
+++ b/.claude/skills/gstack-browse
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/browse

--- a/.claude/skills/gstack-canary
+++ b/.claude/skills/gstack-canary
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/canary

--- a/.claude/skills/gstack-careful
+++ b/.claude/skills/gstack-careful
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/careful

--- a/.claude/skills/gstack-checkpoint
+++ b/.claude/skills/gstack-checkpoint
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/checkpoint

--- a/.claude/skills/gstack-codex
+++ b/.claude/skills/gstack-codex
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/codex

--- a/.claude/skills/gstack-connect-chrome
+++ b/.claude/skills/gstack-connect-chrome
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/connect-chrome

--- a/.claude/skills/gstack-cso
+++ b/.claude/skills/gstack-cso
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/cso

--- a/.claude/skills/gstack-design-consultation
+++ b/.claude/skills/gstack-design-consultation
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-consultation

--- a/.claude/skills/gstack-design-html
+++ b/.claude/skills/gstack-design-html
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-html

--- a/.claude/skills/gstack-design-review
+++ b/.claude/skills/gstack-design-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-review

--- a/.claude/skills/gstack-design-shotgun
+++ b/.claude/skills/gstack-design-shotgun
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/design-shotgun

--- a/.claude/skills/gstack-devex-review
+++ b/.claude/skills/gstack-devex-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/devex-review

--- a/.claude/skills/gstack-document-release
+++ b/.claude/skills/gstack-document-release
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/document-release

--- a/.claude/skills/gstack-freeze
+++ b/.claude/skills/gstack-freeze
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/freeze

--- a/.claude/skills/gstack-guard
+++ b/.claude/skills/gstack-guard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/guard

--- a/.claude/skills/gstack-health
+++ b/.claude/skills/gstack-health
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/health

--- a/.claude/skills/gstack-investigate
+++ b/.claude/skills/gstack-investigate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/investigate

--- a/.claude/skills/gstack-land-and-deploy
+++ b/.claude/skills/gstack-land-and-deploy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/land-and-deploy

--- a/.claude/skills/gstack-learn
+++ b/.claude/skills/gstack-learn
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/learn

--- a/.claude/skills/gstack-office-hours
+++ b/.claude/skills/gstack-office-hours
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/office-hours

--- a/.claude/skills/gstack-open-gstack-browser
+++ b/.claude/skills/gstack-open-gstack-browser
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/open-gstack-browser

--- a/.claude/skills/gstack-openclaw-ceo-review
+++ b/.claude/skills/gstack-openclaw-ceo-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-ceo-review

--- a/.claude/skills/gstack-openclaw-investigate
+++ b/.claude/skills/gstack-openclaw-investigate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-investigate

--- a/.claude/skills/gstack-openclaw-office-hours
+++ b/.claude/skills/gstack-openclaw-office-hours
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-office-hours

--- a/.claude/skills/gstack-openclaw-retro
+++ b/.claude/skills/gstack-openclaw-retro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/openclaw/skills/gstack-openclaw-retro

--- a/.claude/skills/gstack-pair-agent
+++ b/.claude/skills/gstack-pair-agent
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/pair-agent

--- a/.claude/skills/gstack-plan-ceo-review
+++ b/.claude/skills/gstack-plan-ceo-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-ceo-review

--- a/.claude/skills/gstack-plan-design-review
+++ b/.claude/skills/gstack-plan-design-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-design-review

--- a/.claude/skills/gstack-plan-devex-review
+++ b/.claude/skills/gstack-plan-devex-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-devex-review

--- a/.claude/skills/gstack-plan-eng-review
+++ b/.claude/skills/gstack-plan-eng-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/plan-eng-review

--- a/.claude/skills/gstack-qa
+++ b/.claude/skills/gstack-qa
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/qa

--- a/.claude/skills/gstack-qa-only
+++ b/.claude/skills/gstack-qa-only
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/qa-only

--- a/.claude/skills/gstack-retro
+++ b/.claude/skills/gstack-retro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/retro

--- a/.claude/skills/gstack-review
+++ b/.claude/skills/gstack-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/review

--- a/.claude/skills/gstack-setup-browser-cookies
+++ b/.claude/skills/gstack-setup-browser-cookies
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/setup-browser-cookies

--- a/.claude/skills/gstack-setup-deploy
+++ b/.claude/skills/gstack-setup-deploy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/setup-deploy

--- a/.claude/skills/gstack-ship
+++ b/.claude/skills/gstack-ship
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/ship

--- a/.claude/skills/gstack-unfreeze
+++ b/.claude/skills/gstack-unfreeze
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/unfreeze

--- a/.claude/skills/gstack-upgrade
+++ b/.claude/skills/gstack-upgrade
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/gstack-upgrade

--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 
 ## Repo Notes
 
-- Shared Codex and Claude Code skills are assembled from the `trusted-external-repos/skills` and `trusted-external-repos/oh-my-codex` git submodules. The `.agents/skills` and `.claude/skills` directories are managed link farms that expose both skill sets side by side.
+- Shared Codex and Claude Code skills are assembled from the `trusted-external-repos/skills`, `trusted-external-repos/oh-my-codex`, and `trusted-external-repos/gstack` git submodules. The `.agents/skills` and `.claude/skills` directories are managed link farms that expose all three skill sets side by side; gstack skills are namespaced with `gstack-*` plus `gstack` itself to avoid collisions with other skill packs.
 - On a fresh clone, run `git submodule update --init --recursive` or `./scripts/sync_external_skills.sh init`.
 - After updating either external skills repo, run `./scripts/sync_external_skills.sh update` here and commit the submodule pointer bump(s) plus regenerated skill links so the new skills sync through GitHub to other machines.

--- a/scripts/sync_external_skills.sh
+++ b/scripts/sync_external_skills.sh
@@ -13,6 +13,16 @@ OMX_SUBMODULE_PATH="trusted-external-repos/oh-my-codex"
 OMX_SOURCE_PATH="$REPO_ROOT/$OMX_SUBMODULE_PATH/skills"
 OMX_LINK_PREFIX="../../$OMX_SUBMODULE_PATH/skills"
 
+GSTACK_SUBMODULE_PATH="trusted-external-repos/gstack"
+GSTACK_SOURCE_PATH="$REPO_ROOT/$GSTACK_SUBMODULE_PATH"
+GSTACK_LINK_PREFIX="../../$GSTACK_SUBMODULE_PATH"
+
+SUBMODULE_PATHS=(
+  "$CURATED_SUBMODULE_PATH"
+  "$OMX_SUBMODULE_PATH"
+  "$GSTACK_SUBMODULE_PATH"
+)
+
 ENTRYPOINT_DIRS=(
   "$REPO_ROOT/.agents/skills"
   "$REPO_ROOT/.claude/skills"
@@ -53,27 +63,39 @@ require_source_dir() {
   fi
 }
 
-collect_skills() {
+register_skill() {
+  local skill_name="$1"
+  local link_target="$2"
+  local source_label="$3"
+
+  if [[ -n "${LINK_SOURCES[$skill_name]-}" ]]; then
+    echo "Skill name conflict: '$skill_name' appears in both '${LINK_SOURCES[$skill_name]}' and '$source_label'." >&2
+    exit 1
+  fi
+
+  LINK_NAMES+=("$skill_name")
+  LINK_TARGETS[$skill_name]="$link_target"
+  LINK_SOURCES[$skill_name]="$source_label"
+}
+
+collect_directory_skills() {
   local source_label="$1"
   local source_path="$2"
   local link_prefix="$3"
+  local name_prefix="${4:-}"
   local skill_dir=""
   local skill_name=""
 
   require_source_dir "$source_path"
 
-  for skill_dir in "$source_path"/*(/N); do
+  for skill_dir in "$source_path"/*(N); do
+    [[ -d "$skill_dir" ]] || continue
     [[ -f "$skill_dir/SKILL.md" ]] || continue
     skill_name="${skill_dir:t}"
-
-    if [[ -n "${LINK_SOURCES[$skill_name]-}" ]]; then
-      echo "Skill name conflict: '$skill_name' appears in both '${LINK_SOURCES[$skill_name]}' and '$source_label'." >&2
-      exit 1
+    if [[ -n "$name_prefix" && "$skill_name" != ${name_prefix}* ]]; then
+      skill_name="${name_prefix}${skill_name}"
     fi
-
-    LINK_NAMES+=("$skill_name")
-    LINK_TARGETS[$skill_name]="$link_prefix/$skill_name"
-    LINK_SOURCES[$skill_name]="$source_label"
+    register_skill "$skill_name" "$link_prefix/${skill_dir:t}" "$source_label"
   done
 }
 
@@ -85,8 +107,17 @@ rebuild_entrypoints() {
   LINK_TARGETS=()
   LINK_SOURCES=()
 
-  collect_skills "curated" "$CURATED_SOURCE_PATH" "$CURATED_LINK_PREFIX"
-  collect_skills "oh-my-codex" "$OMX_SOURCE_PATH" "$OMX_LINK_PREFIX"
+  collect_directory_skills "curated" "$CURATED_SOURCE_PATH" "$CURATED_LINK_PREFIX"
+  collect_directory_skills "oh-my-codex" "$OMX_SOURCE_PATH" "$OMX_LINK_PREFIX"
+
+  require_source_dir "$GSTACK_SOURCE_PATH"
+  [[ -f "$GSTACK_SOURCE_PATH/SKILL.md" ]] || {
+    echo "Missing gstack root skill: $GSTACK_SOURCE_PATH/SKILL.md" >&2
+    exit 1
+  }
+  register_skill "gstack" "$GSTACK_LINK_PREFIX" "gstack"
+  collect_directory_skills "gstack" "$GSTACK_SOURCE_PATH" "$GSTACK_LINK_PREFIX" "gstack-"
+  collect_directory_skills "gstack-openclaw" "$GSTACK_SOURCE_PATH/openclaw/skills" "$GSTACK_LINK_PREFIX/openclaw/skills"
 
   for entrypoint_dir in "${ENTRYPOINT_DIRS[@]}"; do
     rm -rf "$entrypoint_dir"
@@ -115,7 +146,7 @@ show_entrypoint_status() {
 }
 
 show_status() {
-  git -C "$REPO_ROOT" submodule status -- "$CURATED_SUBMODULE_PATH" "$OMX_SUBMODULE_PATH"
+  git -C "$REPO_ROOT" submodule status -- "${SUBMODULE_PATHS[@]}"
   show_entrypoint_status "$REPO_ROOT/.agents/skills"
   show_entrypoint_status "$REPO_ROOT/.claude/skills"
 }
@@ -125,7 +156,7 @@ case "${1:-status}" in
     show_status
     ;;
   init)
-    git -C "$REPO_ROOT" submodule update --init --recursive "$CURATED_SUBMODULE_PATH" "$OMX_SUBMODULE_PATH"
+    git -C "$REPO_ROOT" submodule update --init --recursive "${SUBMODULE_PATHS[@]}"
     rebuild_entrypoints
     show_status
     ;;
@@ -134,7 +165,7 @@ case "${1:-status}" in
     show_status
     ;;
   update)
-    git -C "$REPO_ROOT" submodule update --init --remote "$CURATED_SUBMODULE_PATH" "$OMX_SUBMODULE_PATH"
+    git -C "$REPO_ROOT" submodule update --init --remote "${SUBMODULE_PATHS[@]}"
     rebuild_entrypoints
     show_status
     echo


### PR DESCRIPTION
## Summary
- extend the external skill sync flow to include gstack skills
- expose gstack skills into both `.agents/skills` and `.claude/skills` with `gstack-*` namespacing to avoid collisions
- document the new three-repo skill layout in the README

## Testing
- `zsh -n scripts/sync_external_skills.sh scripts/sync_curated_skills.sh`
- `./scripts/sync_external_skills.sh refresh`