### PR TITLE
Add skill-creator and docs-to-skill from benchflow-ai/skillsbench

### DIFF
--- a/.claude/skills/docs-to-skill
+++ b/.claude/skills/docs-to-skill
@@ -1,0 +1,1 @@
+../../trusted-external-repos/skillsbench/.claude/skills/docs-to-skill

--- a/.claude/skills/skill-creator
+++ b/.claude/skills/skill-creator
@@ -1,0 +1,1 @@
+../../trusted-external-repos/skillsbench/.claude/skills/skill-creator

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,7 @@
 	path = trusted-external-repos/first-tree
 	url = https://github.com/agent-team-foundation/first-tree.git
 	branch = main
+[submodule "trusted-external-repos/skillsbench"]
+	path = trusted-external-repos/skillsbench
+	url = https://github.com/benchflow-ai/skillsbench.git
+	branch = main


### PR DESCRIPTION
## Summary

- Vendored `benchflow-ai/skillsbench` as a new submodule at `trusted-external-repos/skillsbench` (tracking `main`).
- Symlinked `.claude/skills/skill-creator` → `trusted-external-repos/skillsbench/.claude/skills/skill-creator`.
- Symlinked `.claude/skills/docs-to-skill` → `trusted-external-repos/skillsbench/.claude/skills/docs-to-skill`.

Matches the existing pattern (vendor under `trusted-external-repos/`, symlink into `.claude/skills/`) so the skills are discoverable alongside the rest of the library and stay in sync via `git submodule update --remote`.

## Test plan

- [x] `ls -L .claude/skills/skill-creator` lists `LICENSE.txt`, `SKILL.md`, `references`, `scripts`.
- [x] `ls -L .claude/skills/docs-to-skill` lists `SKILL.md`, `scripts`.
- [x] `git submodule status` shows the new `trusted-external-repos/skillsbench` entry.

https://claude.ai/code/session_01UcUMMpAS4Lr5r9mrFtAYM1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcUMMpAS4Lr5r9mrFtAYM1)_