### PR TITLE
Use bingran-you forks for gbrain and first-tree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	branch = main
 [submodule "trusted-external-repos/gbrain"]
 	path = trusted-external-repos/gbrain
-	url = https://github.com/garrytan/gbrain.git
+	url = https://github.com/bingran-you/gbrain.git
 	branch = master
 [submodule "trusted-external-repos/xiaohongshu-skills"]
 	path = trusted-external-repos/xiaohongshu-skills
@@ -28,7 +28,7 @@
 	branch = main
 [submodule "current-projects/first-tree"]
 	path = current-projects/first-tree
-	url = https://github.com/agent-team-foundation/first-tree.git
+	url = https://github.com/bingran-you/first-tree.git
 	branch = main
 [submodule "current-projects/DoWhiz"]
 	path = current-projects/DoWhiz


### PR DESCRIPTION
## Summary
- switch `trusted-external-repos/gbrain` to `https://github.com/bingran-you/gbrain.git`
- switch `current-projects/first-tree` to `https://github.com/bingran-you/first-tree.git`
- audit the remaining submodules and confirm the only non-`bingran-you` entries left are `xiaohongshu-skills` and `xiaohongshu-ops-skill`, which do not currently have matching `bingran-you/*` forks

## Verification
- ran `git submodule sync -- trusted-external-repos/gbrain current-projects/first-tree`
- ran `git submodule update --init --recursive trusted-external-repos/gbrain current-projects/first-tree`
- verified `git -C trusted-external-repos/gbrain remote -v` and `git -C current-projects/first-tree remote -v` now point at `bingran-you`
