### PR TITLE
Archive published RedNote post for emotion-concepts deck

### DIFF
--- a/social-media/rednote/2026-04-25-claude-emotions/post.md
+++ b/social-media/rednote/2026-04-25-claude-emotions/post.md
@@ -1,0 +1,20 @@
+---
+platform: 小红书
+posted_at: 2026-04-25
+deck: 12 cards (1080×1440)
+source: https://transformer-circuits.pub/2026/emotions/index.html
+---
+
+# 发布原文
+
+> 标题：卧槽原来我之前 Claude 都用错了...
+>
+> 看到 Anthropic 发表的一篇 report 感到非常 surprised，原来骂 AI 会让它降智！？
+>
+> 能不能做一个工具实时看到当前 agent 的精神状态[笑哭R]
+>
+> 让俺的 jarvis 把原文整理成卡片 png，排版看着还不错[doge]
+>
+> 原文链接： https://transformer-circuits.pub/2026/emotions/index.html
+>
+> #人工智能 #大模型 #AI聊天 #AI聊天 #agent #宝宝辅食


### PR DESCRIPTION
Saves the actual caption text that shipped to 小红书 alongside the deck at `social-media/rednote/2026-04-25-claude-emotions/post.md`, so future browsing of the folder shows both the rendered cards and what was posted with them.

`post.md` leads with a small frontmatter (platform / date / source) to keep each deck folder self-describing as more decks accumulate.

https://claude.ai/code/session_016hRpjU415qjaupKqypLPpa

---
_Generated by [Claude Code](https://claude.ai/code/session_016hRpjU415qjaupKqypLPpa)_