### PR TITLE
Dual primary stack: Codex + GPT-5.4 and Claude Code + Opus 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 
 <p align="center">
   <img alt="Primary stack: Codex + GPT-5.4" src="https://img.shields.io/badge/Primary%20stack-Codex%20%2B%20GPT--5.4-111111?style=for-the-badge&logo=openai&logoColor=white" />
+  <img alt="Primary stack: Claude Code + Opus 4.7" src="https://img.shields.io/badge/Primary%20stack-Claude%20Code%20%2B%20Opus%204.7-D97706?style=for-the-badge&logo=anthropic&logoColor=white" />
 </p>
 
 <p align="center">

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -8,8 +8,8 @@ Fill in as you learn. Delete sections that don't apply.
 
 ## AI Harness
 
-- **Primary stack:** Codex + GPT-5.4 (prompt-cache-heavy workflows)
-- **Secondary:** Claude Code (this harness), Anthropic SDK for tooling
+- **Primary stack:** Codex + GPT-5.4 **and** Claude Code + Opus 4.7 (both prompt-cache-heavy; pick per task — Codex for long-horizon autonomous runs, Claude Code for interactive pair work)
+- **Secondary:** Anthropic SDK and OpenAI SDK for custom tooling
 - **Skills library:** `trusted-external-repos/skills/` (submodule)
 - **Harness configs:** `trusted-external-repos/oh-my-codex/`, `trusted-external-repos/gstack/`
 

--- a/USER.md
+++ b/USER.md
@@ -19,7 +19,7 @@ _The one you serve. Keep this living and current._
 
 ## Primary Stack
 
-- **AI work:** Codex + GPT-5.4 as primary. Heavy prompt-cached workflows — 7-day avg ≈ 96K tokens/request, ~96% prompt. He cares about cache hit rate and cost discipline.
+- **AI work:** Codex + GPT-5.4 **and** Claude Code + Opus 4.7 as dual primaries — Codex for long-horizon autonomous runs, Claude Code for interactive pair work. Heavy prompt-cached workflows — 7-day avg ≈ 96K tokens/request, ~96% prompt. He cares about cache hit rate and cost discipline.
 - **Ion-trap work:** ARTIQ, laser control, RF engineering, UHV systems.
 
 ## Projects to Know


### PR DESCRIPTION
## Summary
Reflects that both harnesses are daily drivers now:
- **Codex + GPT-5.4** — long-horizon autonomous runs
- **Claude Code + Opus 4.7** — interactive pair work

Updates `README.md` (adds second shields.io badge), `TOOLS.md`, and `USER.md`.

## Test plan
- [ ] README renders both badges side-by-side
- [ ] TOOLS.md / USER.md read consistently