### PR TITLE
Purge oh-my-codex submodule and all remaining references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = trusted-external-repos/gstack
 	url = https://github.com/bingran-you/gstack.git
 	branch = main
-[submodule "trusted-external-repos/oh-my-codex"]
-	path = trusted-external-repos/oh-my-codex
-	url = https://github.com/bingran-you/oh-my-codex.git
-	branch = main
 [submodule "bingran-you-private"]
 	path = bingran-you-private
 	url = https://github.com/bingran-you/bingran-you-private.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 ├── README.md                                                # Human-facing GitHub profile
 ├── .agents/ .claude/ .openclaw/                             # Agent runtime state + skills
 ├── bingran-you-private/          # 🔒 Private submodule — never exfiltrate
-├── trusted-external-repos/       # Vendored trusted repos (skills, gstack, oh-my-codex)
+├── trusted-external-repos/       # Vendored trusted repos (skills, gstack)
 ├── papers/                       # Research paper workspace
 ├── reading/                      # Reading notes and materials
 ├── scripts/                      # Utility scripts
@@ -46,7 +46,6 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 - `bingran-you-private` — **private.** Treat contents as confidential. Never paste into external channels, commits outside the submodule, PRs, or LLM calls that leave the machine.
 - `trusted-external-repos/skills` — shared skills library.
 - `trusted-external-repos/gstack` — gstack tooling.
-- `trusted-external-repos/oh-my-codex` — Codex harness.
 
 If a submodule looks stale, check `git submodule status` before assuming it's broken.
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -11,7 +11,7 @@ Fill in as you learn. Delete sections that don't apply.
 - **Primary stack:** Codex + GPT-5.4 **and** Claude Code + Opus 4.7 (both prompt-cache-heavy; pick per task — Codex for long-horizon autonomous runs, Claude Code for interactive pair work)
 - **Secondary:** Anthropic SDK and OpenAI SDK for custom tooling
 - **Skills library:** `trusted-external-repos/skills/` (submodule)
-- **Harness configs:** `trusted-external-repos/oh-my-codex/`, `trusted-external-repos/gstack/`
+- **Harness configs:** `trusted-external-repos/gstack/`
 
 ## Repos & Workspaces
 

--- a/scripts/sync_external_skills.sh
+++ b/scripts/sync_external_skills.sh
@@ -9,17 +9,12 @@ CURATED_SUBMODULE_PATH="trusted-external-repos/skills"
 CURATED_SOURCE_PATH="$REPO_ROOT/$CURATED_SUBMODULE_PATH/skills/.curated"
 CURATED_LINK_PREFIX="../../$CURATED_SUBMODULE_PATH/skills/.curated"
 
-OMX_SUBMODULE_PATH="trusted-external-repos/oh-my-codex"
-OMX_SOURCE_PATH="$REPO_ROOT/$OMX_SUBMODULE_PATH/skills"
-OMX_LINK_PREFIX="../../$OMX_SUBMODULE_PATH/skills"
-
 GSTACK_SUBMODULE_PATH="trusted-external-repos/gstack"
 GSTACK_SOURCE_PATH="$REPO_ROOT/$GSTACK_SUBMODULE_PATH"
 GSTACK_LINK_PREFIX="../../$GSTACK_SUBMODULE_PATH"
 
 SUBMODULE_PATHS=(
   "$CURATED_SUBMODULE_PATH"
-  "$OMX_SUBMODULE_PATH"
   "$GSTACK_SUBMODULE_PATH"
 )
 
@@ -108,7 +103,6 @@ rebuild_entrypoints() {
   LINK_SOURCES=()
 
   collect_directory_skills "curated" "$CURATED_SOURCE_PATH" "$CURATED_LINK_PREFIX"
-  collect_directory_skills "oh-my-codex" "$OMX_SOURCE_PATH" "$OMX_LINK_PREFIX"
 
   require_source_dir "$GSTACK_SOURCE_PATH"
   [[ -f "$GSTACK_SOURCE_PATH/SKILL.md" ]] || {


### PR DESCRIPTION
## Summary

Follow-up to #48, which deleted the 74 symlink entrypoints under `.claude/skills/` and `.agents/skills/` but left the `oh-my-codex` submodule itself wired up. The SessionStart hook landed in #48 (`git submodule update --init --recursive`) would have kept re-cloning oh-my-codex on every fresh worktree even though nothing referenced it. This PR finishes the cleanup.

- **Deinit + `git rm`** `trusted-external-repos/oh-my-codex`. Auto-removes the `[submodule "trusted-external-repos/oh-my-codex"]` block from `.gitmodules`.
- **`scripts/sync_external_skills.sh`**: drop `OMX_*` vars, the `oh-my-codex` `collect_directory_skills` call, and the submodule path from `SUBMODULE_PATHS`. The script's `init`/`refresh`/`status`/`update` commands now manage only `curated` + `gstack`. (Without this edit, anyone running `./scripts/sync_external_skills.sh refresh` would have been told the missing OMX source was an error.)
- **`AGENTS.md`** + **`TOOLS.md`**: strip oh-my-codex from workspace layout, submodule list, and harness configs.

After this PR, `git grep -i 'oh-my-codex\|OMX_'` returns zero hits in tracked files.

## Manual cleanup (not in the diff)

The orphan `.git/modules/trusted-external-repos/oh-my-codex/` directory in the main worktree's git internal storage (~16 MB) was trashed locally. Other clones will need to do the same after pulling — this is git's standard behavior on submodule removal and isn't representable in a PR diff.

## Test plan

- [ ] After merge, `git pull` in the main worktree, then run `./scripts/sync_external_skills.sh status` — confirm it lists only `gstack` + `skills` submodules, no errors about missing OMX source.
- [ ] In a fresh worktree (or after `git submodule deinit -f trusted-external-repos/oh-my-codex` + `rm -rf .git/modules/trusted-external-repos/oh-my-codex`), the SessionStart hook from #48 should now only init `bingran-you-private` + `gstack` + `skills` + `skillsbench` + the two xiaohongshu submodules — not oh-my-codex.
- [ ] Open Claude Code in the main worktree → confirm the loaded skill list contains zero oh-my-codex skills (`autopilot`, `ralph`, `swarm`, `team`, `pipeline`, etc. should all be absent).