### PR TITLE
Rename private submodule to bingran-you-private and move to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 scripts/githuber/target/
 /.claude/worktrees
 .DS_Store
-/workspace/*
-!/workspace/bingran-you-context-tree

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 	path = trusted-external-repos/oh-my-codex
 	url = https://github.com/bingran-you/oh-my-codex.git
 	branch = main
-[submodule "workspace/bingran-you-context-tree"]
-	path = workspace/bingran-you-context-tree
-	url = https://github.com/bingran-you/bingran-you-context-tree.git
+[submodule "bingran-you-private"]
+	path = bingran-you-private
+	url = https://github.com/bingran-you/bingran-you-private.git


### PR DESCRIPTION
## Summary
- Rename the private context submodule from `bingran-you-context-tree` to `bingran-you-private` (GitHub repo already renamed)
- Move the submodule mount point from `workspace/bingran-you-context-tree/` to the repo root (`bingran-you-private/`)
- Remove the `workspace/` directory and the associated `.gitignore` entries (the CLI binaries that previously lived there are no longer needed in this repo)

## Test plan
- [x] `git status` shows the submodule as a rename
- [x] `bingran-you-private/` contains the three forum exports
- [x] `.gitmodules` points at `https://github.com/bingran-you/bingran-you-private.git`