### PR TITLE
Add claude-skills to trusted external repos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 	path = current-projects/skillsbench
 	url = https://github.com/bingran-you/skillsbench.git
 	branch = main
+[submodule "trusted-external-repos/claude-skills"]
+	path = trusted-external-repos/claude-skills
+	url = https://github.com/bingran-you/claude-skills.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 ├── README.md                                                # Human-facing GitHub profile
 ├── .agents/ .claude/ .openclaw/                             # Agent runtime state + skills
 ├── bingran-you-private/          # 🔒 Private submodule — never exfiltrate
-├── trusted-external-repos/       # Vendored trusted repos (skills, gstack)
+├── trusted-external-repos/       # Vendored trusted repos (skills, claude-skills, gstack, gbrain)
 ├── papers/                       # Research paper workspace
 ├── reading/                      # Reading notes and materials
 ├── scripts/                      # Utility scripts
@@ -45,7 +45,9 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 
 - `bingran-you-private` — **private.** Treat contents as confidential. Never paste into external channels, commits outside the submodule, PRs, or LLM calls that leave the machine.
 - `trusted-external-repos/skills` — shared skills library.
+- `trusted-external-repos/claude-skills` — Anthropic/Claude example skills reference library.
 - `trusted-external-repos/gstack` — gstack tooling.
+- `trusted-external-repos/gbrain` — gbrain tooling.
 
 If a submodule looks stale, check `git submodule status` before assuming it's broken.
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -10,9 +10,9 @@ Fill in as you learn. Delete sections that don't apply.
 
 - **Primary stack:** Codex + GPT-5.5 **and** Claude Code + Opus 4.7 (both prompt-cache-heavy; pick per task — Codex for long-horizon autonomous runs, Claude Code for interactive pair work)
 - **Secondary:** Anthropic SDK and OpenAI SDK for custom tooling
-- **Skills library:** `trusted-external-repos/skills/` (submodule)
+- **Shared skill libraries:** `trusted-external-repos/skills/`, `trusted-external-repos/claude-skills/` (submodules)
 - **Repo-local skills:** source lives in `repo-skills/`; mirrored into `.claude/skills` and `.agents/skills` by `scripts/sync_skills.sh`
-- **Harness configs:** `trusted-external-repos/gstack/`
+- **Harness/tooling repos:** `trusted-external-repos/gstack/`, `trusted-external-repos/gbrain/`
 
 ## Repos & Workspaces
 


### PR DESCRIPTION
## Summary
- add `trusted-external-repos/claude-skills` as a git submodule tracking `main`
- update workspace docs so agents know this trusted repo exists

## Testing
- verified the new submodule initializes and points at commit `5128e18` on `main`