### PR TITLE
Keep githuber from missing or repeating recent thread work

### DIFF
--- a/scripts/githuber/README.md
+++ b/scripts/githuber/README.md
@@ -16,7 +16,7 @@ cargo run --manifest-path scripts/githuber/Cargo.toml -- stop
 
 - Reuses the active `gh` identity for the configured host.
 - Refuses to start if another `githuber` instance is already running for the same `host + login + profile`.
-- Uses unread notifications as the hot poll path and only backfills with GitHub search on a slower reconcile interval.
+- Sweeps actionable notification threads from the last 24 hours on every poll, even if they are already marked read, and only uses GitHub search as a slower backfill path.
 - Creates one isolated `git worktree` per scheduled task.
 - Prepares a local snapshot for each task before the agent starts so the agent can inspect GitHub context without re-fetching it.
 - Launches `codex` and/or `claude` in round-robin order with dangerous local permissions.

--- a/scripts/githuber/src/config.rs
+++ b/scripts/githuber/src/config.rs
@@ -123,6 +123,7 @@ pub struct Config {
     pub max_parallel: usize,
     pub poll_interval_secs: u64,
     pub task_limit: usize,
+    pub notification_lookback_secs: u64,
     pub search_reconcile_interval_secs: u64,
     pub gh_write_cooldown_ms: u64,
     pub workspace_ttl_secs: u64,
@@ -174,6 +175,8 @@ impl Config {
         let mut max_parallel = parse_usize_env("GITHUBER_MAX_PARALLEL").unwrap_or(20);
         let mut poll_interval_secs = parse_u64_env("GITHUBER_POLL_INTERVAL_SECS").unwrap_or(600);
         let mut task_limit = parse_usize_env("GITHUBER_TASK_LIMIT").unwrap_or(100);
+        let mut notification_lookback_secs =
+            parse_u64_env("GITHUBER_NOTIFICATION_LOOKBACK_SECS").unwrap_or(60 * 60 * 24);
         let mut search_reconcile_interval_secs =
             parse_u64_env("GITHUBER_SEARCH_RECONCILE_INTERVAL_SECS").unwrap_or(60 * 60 * 6);
         let mut gh_write_cooldown_ms =
@@ -212,6 +215,9 @@ impl Config {
                 "--max-parallel" => max_parallel = parse_usize(&next_value(&mut index)?)?,
                 "--poll-interval-secs" => poll_interval_secs = parse_u64(&next_value(&mut index)?)?,
                 "--task-limit" => task_limit = parse_usize(&next_value(&mut index)?)?,
+                "--notification-lookback-secs" => {
+                    notification_lookback_secs = parse_u64(&next_value(&mut index)?)?
+                }
                 "--search-reconcile-interval-secs" => {
                     search_reconcile_interval_secs = parse_u64(&next_value(&mut index)?)?
                 }
@@ -238,6 +244,11 @@ impl Config {
         }
         if task_limit == 0 {
             return Err(app_error("--task-limit must be greater than zero"));
+        }
+        if notification_lookback_secs == 0 {
+            return Err(app_error(
+                "--notification-lookback-secs must be greater than zero",
+            ));
         }
         if search_reconcile_interval_secs == 0 {
             return Err(app_error(
@@ -266,6 +277,7 @@ impl Config {
             max_parallel,
             poll_interval_secs,
             task_limit,
+            notification_lookback_secs,
             search_reconcile_interval_secs,
             gh_write_cooldown_ms,
             workspace_ttl_secs,
@@ -287,6 +299,7 @@ impl Config {
             max_parallel: 20,
             poll_interval_secs: 600,
             task_limit: 100,
+            notification_lookback_secs: 60 * 60 * 24,
             search_reconcile_interval_secs: 60 * 60 * 6,
             gh_write_cooldown_ms: 1_250,
             workspace_ttl_secs: 60 * 60 * 24 * 3,
@@ -324,6 +337,8 @@ FLAGS
   --max-parallel <n>             Max concurrent tasks (default: 20)
   --poll-interval-secs <n>       Poll cadence in seconds (default: 600)
   --task-limit <n>               Search result limit per source (default: 100)
+  --notification-lookback-secs <n>
+                                 Recent-thread window to reconsider every poll (default: 86400)
   --search-reconcile-interval-secs <n>
                                  How often to backfill with GitHub search (default: 21600)
   --gh-write-cooldown-ms <n>     Minimum pause between mutating gh commands (default: 1250)
@@ -342,6 +357,7 @@ ENV
   GITHUBER_MAX_PARALLEL
   GITHUBER_POLL_INTERVAL_SECS
   GITHUBER_TASK_LIMIT
+  GITHUBER_NOTIFICATION_LOOKBACK_SECS
   GITHUBER_SEARCH_RECONCILE_INTERVAL_SECS
   GITHUBER_GH_WRITE_COOLDOWN_MS
   GITHUBER_WORKSPACE_TTL_SECS
@@ -424,6 +440,8 @@ mod tests {
             "4".to_string(),
             "--search-reconcile-interval-secs".to_string(),
             "3600".to_string(),
+            "--notification-lookback-secs".to_string(),
+            "7200".to_string(),
             "--gh-write-cooldown-ms".to_string(),
             "1500".to_string(),
             "--dry-run".to_string(),
@@ -434,6 +452,7 @@ mod tests {
         assert_eq!(config.runners, vec![RunnerKind::Claude, RunnerKind::Codex]);
         assert_eq!(config.max_parallel, 4);
         assert_eq!(config.search_reconcile_interval_secs, 3600);
+        assert_eq!(config.notification_lookback_secs, 7200);
         assert_eq!(config.gh_write_cooldown_ms, 1500);
         assert!(config.dry_run);
     }

--- a/scripts/githuber/src/gh.rs
+++ b/scripts/githuber/src/gh.rs
@@ -2,11 +2,16 @@ use std::path::{Path, PathBuf};
 
 use crate::config::RepoFilter;
 use crate::gh_executor::{GhBucket, GhCommandSpec, GhExecutor, is_rate_limited};
+#[cfg(test)]
+use crate::task::TaskKind;
 use crate::task::{
-    TaskCandidate, TaskKind, build_assigned_candidate, build_notification_candidate,
+    TaskCandidate, build_assigned_candidate, build_notification_candidate,
     build_review_request_candidate,
 };
-use crate::util::{AppResult, ensure_dir, parse_tsv_line, shell_quote, write_lines, write_text};
+use crate::util::{
+    AppResult, ensure_dir, is_recent_github_timestamp, parse_tsv_line, shell_quote, write_lines,
+    write_text,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SearchScope {
@@ -30,6 +35,13 @@ pub struct CandidatePoll {
     pub search_rate_limited: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ThreadActivity {
+    pub login: String,
+    pub user_type: String,
+    pub updated_at: String,
+}
+
 impl GhClient {
     pub fn new(host: String, repo_filter: RepoFilter, executor: GhExecutor) -> Self {
         Self {
@@ -39,13 +51,18 @@ impl GhClient {
         }
     }
 
-    pub fn unread_notifications(&self) -> AppResult<Vec<TaskCandidate>> {
-        let jq = ".[] | select(.unread == true) | [(.repository.full_name // \"\"), (.subject.type // \"\"), (.reason // \"\"), (.subject.title // \"\"), (.subject.url // \"\"), (.latest_comment_url // \"\"), (.updated_at // \"\")] | @tsv";
+    pub fn recent_notifications(
+        &self,
+        now_epoch: u64,
+        lookback_secs: u64,
+    ) -> AppResult<Vec<TaskCandidate>> {
+        let jq = ".[] | [(.repository.full_name // \"\"), (.subject.type // \"\"), (.reason // \"\"), (.subject.title // \"\"), (.subject.url // \"\"), (.latest_comment_url // \"\"), (.updated_at // \"\")] | @tsv";
         let stdout = self.run_checked(
-            "read notifications",
+            "read recent notifications",
             vec![
                 "api".to_string(),
-                "/notifications".to_string(),
+                "/notifications?all=true&participating=false&per_page=100".to_string(),
+                "--paginate".to_string(),
                 "-H".to_string(),
                 "X-GitHub-Api-Version: 2022-11-28".to_string(),
                 "--jq".to_string(),
@@ -69,6 +86,9 @@ impl GhClient {
                 fields[6].clone(),
             ) {
                 if !self.repo_filter.matches_repo(&task.repo) {
+                    continue;
+                }
+                if !is_recent_candidate(&task, now_epoch, lookback_secs) {
                     continue;
                 }
                 tasks.push(task);
@@ -164,13 +184,13 @@ impl GhClient {
         Ok(deduplicate(tasks))
     }
 
-    pub fn latest_comment_author(&self, api_url: &str) -> AppResult<Option<String>> {
+    pub fn latest_comment_activity(&self, api_url: &str) -> AppResult<Option<ThreadActivity>> {
         if api_url.trim().is_empty() {
             return Ok(None);
         }
-        let jq = "[.user.login // \"\", .user.type // \"\"] | @tsv";
+        let jq = "[.user.login // \"\", .user.type // \"\", (.updated_at // .created_at // \"\")] | @tsv";
         let stdout = self.run_checked(
-            "inspect latest comment author",
+            "inspect latest comment activity",
             vec![
                 "api".to_string(),
                 canonical_api_path(api_url),
@@ -179,21 +199,56 @@ impl GhClient {
             ],
             GhBucket::Core,
         )?;
-        let line = stdout.lines().find(|line| !line.trim().is_empty());
-        let Some(line) = line else {
-            return Ok(None);
-        };
-        let fields = parse_tsv_line(line);
-        if fields.is_empty() {
-            return Ok(None);
-        }
-        Ok(Some(fields[0].clone()))
+        Ok(parse_thread_activity(
+            stdout.lines().find(|line| !line.trim().is_empty()),
+        ))
     }
 
-    pub fn collect_candidates(&self, limit: usize, include_search: bool) -> CandidatePoll {
+    pub fn latest_review_activity(
+        &self,
+        repo: &str,
+        pr_number: u64,
+    ) -> AppResult<Option<ThreadActivity>> {
+        let jq = "if length == 0 then empty else .[-1] | [(.user.login // \"\"), (.user.type // \"\"), (.submitted_at // \"\")] | @tsv end";
+        let stdout = self.run_checked(
+            "inspect latest review activity",
+            vec![
+                "api".to_string(),
+                format!("/repos/{repo}/pulls/{pr_number}/reviews?per_page=100"),
+                "-H".to_string(),
+                "X-GitHub-Api-Version: 2022-11-28".to_string(),
+                "--jq".to_string(),
+                jq.to_string(),
+            ],
+            GhBucket::Core,
+        )?;
+        Ok(parse_thread_activity(
+            stdout.lines().find(|line| !line.trim().is_empty()),
+        ))
+    }
+
+    pub fn latest_visible_activity(
+        &self,
+        task: &TaskCandidate,
+    ) -> AppResult<Option<ThreadActivity>> {
+        let comment = self.latest_comment_activity(&task.latest_comment_api_url)?;
+        let review = match task.pr_number() {
+            Some(pr_number) => self.latest_review_activity(&task.repo, pr_number)?,
+            None => None,
+        };
+        Ok(pick_newer_activity(comment, review))
+    }
+
+    pub fn collect_candidates(
+        &self,
+        limit: usize,
+        include_search: bool,
+        now_epoch: u64,
+        lookback_secs: u64,
+    ) -> CandidatePoll {
         let mut poll = CandidatePoll::default();
 
-        match self.unread_notifications() {
+        match self.recent_notifications(now_epoch, lookback_secs) {
             Ok(tasks) => poll.tasks.extend(tasks),
             Err(error) => poll
                 .warnings
@@ -224,8 +279,10 @@ impl GhClient {
             }
         }
 
-        poll.tasks
-            .retain(|task| self.repo_filter.matches_repo(&task.repo));
+        poll.tasks.retain(|task| {
+            self.repo_filter.matches_repo(&task.repo)
+                && is_recent_candidate(task, now_epoch, lookback_secs)
+        });
         poll.tasks.sort_by(|left, right| {
             right
                 .priority
@@ -512,6 +569,41 @@ impl GhClient {
     }
 }
 
+fn is_recent_candidate(task: &TaskCandidate, now_epoch: u64, lookback_secs: u64) -> bool {
+    is_recent_github_timestamp(&task.updated_at, now_epoch, lookback_secs)
+}
+
+fn parse_thread_activity(line: Option<&str>) -> Option<ThreadActivity> {
+    let line = line?;
+    let fields = parse_tsv_line(line);
+    if fields.len() < 3 {
+        return None;
+    }
+    Some(ThreadActivity {
+        login: fields[0].clone(),
+        user_type: fields[1].clone(),
+        updated_at: fields[2].clone(),
+    })
+}
+
+fn pick_newer_activity(
+    left: Option<ThreadActivity>,
+    right: Option<ThreadActivity>,
+) -> Option<ThreadActivity> {
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            if right.updated_at > left.updated_at {
+                Some(right)
+            } else {
+                Some(left)
+            }
+        }
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
 fn deduplicate(tasks: Vec<TaskCandidate>) -> Vec<TaskCandidate> {
     let mut seen = std::collections::HashSet::new();
     let mut unique = Vec::new();
@@ -524,6 +616,7 @@ fn deduplicate(tasks: Vec<TaskCandidate>) -> Vec<TaskCandidate> {
     unique
 }
 
+#[cfg(test)]
 pub fn should_ignore_self_authored(
     login: &str,
     latest_comment_author: Option<&str>,
@@ -538,6 +631,25 @@ pub fn should_ignore_self_authored(
             .map(|author| author == login || author.ends_with("[bot]"))
             .unwrap_or(false),
     }
+}
+
+pub fn should_ignore_latest_self_activity(
+    login: &str,
+    activity: Option<&ThreadActivity>,
+    task_updated_at: &str,
+) -> bool {
+    let Some(activity) = activity else {
+        return false;
+    };
+    if activity.updated_at.as_str() < task_updated_at {
+        return false;
+    }
+    is_self_or_bot_actor(login, &activity.login, &activity.user_type)
+}
+
+fn is_self_or_bot_actor(login: &str, actor_login: &str, actor_type: &str) -> bool {
+    !actor_login.trim().is_empty()
+        && (actor_login == login || actor_login.ends_with("[bot]") || actor_type == "Bot")
 }
 
 pub fn is_rate_limit_error(message: &str) -> bool {
@@ -588,7 +700,10 @@ URL: {url}\n",
 
 #[cfg(test)]
 mod tests {
-    use super::{GhClient, SearchScope, is_rate_limit_error, should_ignore_self_authored};
+    use super::{
+        GhClient, SearchScope, ThreadActivity, is_rate_limit_error, pick_newer_activity,
+        should_ignore_latest_self_activity, should_ignore_self_authored,
+    };
     use crate::config::RepoFilter;
     use crate::gh_executor::GhExecutor;
     use crate::task::TaskKind;
@@ -619,6 +734,50 @@ mod tests {
             "bingran-you",
             Some("github-actions[bot]"),
             &TaskKind::Mention
+        ));
+    }
+
+    #[test]
+    fn prefers_newer_thread_activity() {
+        let older = ThreadActivity {
+            login: "alice".to_string(),
+            user_type: "User".to_string(),
+            updated_at: "2026-04-15T05:16:22Z".to_string(),
+        };
+        let newer = ThreadActivity {
+            login: "bingran-you".to_string(),
+            user_type: "User".to_string(),
+            updated_at: "2026-04-15T05:16:25Z".to_string(),
+        };
+
+        assert_eq!(
+            pick_newer_activity(Some(older), Some(newer.clone())),
+            Some(newer)
+        );
+    }
+
+    #[test]
+    fn ignores_latest_self_activity_only_when_it_is_current() {
+        let current = ThreadActivity {
+            login: "bingran-you".to_string(),
+            user_type: "User".to_string(),
+            updated_at: "2026-04-15T05:16:25Z".to_string(),
+        };
+        let stale = ThreadActivity {
+            login: "bingran-you".to_string(),
+            user_type: "User".to_string(),
+            updated_at: "2026-04-15T05:16:20Z".to_string(),
+        };
+
+        assert!(should_ignore_latest_self_activity(
+            "bingran-you",
+            Some(&current),
+            "2026-04-15T05:16:25Z"
+        ));
+        assert!(!should_ignore_latest_self_activity(
+            "bingran-you",
+            Some(&stale),
+            "2026-04-15T05:16:25Z"
         ));
     }
 

--- a/scripts/githuber/src/runner.rs
+++ b/scripts/githuber/src/runner.rs
@@ -216,10 +216,23 @@ Rules
 - First inspect the local snapshot files in `{snapshot_dir}`. Only call `gh` when you need fresh data or to publish the final result.
 - Address the task fully: reply, review, comment, or prepare code changes as needed.
 - If you post a public GitHub reply, review, or comment, include this exact disclosure sentence once: {disclosure}
+- Before posting anything public, inspect `issue-comments.json` and `pr-reviews.json` when present. If the active account already posted a message or review that still covers the current thread state or current PR head, do not post another one; return `GITHUBER_RESULT: status=skipped ...`.
 - If code changes are required, create a branch named `githuber/{slug}`, commit cleanly, push it, and open a draft PR that references the original thread.
 - Do not merge PRs, delete branches, change repository settings, or do admin/billing/security work.
 - Avoid duplicate replies if the thread is already fully addressed.
 - The `gh` binary in this task is brokered by githuber and may serialize requests. Batch your GitHub writes and avoid redundant reads.
+
+Preferred public message format
+- Start with a hidden state marker:
+  `<!-- githuber:state handled_for={updated_at} thread={thread_key} -->`
+- Then use this structure unless the repo already has a stronger established format:
+  `## GitHuber Update`
+  `**Verdict: <ALIGNED|ACTION NEEDED|IN PROGRESS|BLOCKED|DONE>** — <one-sentence conclusion>`
+  `<one short paragraph or a few short lines with the reasoning / next action>`
+  `---`
+  `{disclosure}`
+- Keep it concise. If no action is required, say that plainly.
+- For PR reviews, use the same structure inside the review body when practical and keep the verdict specific to the current head commit.
 
 Helpful guidance
 {task_hints}
@@ -242,6 +255,8 @@ GITHUBER_RESULT: status=<handled|skipped|failed> summary=<one-line summary>",
         task_dir = request.task_dir.display(),
         disclosure = request.disclosure_text,
         slug = task.slug(),
+        updated_at = task.updated_at,
+        thread_key = task.thread_key,
         task_hints = task_hints,
     )
 }

--- a/scripts/githuber/src/service.rs
+++ b/scripts/githuber/src/service.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use crate::broker::GhBroker;
 use crate::config::{CommandKind, Config};
-use crate::gh::{GhClient, should_ignore_self_authored};
+use crate::gh::{GhClient, should_ignore_latest_self_activity};
 use crate::gh_executor::GhExecutor;
 use crate::identity::{Identity, resolve_identity};
 use crate::lock::{LockInfo, ServiceLock, find_lock, lock_is_live, remove_lock_dir, stop_process};
@@ -420,9 +420,12 @@ impl Service {
     fn poll_candidates(&mut self) -> AppResult<Vec<TaskCandidate>> {
         let now = current_epoch_secs();
         let include_search = now >= self.next_search_reconcile_epoch;
-        let poll = self
-            .gh
-            .collect_candidates(self.config.task_limit, include_search);
+        let poll = self.gh.collect_candidates(
+            self.config.task_limit,
+            include_search,
+            now,
+            self.config.notification_lookback_secs,
+        );
 
         if include_search {
             let delay = if poll.search_rate_limited {
@@ -558,15 +561,17 @@ impl Service {
         {
             return Ok(false);
         }
-        if !candidate.latest_comment_api_url.is_empty() {
-            let author = self
-                .gh
-                .latest_comment_author(&candidate.latest_comment_api_url)
-                .unwrap_or(None);
-            if should_ignore_self_authored(&self.identity.login, author.as_deref(), &candidate.kind)
-            {
-                return Ok(false);
-            }
+        let latest_activity = self.gh.latest_visible_activity(candidate).unwrap_or(None);
+        if should_ignore_latest_self_activity(
+            &self.identity.login,
+            latest_activity.as_ref(),
+            &candidate.updated_at,
+        ) {
+            record.last_handled_updated_at = candidate.updated_at.clone();
+            record.last_result = "skipped".to_string();
+            record.next_retry_epoch = 0;
+            self.store.save_thread_record(&record)?;
+            return Ok(false);
         }
         Ok(true)
     }
@@ -740,7 +745,8 @@ impl Service {
         record.repo = candidate.repo.clone();
         record.last_seen_updated_at = candidate.updated_at.clone();
         record.failure_count = record.failure_count.saturating_add(1);
-        record.next_retry_epoch = current_epoch_secs() + retry_delay(record.failure_count);
+        record.next_retry_epoch =
+            current_epoch_secs() + self.failure_retry_delay(record.failure_count);
         record.last_result = "failed".to_string();
         record.last_task_id = task_id.to_string();
         self.store.save_thread_record(&record)
@@ -785,7 +791,7 @@ impl Service {
                 } else if result.result_status == "failed" {
                     record.failure_count = record.failure_count.saturating_add(1);
                     record.next_retry_epoch =
-                        current_epoch_secs() + retry_delay(record.failure_count);
+                        current_epoch_secs() + self.failure_retry_delay(record.failure_count);
                 }
                 record.last_task_id = completion.task_id.clone();
                 record.last_result = result.result_status.clone();
@@ -801,7 +807,8 @@ impl Service {
                 let mut record = self.store.load_thread_record(&completion.thread_key)?;
                 record.thread_key = completion.thread_key.clone();
                 record.failure_count = record.failure_count.saturating_add(1);
-                record.next_retry_epoch = current_epoch_secs() + retry_delay(record.failure_count);
+                record.next_retry_epoch =
+                    current_epoch_secs() + self.failure_retry_delay(record.failure_count);
                 record.last_result = "failed".to_string();
                 record.last_task_id = completion.task_id.clone();
                 self.store.save_thread_record(&record)?;
@@ -989,6 +996,8 @@ impl Service {
             self.config.poll_interval_secs.to_string(),
             "--task-limit".to_string(),
             self.config.task_limit.to_string(),
+            "--notification-lookback-secs".to_string(),
+            self.config.notification_lookback_secs.to_string(),
             "--search-reconcile-interval-secs".to_string(),
             self.config.search_reconcile_interval_secs.to_string(),
             "--gh-write-cooldown-ms".to_string(),
@@ -1024,7 +1033,7 @@ impl Service {
             ("HOME".to_string(), env::var("HOME").unwrap_or_default()),
         ];
         for variable in passthrough_launchd_env_vars() {
-            if let Ok(value) = env::var(variable) {
+            if let Some(value) = resolve_launchd_env_var(variable) {
                 environment_entries.push((variable.to_string(), value));
             }
         }
@@ -1072,11 +1081,17 @@ impl Service {
             log_path = escape_xml(&log_path.display().to_string()),
         )
     }
+
+    fn failure_retry_delay(&self, failure_count: u32) -> u64 {
+        retry_delay(failure_count).min(self.config.poll_interval_secs)
+    }
 }
 
 fn passthrough_launchd_env_vars() -> &'static [&'static str] {
     &[
+        "AZURE_OPENAI_ENDPOINT",
         "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT_BACKUP",
         "AZURE_OPENAI_API_KEY_BACKUP",
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
@@ -1086,6 +1101,30 @@ fn passthrough_launchd_env_vars() -> &'static [&'static str] {
         "CLAUDE_CODE_USE_BEDROCK",
         "CLAUDE_CODE_USE_VERTEX",
     ]
+}
+
+fn resolve_launchd_env_var(variable: &str) -> Option<String> {
+    match env::var(variable) {
+        Ok(value) if !value.trim().is_empty() => Some(value),
+        _ => resolve_env_var_from_login_shell(variable),
+    }
+}
+
+fn resolve_env_var_from_login_shell(variable: &str) -> Option<String> {
+    let mut command = Command::new("/bin/zsh");
+    command
+        .arg("-lc")
+        .arg(format!("printf '%s' \"${{{variable}:-}}\""));
+    let output = run_command(&mut command).ok()?;
+    if output.status_code != 0 {
+        return None;
+    }
+    let value = output.stdout;
+    if value.trim().is_empty() {
+        None
+    } else {
+        Some(value)
+    }
 }
 
 fn execute_task(

--- a/scripts/githuber/src/util.rs
+++ b/scripts/githuber/src/util.rs
@@ -260,3 +260,135 @@ pub fn read_lines(path: &Path) -> AppResult<Vec<String>> {
     };
     Ok(contents.lines().map(|line| line.to_string()).collect())
 }
+
+pub fn parse_github_timestamp_epoch(value: &str) -> Option<u64> {
+    if value.len() != 20 {
+        return None;
+    }
+    if !matches!(
+        (
+            value.as_bytes().get(4),
+            value.as_bytes().get(7),
+            value.as_bytes().get(10),
+            value.as_bytes().get(13),
+            value.as_bytes().get(16),
+            value.as_bytes().get(19),
+        ),
+        (
+            Some(b'-'),
+            Some(b'-'),
+            Some(b'T'),
+            Some(b':'),
+            Some(b':'),
+            Some(b'Z')
+        )
+    ) {
+        return None;
+    }
+
+    let year = parse_i32_slice(value, 0, 4)?;
+    let month = parse_u32_slice(value, 5, 7)?;
+    let day = parse_u32_slice(value, 8, 10)?;
+    let hour = parse_u32_slice(value, 11, 13)?;
+    let minute = parse_u32_slice(value, 14, 16)?;
+    let second = parse_u32_slice(value, 17, 19)?;
+
+    if !(1..=12).contains(&month) {
+        return None;
+    }
+    if !(1..=days_in_month(year, month)).contains(&day) {
+        return None;
+    }
+    if hour > 23 || minute > 59 || second > 59 {
+        return None;
+    }
+
+    let days = days_from_civil(year, month, day);
+    if days < 0 {
+        return None;
+    }
+
+    Some(
+        (days as u64)
+            .saturating_mul(86_400)
+            .saturating_add(u64::from(hour) * 3_600)
+            .saturating_add(u64::from(minute) * 60)
+            .saturating_add(u64::from(second)),
+    )
+}
+
+pub fn is_recent_github_timestamp(value: &str, now_epoch: u64, lookback_secs: u64) -> bool {
+    parse_github_timestamp_epoch(value)
+        .map(|timestamp| timestamp >= now_epoch.saturating_sub(lookback_secs))
+        .unwrap_or(false)
+}
+
+fn parse_i32_slice(value: &str, start: usize, end: usize) -> Option<i32> {
+    value.get(start..end)?.parse::<i32>().ok()
+}
+
+fn parse_u32_slice(value: &str, start: usize, end: usize) -> Option<u32> {
+    value.get(start..end)?.parse::<u32>().ok()
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+fn days_from_civil(year: i32, month: u32, day: u32) -> i64 {
+    let year = i64::from(year) - i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month = i64::from(month);
+    let day = i64::from(day);
+    let day_of_year = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_recent_github_timestamp, parse_github_timestamp_epoch};
+
+    #[test]
+    fn parses_github_timestamps_to_epoch() {
+        assert_eq!(
+            parse_github_timestamp_epoch("1970-01-01T00:00:00Z"),
+            Some(0)
+        );
+        assert_eq!(
+            parse_github_timestamp_epoch("1970-01-01T00:15:50Z"),
+            Some(950)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_github_timestamps() {
+        assert_eq!(parse_github_timestamp_epoch("2026-13-01T00:00:00Z"), None);
+        assert_eq!(parse_github_timestamp_epoch("not-a-timestamp"), None);
+    }
+
+    #[test]
+    fn checks_recent_timestamp_window() {
+        assert!(is_recent_github_timestamp(
+            "1970-01-01T00:15:50Z",
+            1_000,
+            100
+        ));
+        assert!(!is_recent_github_timestamp(
+            "1970-01-01T00:14:59Z",
+            1_000,
+            100
+        ));
+    }
+}

--- a/scripts/githuber/tests/run_once_fake.rs
+++ b/scripts/githuber/tests/run_once_fake.rs
@@ -40,7 +40,7 @@ case "$*" in
     printf 'github.com\tbingran-you\thttps\trepo,workflow\n'
     ;;
   *"api /notifications"*)
-    printf 'owner/repo\tIssue\tcomment\tPlease respond\thttps://api.github.com/repos/owner/repo/issues/1\thttps://api.github.com/repos/owner/repo/issues/comments/10\t2026-04-13T00:00:00Z\n'
+    printf 'owner/repo\tIssue\tcomment\tPlease respond\thttps://api.github.com/repos/owner/repo/issues/1\thttps://api.github.com/repos/owner/repo/issues/comments/10\t2099-01-01T00:00:00Z\n'
     ;;
   *"api /repos/owner/repo/issues/comments/10"*)
     printf 'alice\tUser\n'
@@ -150,7 +150,10 @@ printf 'GITHUBER_RESULT: status=handled summary=fake codex handled thread\n' > "
 
     let calls = fs::read_to_string(&calls_path).expect("calls log");
     assert!(calls.contains("gh auth status"));
-    assert!(calls.contains("gh api /notifications"));
+    assert!(
+        calls
+            .contains("gh api /notifications?all=true&participating=false&per_page=100 --paginate")
+    );
     assert!(calls.contains("git -c credential.helper=!gh auth git-credential clone --bare"));
     assert!(calls.contains("codex exec"));
 
@@ -193,7 +196,7 @@ case "$*" in
     printf 'github.com\tbingran-you\thttps\trepo,workflow\n'
     ;;
   *"api /notifications"*)
-    printf 'owner/repo\tIssue\tcomment\tPlease respond\thttps://api.github.com/repos/owner/repo/issues/1\thttps://api.github.com/repos/owner/repo/issues/comments/10\t2026-04-13T00:00:00Z\n'
+    printf 'owner/repo\tIssue\tcomment\tPlease respond\thttps://api.github.com/repos/owner/repo/issues/1\thttps://api.github.com/repos/owner/repo/issues/comments/10\t2099-01-01T00:00:00Z\n'
     ;;
   *"api /repos/owner/repo/issues/comments/10"*)
     printf 'alice\tUser\n'
@@ -307,6 +310,7 @@ printf 'GITHUBER_RESULT: status=handled summary=fake codex handled thread\n' > "
     assert!(first_calls.contains("gh search issues"));
 
     fs::write(&calls_path, "").expect("clear calls");
+    fs::write(&actions_path, "").expect("clear actions");
 
     let second = run();
     assert!(
@@ -317,9 +321,16 @@ printf 'GITHUBER_RESULT: status=handled summary=fake codex handled thread\n' > "
     );
 
     let second_calls = fs::read_to_string(&calls_path).expect("second calls");
-    assert!(second_calls.contains("gh api /notifications"));
+    assert!(
+        second_calls
+            .contains("gh api /notifications?all=true&participating=false&per_page=100 --paginate")
+    );
     assert!(!second_calls.contains("gh search prs"));
     assert!(!second_calls.contains("gh search issues"));
+    assert!(!second_calls.contains("codex exec"));
+
+    let second_actions = fs::read_to_string(&actions_path).expect("second actions");
+    assert!(second_actions.trim().is_empty());
 
     fs::remove_dir_all(root).expect("cleanup temp test dir");
 }
@@ -345,7 +356,7 @@ thread_key=/repos/owner/repo/issues/1
 title=Recover stale task
 kind=assigned_issue
 reason=assigned
-updated_at=2026-04-13T00:00:00Z
+updated_at=2099-01-01T00:00:00Z
 source=assigned-search
 started_at=1
 ",
@@ -481,6 +492,101 @@ printf 'GITHUBER_RESULT: status=handled summary=recovered stale task\n' > "$out"
 
     let actions = fs::read_to_string(&actions_path).expect("actions log");
     assert!(actions.contains("Recovered stale task"));
+
+    fs::remove_dir_all(root).expect("cleanup temp test dir");
+}
+
+#[test]
+fn run_once_ignores_notifications_older_than_lookback_window() {
+    let root = unique_dir("old-notification");
+    let bin_dir = root.join("bin");
+    let home_dir = root.join("home");
+    let calls_path = root.join("calls.log");
+    let actions_path = root.join("actions.log");
+    fs::create_dir_all(&bin_dir).expect("bin dir");
+    fs::create_dir_all(&home_dir).expect("home dir");
+
+    write_script(
+        &bin_dir.join("gh"),
+        r#"#!/bin/sh
+set -eu
+printf 'gh %s\n' "$*" >> "$GITHUBER_CALLS"
+case "$*" in
+  *"auth status"*)
+    printf 'github.com\tbingran-you\thttps\trepo,workflow\n'
+    ;;
+  *"api /notifications"*)
+    printf 'owner/repo\tIssue\tcomment\tOld thread\thttps://api.github.com/repos/owner/repo/issues/1\thttps://api.github.com/repos/owner/repo/issues/comments/10\t2000-01-01T00:00:00Z\n'
+    ;;
+  *"search prs"*)
+    printf ''
+    ;;
+  *"search issues"*)
+    printf ''
+    ;;
+  *"issue comment"*)
+    printf 'gh-action %s\n' "$*" >> "$GITHUBER_ACTIONS"
+    ;;
+  *)
+    printf ''
+    ;;
+esac
+"#,
+    );
+
+    write_script(
+        &bin_dir.join("git"),
+        r#"#!/bin/sh
+set -eu
+exit 0
+"#,
+    );
+
+    write_script(
+        &bin_dir.join("codex"),
+        r#"#!/bin/sh
+set -eu
+printf 'codex %s\n' "$*" >> "$GITHUBER_CALLS"
+exit 1
+"#,
+    );
+
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_githuber"))
+        .env("PATH", path)
+        .env("GITHUBER_HOME", &home_dir)
+        .env("GITHUBER_CALLS", &calls_path)
+        .env("GITHUBER_ACTIONS", &actions_path)
+        .args(["run-once", "--runner", "codex", "--host", "github.com"])
+        .output()
+        .expect("githuber should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let calls = fs::read_to_string(&calls_path).expect("calls log");
+    assert!(
+        calls
+            .contains("gh api /notifications?all=true&participating=false&per_page=100 --paginate")
+    );
+    assert!(!calls.contains("codex "));
+
+    let actions = fs::read_to_string(&actions_path).unwrap_or_default();
+    assert!(actions.trim().is_empty());
+
+    let task_dirs = fs::read_dir(home_dir.join("tasks"))
+        .expect("tasks dir")
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+    assert!(task_dirs.is_empty());
 
     fs::remove_dir_all(root).expect("cleanup temp test dir");
 }


### PR DESCRIPTION
## Summary
- sweep actionable notification threads from the last 24 hours on every poll, even when they are already marked read
- suppress duplicate follow-up when the latest visible review/comment is already from the active account
- tighten the public reply template so agent comments stay concise and consistently formatted

## Testing
- cargo test --manifest-path scripts/githuber/Cargo.toml

## Notes
- I intentionally did not restart the currently busy local githuber daemon after the final duplicate-guard patch because it still had 20 active and 37 queued tasks in flight.
