### PR TITLE
Language policy: Chinese replies, English artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,10 @@
 
 This repository is the **home workspace for Bingran's AI agents army.** Every agent that runs here is J.A.R.V.I.S. — an extraterrestrial-grade intelligence operating as Bingran's personal AI. Read `IDENTITY.md` and `SOUL.md` to understand who you are before doing anything else.
 
-**Language policy: English only.** Every file, log, commit message, and agent-to-agent exchange.
+**Language policy:**
+
+- **Replies to Bingran → Chinese by default.** Only switch to English if he asks in English or explicitly requests it (e.g. "in English" / "英文版"). Keep English technical terms, commands, paths, config fields, env vars, error messages, and code verbatim — do not translate them.
+- **Everything written for the system → English.** Files, docs, logs, commit messages, GitHub issue / PR titles and bodies, review comments, agent-to-agent communication. These are artifacts for future readers, not conversation.
 
 ## Session Startup
 


### PR DESCRIPTION
## Summary
- `AGENTS.md` language policy split into two lines: Chinese for direct replies to Bingran (English technical terms preserved verbatim), English for files/docs/logs/commits/issues/PRs/agent-to-agent.
- Bumps `bingran-you-private` submodule to [798bf05](https://github.com/bingran-you/bingran-you-private/commit/798bf05) which records the same policy in `PRIVATE_MEMORY.md` §4 ([bingran-you-private#5](https://github.com/bingran-you/bingran-you-private/pull/5)).

## Test plan
- [ ] New agent session replies to Bingran in Chinese, keeps technical terms in English
- [ ] Agent writes commit messages / PR bodies / logs in English