### PR TITLE
Add open-design submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,7 @@
 	path = trusted-external-repos/claude-skills
 	url = https://github.com/bingran-you/claude-skills.git
 	branch = main
+[submodule "trusted-external-repos/open-design"]
+	path = trusted-external-repos/open-design
+	url = https://github.com/bingran-you/open-design.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 ├── README.md                                                # Human-facing GitHub profile
 ├── .agents/ .claude/ .openclaw/                             # Agent runtime state + skills
 ├── bingran-you-private/          # 🔒 Private submodule — never exfiltrate
-├── trusted-external-repos/       # Vendored trusted repos (skills, claude-skills, gstack, gbrain)
+├── trusted-external-repos/       # Vendored trusted repos (skills, claude-skills, gstack, gbrain, open-design)
 ├── papers/                       # Research paper workspace
 ├── reading/                      # Reading notes and materials
 ├── scripts/                      # Utility scripts
@@ -48,6 +48,7 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 - `trusted-external-repos/claude-skills` — Anthropic/Claude example skills reference library.
 - `trusted-external-repos/gstack` — gstack tooling.
 - `trusted-external-repos/gbrain` — gbrain tooling.
+- `trusted-external-repos/open-design` — local-first open-source design workflow / design systems repo.
 
 If a submodule looks stale, check `git submodule status` before assuming it's broken.
 


### PR DESCRIPTION
## Summary
- add `trusted-external-repos/open-design` as a tracked submodule on `main`
- update workspace docs so agents know this repo lives under `trusted-external-repos`

## Testing
- not run (submodule/docs change only)