### PR TITLE
Drop oh-my-codex skills, add workspace-scoped SessionStart hooks

### DIFF
--- a/.agents/skills/ai-slop-cleaner
+++ b/.agents/skills/ai-slop-cleaner
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ai-slop-cleaner

--- a/.agents/skills/analyze
+++ b/.agents/skills/analyze
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/analyze

--- a/.agents/skills/ask-claude
+++ b/.agents/skills/ask-claude
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ask-claude

--- a/.agents/skills/ask-gemini
+++ b/.agents/skills/ask-gemini
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ask-gemini

--- a/.agents/skills/autopilot
+++ b/.agents/skills/autopilot
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/autopilot

--- a/.agents/skills/build-fix
+++ b/.agents/skills/build-fix
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/build-fix

--- a/.agents/skills/cancel
+++ b/.agents/skills/cancel
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/cancel

--- a/.agents/skills/code-review
+++ b/.agents/skills/code-review
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/code-review

--- a/.agents/skills/configure-notifications
+++ b/.agents/skills/configure-notifications
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/configure-notifications

--- a/.agents/skills/deep-interview
+++ b/.agents/skills/deep-interview
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/deep-interview

--- a/.agents/skills/deepsearch
+++ b/.agents/skills/deepsearch
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/deepsearch

--- a/.agents/skills/doctor
+++ b/.agents/skills/doctor
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/doctor

--- a/.agents/skills/ecomode
+++ b/.agents/skills/ecomode
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ecomode

--- a/.agents/skills/frontend-ui-ux
+++ b/.agents/skills/frontend-ui-ux
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/frontend-ui-ux

--- a/.agents/skills/git-master
+++ b/.agents/skills/git-master
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/git-master

--- a/.agents/skills/help
+++ b/.agents/skills/help
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/help

--- a/.agents/skills/hud
+++ b/.agents/skills/hud
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/hud

--- a/.agents/skills/note
+++ b/.agents/skills/note
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/note

--- a/.agents/skills/omx-setup
+++ b/.agents/skills/omx-setup
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/omx-setup

--- a/.agents/skills/pipeline
+++ b/.agents/skills/pipeline
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/pipeline

--- a/.agents/skills/plan
+++ b/.agents/skills/plan
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/plan

--- a/.agents/skills/ralph
+++ b/.agents/skills/ralph
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ralph

--- a/.agents/skills/ralph-init
+++ b/.agents/skills/ralph-init
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ralph-init

--- a/.agents/skills/ralplan
+++ b/.agents/skills/ralplan
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ralplan

--- a/.agents/skills/review
+++ b/.agents/skills/review
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/review

--- a/.agents/skills/security-review
+++ b/.agents/skills/security-review
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/security-review

--- a/.agents/skills/skill
+++ b/.agents/skills/skill
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/skill

--- a/.agents/skills/swarm
+++ b/.agents/skills/swarm
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/swarm

--- a/.agents/skills/tdd
+++ b/.agents/skills/tdd
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/tdd

--- a/.agents/skills/team
+++ b/.agents/skills/team
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/team

--- a/.agents/skills/trace
+++ b/.agents/skills/trace
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/trace

--- a/.agents/skills/ultraqa
+++ b/.agents/skills/ultraqa
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ultraqa

--- a/.agents/skills/ultrawork
+++ b/.agents/skills/ultrawork
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ultrawork

--- a/.agents/skills/visual-verdict
+++ b/.agents/skills/visual-verdict
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/visual-verdict

--- a/.agents/skills/web-clone
+++ b/.agents/skills/web-clone
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/web-clone

--- a/.agents/skills/wiki
+++ b/.agents/skills/wiki
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/wiki

--- a/.agents/skills/worker
+++ b/.agents/skills/worker
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/worker

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git submodule update --init --recursive >/dev/null 2>&1 || true",
+            "async": true,
+            "timeout": 300,
+            "statusMessage": "Initializing submodules..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ai-slop-cleaner
+++ b/.claude/skills/ai-slop-cleaner
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ai-slop-cleaner

--- a/.claude/skills/analyze
+++ b/.claude/skills/analyze
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/analyze

--- a/.claude/skills/ask-claude
+++ b/.claude/skills/ask-claude
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ask-claude

--- a/.claude/skills/ask-gemini
+++ b/.claude/skills/ask-gemini
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ask-gemini

--- a/.claude/skills/autopilot
+++ b/.claude/skills/autopilot
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/autopilot

--- a/.claude/skills/build-fix
+++ b/.claude/skills/build-fix
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/build-fix

--- a/.claude/skills/cancel
+++ b/.claude/skills/cancel
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/cancel

--- a/.claude/skills/code-review
+++ b/.claude/skills/code-review
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/code-review

--- a/.claude/skills/configure-notifications
+++ b/.claude/skills/configure-notifications
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/configure-notifications

--- a/.claude/skills/deep-interview
+++ b/.claude/skills/deep-interview
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/deep-interview

--- a/.claude/skills/deepsearch
+++ b/.claude/skills/deepsearch
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/deepsearch

--- a/.claude/skills/doctor
+++ b/.claude/skills/doctor
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/doctor

--- a/.claude/skills/ecomode
+++ b/.claude/skills/ecomode
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ecomode

--- a/.claude/skills/frontend-ui-ux
+++ b/.claude/skills/frontend-ui-ux
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/frontend-ui-ux

--- a/.claude/skills/git-master
+++ b/.claude/skills/git-master
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/git-master

--- a/.claude/skills/help
+++ b/.claude/skills/help
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/help

--- a/.claude/skills/hud
+++ b/.claude/skills/hud
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/hud

--- a/.claude/skills/note
+++ b/.claude/skills/note
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/note

--- a/.claude/skills/omx-setup
+++ b/.claude/skills/omx-setup
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/omx-setup

--- a/.claude/skills/pipeline
+++ b/.claude/skills/pipeline
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/pipeline

--- a/.claude/skills/plan
+++ b/.claude/skills/plan
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/plan

--- a/.claude/skills/ralph
+++ b/.claude/skills/ralph
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ralph

--- a/.claude/skills/ralph-init
+++ b/.claude/skills/ralph-init
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ralph-init

--- a/.claude/skills/ralplan
+++ b/.claude/skills/ralplan
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ralplan

--- a/.claude/skills/review
+++ b/.claude/skills/review
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/review

--- a/.claude/skills/security-review
+++ b/.claude/skills/security-review
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/security-review

--- a/.claude/skills/skill
+++ b/.claude/skills/skill
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/skill

--- a/.claude/skills/swarm
+++ b/.claude/skills/swarm
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/swarm

--- a/.claude/skills/tdd
+++ b/.claude/skills/tdd
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/tdd

--- a/.claude/skills/team
+++ b/.claude/skills/team
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/team

--- a/.claude/skills/trace
+++ b/.claude/skills/trace
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/trace

--- a/.claude/skills/ultraqa
+++ b/.claude/skills/ultraqa
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ultraqa

--- a/.claude/skills/ultrawork
+++ b/.claude/skills/ultrawork
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/ultrawork

--- a/.claude/skills/visual-verdict
+++ b/.claude/skills/visual-verdict
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/visual-verdict

--- a/.claude/skills/web-clone
+++ b/.claude/skills/web-clone
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/web-clone

--- a/.claude/skills/wiki
+++ b/.claude/skills/wiki
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/wiki

--- a/.claude/skills/worker
+++ b/.claude/skills/worker
@@ -1,1 +1,0 @@
-../../trusted-external-repos/oh-my-codex/skills/worker

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,20 @@
+# Codex CLI configuration — workspace-scoped.
+# Mirrors the SessionStart hook in .claude/settings.json so both harnesses
+# auto-initialize the trusted-external-repos/* submodules on session start.
+#
+# Caveat: openai/codex#17532 — repo-local hooks may not fire in interactive
+# sessions on some Codex versions. If you see stale submodules, run
+# `git submodule update --init --recursive` once manually, or move this block
+# into ~/.codex/config.toml and gate the command on $PWD.
+
+[features]
+codex_hooks = true
+
+[[hooks.SessionStart]]
+matcher = "startup|resume"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "git submodule update --init --recursive >/dev/null 2>&1 || true"
+statusMessage = "Initializing submodules"
+timeout = 300


### PR DESCRIPTION
## Summary

- Remove 74 symlinks under `.claude/skills/` and `.agents/skills/` that pointed into `trusted-external-repos/oh-my-codex/`. This workspace no longer depends on `oh-my-codex` for skill loading.
- Add `.claude/settings.json` with a `SessionStart` hook that silently runs `git submodule update --init --recursive` in the background — fixes the dangling-symlink problem in fresh worktrees where `trusted-external-repos/*` submodules aren't initialized.
- Add `.codex/config.toml` with the equivalent Codex hook (`codex_hooks` feature flag + `SessionStart` command). Both hooks live at the repo root so they only apply when working in this workspace.

## Why repo-scoped, not user-global

The hooks are tied to this workspace's submodule layout. Putting them in `~/.claude/settings.json` / `~/.codex/config.toml` would leak into every other project. Keeping them committed here means: every J.A.R.V.I.S. instance / every worktree picks them up automatically, and nothing else does.

## Known caveat: openai/codex#17532

[openai/codex#17532](https://github.com/openai/codex/issues/17532) reports that repo-local Codex hooks may not fire in interactive sessions on some Codex versions. The config is correct and will start working once the bug is fixed; until then, non-interactive Codex sessions still honor it. If you hit dangling submodule symlinks under Codex, run `git submodule update --init --recursive` once manually.

## Follow-up (not in this PR)

The `oh-my-codex` submodule itself (11 MB, defined in `.gitmodules`) is still present. The new SessionStart hook will keep cloning it on every fresh worktree even though nothing references it now. A follow-up PR should `git submodule deinit` it and remove the `.gitmodules` entry.

## Test plan

- [ ] In a fresh worktree, run `claude` → confirm no permission prompt, status bar briefly shows `Initializing submodules…`, and `ls trusted-external-repos/skills/skills/.curated/` returns content (not empty).
- [ ] In the same worktree, run `codex` (with `codex_hooks` feature available) → confirm submodule init runs at session start. If interactive doesn't trigger due to #17532, verify in a non-interactive `codex exec` invocation.
- [ ] Confirm the skill list shown by Claude no longer contains any of the 37 oh-my-codex skill names (`autopilot`, `ralph`, `swarm`, `team`, `pipeline`, `plan`, `review`, `note`, `wiki`, etc.).