### PR TITLE
Track mirrored skill links in the repo

### DIFF
--- a/.agents/skills/audio-jingle
+++ b/.agents/skills/audio-jingle
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/audio-jingle

--- a/.agents/skills/blog-post
+++ b/.agents/skills/blog-post
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/blog-post

--- a/.agents/skills/cli-creator
+++ b/.agents/skills/cli-creator
@@ -1,0 +1,1 @@
+../../repo-skills/cli-creator

--- a/.agents/skills/critique
+++ b/.agents/skills/critique
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/critique

--- a/.agents/skills/dashboard
+++ b/.agents/skills/dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/dashboard

--- a/.agents/skills/dating-web
+++ b/.agents/skills/dating-web
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/dating-web

--- a/.agents/skills/digital-eguide
+++ b/.agents/skills/digital-eguide
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/digital-eguide

--- a/.agents/skills/doc
+++ b/.agents/skills/doc
@@ -1,0 +1,1 @@
+../../repo-skills/doc

--- a/.agents/skills/docs-page
+++ b/.agents/skills/docs-page
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/docs-page

--- a/.agents/skills/docx
+++ b/.agents/skills/docx
@@ -1,0 +1,1 @@
+../../repo-skills/docx

--- a/.agents/skills/email-marketing
+++ b/.agents/skills/email-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/email-marketing

--- a/.agents/skills/eng-runbook
+++ b/.agents/skills/eng-runbook
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/eng-runbook

--- a/.agents/skills/finance-report
+++ b/.agents/skills/finance-report
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/finance-report

--- a/.agents/skills/frontend-design
+++ b/.agents/skills/frontend-design
@@ -1,0 +1,1 @@
+../../repo-skills/frontend-design

--- a/.agents/skills/frontend-slides
+++ b/.agents/skills/frontend-slides
@@ -1,0 +1,1 @@
+../../repo-skills/frontend-slides

--- a/.agents/skills/gamified-app
+++ b/.agents/skills/gamified-app
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gamified-app

--- a/.agents/skills/gh-address-comments
+++ b/.agents/skills/gh-address-comments
@@ -1,0 +1,1 @@
+../../repo-skills/gh-address-comments

--- a/.agents/skills/gh-fix-ci
+++ b/.agents/skills/gh-fix-ci
@@ -1,0 +1,1 @@
+../../repo-skills/gh-fix-ci

--- a/.agents/skills/guizang-ppt
+++ b/.agents/skills/guizang-ppt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/guizang-ppt

--- a/.agents/skills/hr-onboarding
+++ b/.agents/skills/hr-onboarding
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/hr-onboarding

--- a/.agents/skills/hyperframes
+++ b/.agents/skills/hyperframes
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/hyperframes

--- a/.agents/skills/image-poster
+++ b/.agents/skills/image-poster
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/image-poster

--- a/.agents/skills/invoice
+++ b/.agents/skills/invoice
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/invoice

--- a/.agents/skills/jupyter-notebook
+++ b/.agents/skills/jupyter-notebook
@@ -1,0 +1,1 @@
+../../repo-skills/jupyter-notebook

--- a/.agents/skills/kanban-board
+++ b/.agents/skills/kanban-board
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/kanban-board

--- a/.agents/skills/magazine-poster
+++ b/.agents/skills/magazine-poster
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/magazine-poster

--- a/.agents/skills/mcp-builder
+++ b/.agents/skills/mcp-builder
@@ -1,0 +1,1 @@
+../../repo-skills/mcp-builder

--- a/.agents/skills/meeting-notes
+++ b/.agents/skills/meeting-notes
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/meeting-notes

--- a/.agents/skills/mobile-app
+++ b/.agents/skills/mobile-app
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/mobile-app

--- a/.agents/skills/mobile-onboarding
+++ b/.agents/skills/mobile-onboarding
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/mobile-onboarding

--- a/.agents/skills/motion-frames
+++ b/.agents/skills/motion-frames
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/motion-frames

--- a/.agents/skills/pdf
+++ b/.agents/skills/pdf
@@ -1,0 +1,1 @@
+../../repo-skills/pdf

--- a/.agents/skills/playwright
+++ b/.agents/skills/playwright
@@ -1,0 +1,1 @@
+../../repo-skills/playwright

--- a/.agents/skills/playwright-interactive
+++ b/.agents/skills/playwright-interactive
@@ -1,0 +1,1 @@
+../../repo-skills/playwright-interactive

--- a/.agents/skills/plugin-creator
+++ b/.agents/skills/plugin-creator
@@ -1,0 +1,1 @@
+../../repo-skills/plugin-creator

--- a/.agents/skills/pm-spec
+++ b/.agents/skills/pm-spec
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pm-spec

--- a/.agents/skills/pptx
+++ b/.agents/skills/pptx
@@ -1,0 +1,1 @@
+../../repo-skills/pptx

--- a/.agents/skills/pricing-page
+++ b/.agents/skills/pricing-page
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pricing-page

--- a/.agents/skills/replit-deck
+++ b/.agents/skills/replit-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/replit-deck

--- a/.agents/skills/saas-landing
+++ b/.agents/skills/saas-landing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/saas-landing

--- a/.agents/skills/screenshot
+++ b/.agents/skills/screenshot
@@ -1,0 +1,1 @@
+../../repo-skills/screenshot

--- a/.agents/skills/security-best-practices
+++ b/.agents/skills/security-best-practices
@@ -1,0 +1,1 @@
+../../repo-skills/security-best-practices

--- a/.agents/skills/security-ownership-map
+++ b/.agents/skills/security-ownership-map
@@ -1,0 +1,1 @@
+../../repo-skills/security-ownership-map

--- a/.agents/skills/security-threat-model
+++ b/.agents/skills/security-threat-model
@@ -1,0 +1,1 @@
+../../repo-skills/security-threat-model

--- a/.agents/skills/simple-deck
+++ b/.agents/skills/simple-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/simple-deck

--- a/.agents/skills/skill-creator
+++ b/.agents/skills/skill-creator
@@ -1,0 +1,1 @@
+../../repo-skills/skill-creator

--- a/.agents/skills/skill-installer
+++ b/.agents/skills/skill-installer
@@ -1,0 +1,1 @@
+../../repo-skills/skill-installer

--- a/.agents/skills/social-carousel
+++ b/.agents/skills/social-carousel
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/social-carousel

--- a/.agents/skills/sprite-animation
+++ b/.agents/skills/sprite-animation
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/sprite-animation

--- a/.agents/skills/team-okrs
+++ b/.agents/skills/team-okrs
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/team-okrs

--- a/.agents/skills/theme-factory
+++ b/.agents/skills/theme-factory
@@ -1,0 +1,1 @@
+../../repo-skills/theme-factory

--- a/.agents/skills/tweaks
+++ b/.agents/skills/tweaks
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/tweaks

--- a/.agents/skills/vercel-deploy
+++ b/.agents/skills/vercel-deploy
@@ -1,0 +1,1 @@
+../../repo-skills/vercel-deploy

--- a/.agents/skills/video-shortform
+++ b/.agents/skills/video-shortform
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/video-shortform

--- a/.agents/skills/web-artifacts-builder
+++ b/.agents/skills/web-artifacts-builder
@@ -1,0 +1,1 @@
+../../repo-skills/web-artifacts-builder

--- a/.agents/skills/web-prototype
+++ b/.agents/skills/web-prototype
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/web-prototype

--- a/.agents/skills/webapp-testing
+++ b/.agents/skills/webapp-testing
@@ -1,0 +1,1 @@
+../../repo-skills/webapp-testing

--- a/.agents/skills/weekly-update
+++ b/.agents/skills/weekly-update
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/weekly-update

--- a/.agents/skills/wireframe-sketch
+++ b/.agents/skills/wireframe-sketch
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/wireframe-sketch

--- a/.agents/skills/xiaohongshu-knowledge
+++ b/.agents/skills/xiaohongshu-knowledge
@@ -1,0 +1,1 @@
+../../repo-skills/xiaohongshu-knowledge

--- a/.agents/skills/xlsx
+++ b/.agents/skills/xlsx
@@ -1,0 +1,1 @@
+../../repo-skills/xlsx

--- a/.claude/skills/audio-jingle
+++ b/.claude/skills/audio-jingle
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/audio-jingle

--- a/.claude/skills/blog-post
+++ b/.claude/skills/blog-post
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/blog-post

--- a/.claude/skills/cli-creator
+++ b/.claude/skills/cli-creator
@@ -1,0 +1,1 @@
+../../repo-skills/cli-creator

--- a/.claude/skills/critique
+++ b/.claude/skills/critique
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/critique

--- a/.claude/skills/dashboard
+++ b/.claude/skills/dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/dashboard

--- a/.claude/skills/dating-web
+++ b/.claude/skills/dating-web
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/dating-web

--- a/.claude/skills/digital-eguide
+++ b/.claude/skills/digital-eguide
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/digital-eguide

--- a/.claude/skills/doc
+++ b/.claude/skills/doc
@@ -1,0 +1,1 @@
+../../repo-skills/doc

--- a/.claude/skills/docs-page
+++ b/.claude/skills/docs-page
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/docs-page

--- a/.claude/skills/docx
+++ b/.claude/skills/docx
@@ -1,0 +1,1 @@
+../../repo-skills/docx

--- a/.claude/skills/email-marketing
+++ b/.claude/skills/email-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/email-marketing

--- a/.claude/skills/eng-runbook
+++ b/.claude/skills/eng-runbook
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/eng-runbook

--- a/.claude/skills/finance-report
+++ b/.claude/skills/finance-report
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/finance-report

--- a/.claude/skills/frontend-design
+++ b/.claude/skills/frontend-design
@@ -1,0 +1,1 @@
+../../repo-skills/frontend-design

--- a/.claude/skills/frontend-slides
+++ b/.claude/skills/frontend-slides
@@ -1,0 +1,1 @@
+../../repo-skills/frontend-slides

--- a/.claude/skills/gamified-app
+++ b/.claude/skills/gamified-app
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gamified-app

--- a/.claude/skills/gh-address-comments
+++ b/.claude/skills/gh-address-comments
@@ -1,0 +1,1 @@
+../../repo-skills/gh-address-comments

--- a/.claude/skills/gh-fix-ci
+++ b/.claude/skills/gh-fix-ci
@@ -1,0 +1,1 @@
+../../repo-skills/gh-fix-ci

--- a/.claude/skills/guizang-ppt
+++ b/.claude/skills/guizang-ppt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/guizang-ppt

--- a/.claude/skills/hr-onboarding
+++ b/.claude/skills/hr-onboarding
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/hr-onboarding

--- a/.claude/skills/hyperframes
+++ b/.claude/skills/hyperframes
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/hyperframes

--- a/.claude/skills/image-poster
+++ b/.claude/skills/image-poster
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/image-poster

--- a/.claude/skills/invoice
+++ b/.claude/skills/invoice
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/invoice

--- a/.claude/skills/jupyter-notebook
+++ b/.claude/skills/jupyter-notebook
@@ -1,0 +1,1 @@
+../../repo-skills/jupyter-notebook

--- a/.claude/skills/kanban-board
+++ b/.claude/skills/kanban-board
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/kanban-board

--- a/.claude/skills/magazine-poster
+++ b/.claude/skills/magazine-poster
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/magazine-poster

--- a/.claude/skills/mcp-builder
+++ b/.claude/skills/mcp-builder
@@ -1,0 +1,1 @@
+../../repo-skills/mcp-builder

--- a/.claude/skills/meeting-notes
+++ b/.claude/skills/meeting-notes
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/meeting-notes

--- a/.claude/skills/mobile-app
+++ b/.claude/skills/mobile-app
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/mobile-app

--- a/.claude/skills/mobile-onboarding
+++ b/.claude/skills/mobile-onboarding
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/mobile-onboarding

--- a/.claude/skills/motion-frames
+++ b/.claude/skills/motion-frames
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/motion-frames

--- a/.claude/skills/pdf
+++ b/.claude/skills/pdf
@@ -1,0 +1,1 @@
+../../repo-skills/pdf

--- a/.claude/skills/playwright
+++ b/.claude/skills/playwright
@@ -1,0 +1,1 @@
+../../repo-skills/playwright

--- a/.claude/skills/playwright-interactive
+++ b/.claude/skills/playwright-interactive
@@ -1,0 +1,1 @@
+../../repo-skills/playwright-interactive

--- a/.claude/skills/plugin-creator
+++ b/.claude/skills/plugin-creator
@@ -1,0 +1,1 @@
+../../repo-skills/plugin-creator

--- a/.claude/skills/pm-spec
+++ b/.claude/skills/pm-spec
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pm-spec

--- a/.claude/skills/pptx
+++ b/.claude/skills/pptx
@@ -1,0 +1,1 @@
+../../repo-skills/pptx

--- a/.claude/skills/pricing-page
+++ b/.claude/skills/pricing-page
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pricing-page

--- a/.claude/skills/replit-deck
+++ b/.claude/skills/replit-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/replit-deck

--- a/.claude/skills/saas-landing
+++ b/.claude/skills/saas-landing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/saas-landing

--- a/.claude/skills/screenshot
+++ b/.claude/skills/screenshot
@@ -1,0 +1,1 @@
+../../repo-skills/screenshot

--- a/.claude/skills/security-best-practices
+++ b/.claude/skills/security-best-practices
@@ -1,0 +1,1 @@
+../../repo-skills/security-best-practices

--- a/.claude/skills/security-ownership-map
+++ b/.claude/skills/security-ownership-map
@@ -1,0 +1,1 @@
+../../repo-skills/security-ownership-map

--- a/.claude/skills/security-threat-model
+++ b/.claude/skills/security-threat-model
@@ -1,0 +1,1 @@
+../../repo-skills/security-threat-model

--- a/.claude/skills/simple-deck
+++ b/.claude/skills/simple-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/simple-deck

--- a/.claude/skills/skill-creator
+++ b/.claude/skills/skill-creator
@@ -1,0 +1,1 @@
+../../repo-skills/skill-creator

--- a/.claude/skills/skill-installer
+++ b/.claude/skills/skill-installer
@@ -1,0 +1,1 @@
+../../repo-skills/skill-installer

--- a/.claude/skills/social-carousel
+++ b/.claude/skills/social-carousel
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/social-carousel

--- a/.claude/skills/sprite-animation
+++ b/.claude/skills/sprite-animation
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/sprite-animation

--- a/.claude/skills/team-okrs
+++ b/.claude/skills/team-okrs
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/team-okrs

--- a/.claude/skills/theme-factory
+++ b/.claude/skills/theme-factory
@@ -1,0 +1,1 @@
+../../repo-skills/theme-factory

--- a/.claude/skills/tweaks
+++ b/.claude/skills/tweaks
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/tweaks

--- a/.claude/skills/vercel-deploy
+++ b/.claude/skills/vercel-deploy
@@ -1,0 +1,1 @@
+../../repo-skills/vercel-deploy

--- a/.claude/skills/video-shortform
+++ b/.claude/skills/video-shortform
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/video-shortform

--- a/.claude/skills/web-artifacts-builder
+++ b/.claude/skills/web-artifacts-builder
@@ -1,0 +1,1 @@
+../../repo-skills/web-artifacts-builder

--- a/.claude/skills/web-prototype
+++ b/.claude/skills/web-prototype
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/web-prototype

--- a/.claude/skills/webapp-testing
+++ b/.claude/skills/webapp-testing
@@ -1,0 +1,1 @@
+../../repo-skills/webapp-testing

--- a/.claude/skills/weekly-update
+++ b/.claude/skills/weekly-update
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/weekly-update

--- a/.claude/skills/wireframe-sketch
+++ b/.claude/skills/wireframe-sketch
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/wireframe-sketch

--- a/.claude/skills/xiaohongshu-knowledge
+++ b/.claude/skills/xiaohongshu-knowledge
@@ -1,0 +1,1 @@
+../../repo-skills/xiaohongshu-knowledge

--- a/.claude/skills/xlsx
+++ b/.claude/skills/xlsx
@@ -1,0 +1,1 @@
+../../repo-skills/xlsx

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 .omx/
 scripts/githuber/target/
 /.claude/worktrees
-/.claude/skills/
-/.agents/skills/
 .DS_Store
 /papers/papers-reading/GEN-1/presentation-workspace/scratch
 /papers/papers-reading/GEN-1/presentation-workspace/node_modules


### PR DESCRIPTION
## Summary
- stop ignoring `.claude/skills` and `.agents/skills`
- check the mirrored skill symlinks into the repo so link changes sync through git
- keep the existing auto-link sync flow intact for rebuilding the link farm when skill directories are added or removed

## Verification
- `./scripts/sync_skills.sh refresh`
- `git add .gitignore .claude/skills .agents/skills`
- verified 61 symlinks in each mirrored directory