### PR TITLE
Add bingran-you-context-tree submodule under workspace/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 scripts/githuber/target/
 /.claude/worktrees
 .DS_Store
-/workspace
+/workspace/*
+!/workspace/bingran-you-context-tree

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 	path = trusted-external-repos/oh-my-codex
 	url = https://github.com/bingran-you/oh-my-codex.git
 	branch = main
+[submodule "workspace/bingran-you-context-tree"]
+	path = workspace/bingran-you-context-tree
+	url = https://github.com/bingran-you/bingran-you-context-tree.git


### PR DESCRIPTION
## Summary
- Add `workspace/bingran-you-context-tree` as a submodule pointing to the private repo [bingran-you/bingran-you-context-tree](https://github.com/bingran-you/bingran-you-context-tree)
- Submodule contains Discord forum exports: `tb-task-proposals`, `tb-science-task-proposals`, `ralphbench-task-discussion`
- Update `.gitignore`: replace blanket `/workspace` with `/workspace/*` + `!/workspace/bingran-you-context-tree` so the submodule link is tracked while CLI binaries (`DiscordChatExporter.Cli.osx-arm64/`, `.zip`) remain ignored

## Test plan
- [x] Submodule clones successfully (verified locally via `git submodule add`)
- [x] `.gitignore` keeps `DiscordChatExporter.Cli.osx-arm64` and `.zip` ignored
- [ ] After merge: `git clone --recurse-submodules` pulls the private context tree for authorized users