### PR TITLE
fix(personal-site): correct source link in welcome post

### DIFF
--- a/personal-site/content/posts/welcome.mdx
+++ b/personal-site/content/posts/welcome.mdx
@@ -16,7 +16,7 @@ This is a small place on the internet for two tracks of work I care about: build
 
 ## Stack
 
-This site is a small Next.js + MDX app, deployed on Vercel. Source on [GitHub](https://github.com/bingran-you/personal-site). It's written so I can drop a new MDX file into `content/posts/` and ship a post.
+This site is a small Next.js + MDX app, deployed on Vercel. Source lives in the [`personal-site/`](https://github.com/bingran-you/bingran-you/tree/main/personal-site) directory of my workspace repo. It's written so I can drop a new MDX file into `content/posts/` and ship a post.
 
 If you want to reach out, the footer has the usual suspects.
 


### PR DESCRIPTION
Stale link in the welcome blog post pointed to the now-archived `bingran-you/personal-site` repo. Update to the `personal-site/` subdirectory of this repo (the new home).

Also serves as the first git → Vercel auto-deploy test.