### PR TITLE
Expose skill-creator to Codex via .agents/skills/ symlink

### DIFF
--- a/.agents/skills/skill-creator
+++ b/.agents/skills/skill-creator
@@ -1,0 +1,1 @@
+../../.claude/skills/skill-creator


### PR DESCRIPTION
## Summary

Symlinks `.agents/skills/skill-creator -> ../../.claude/skills/skill-creator` so the upstream skill vendored in #45 is discoverable by Codex too, not just Claude Code.

- Claude Code reads `.claude/skills/skill-creator/` directly.
- Codex (oh-my-codex) reads `.agents/skills/skill-creator/` and follows the symlink to the same files.

Single source of truth — no content duplication, no submodule indirection. The triggering description ("Create new skills, modify and improve existing skills, and measure skill performance...") now shows up in Codex's available-skills list.

## Test plan

- [x] `ls .agents/skills/skill-creator/` resolves to the same file set (`SKILL.md`, `agents/`, `assets/`, `eval-viewer/`, `references/`, `scripts/`).
- [x] Symlink target is relative (`../../.claude/skills/skill-creator`), so it works from any worktree clone.
- [x] Codex available-skills list now includes `skill-creator` with the new description.


---
_Generated by [Claude Code](https://claude.ai/code/session_014AJSxf3hFntF4AZa4Njymx)_