### PR TITLE
memory: log personal-site shipping

### DIFF
--- a/memory/2026-05-01.md
+++ b/memory/2026-05-01.md
@@ -1,0 +1,46 @@
+# 2026-05-01
+
+## Personal site shipped: bingranyou.com
+
+End-to-end stand-up of the personal site Bingran bought the domain for.
+
+### Stack
+
+- Next.js 16 (App Router, Turbopack, React 19) + TypeScript
+- Tailwind CSS v4 + `@tailwindcss/typography`
+- MDX via `@next/mdx` + `remark-gfm` (file-based blog: `personal-site/content/posts/{slug}.mdx`, registered in `personal-site/lib/posts.ts`)
+- Deployed on Vercel, project `personal-site` under team `bingran-yous-projects`
+
+### Layout
+
+- Source lives at `personal-site/` of this repo (`bingran-you/bingran-you`)
+- Vercel Root Directory set to `personal-site`
+- Pages: `/`, `/projects`, `/papers`, `/blog`, `/blog/{slug}`
+- Header nav + footer with social links sourced from the profile README
+- Two-track identity: 🖥️ AI Builder + ⚛︎ Ion Trapper
+
+### Domain wiring
+
+- Domain registered with Cloudflare DNS
+- Two A records (DNS only, gray cloud), both → `76.76.21.21`:
+  - `@` → bingranyou.com
+  - `www` → www.bingranyou.com
+- Vercel auto-issued Let's Encrypt cert in ~1 min once DNS propagated
+- DNS-only mode chosen (not Cloudflare proxy) — proxy + Vercel TLS conflict; future CDN switch would need SSL/TLS Full strict
+
+### CI/deploy flow
+
+- Vercel GitHub App connected to `bingran-you/bingran-you`
+- `git push main` → production build, `git push <branch>` + PR → preview build
+- `Include files outside root directory` was originally Enabled (default for monorepos), causing every root-level commit (e.g. profile README edits) to redeploy. Disabled to limit Vercel triggers to changes inside `personal-site/`. `Skip deployments when no changes to root dir` stays Enabled.
+
+### Migration history
+
+- Initially created standalone repo `bingran-you/personal-site` (PR #1 merged), then migrated into this workspace repo via PR [#72](https://github.com/bingran-you/bingran-you/pull/72) (squash-merge) at `personal-site/`. Old repo archived.
+- PR [#73](https://github.com/bingran-you/bingran-you/pull/73) was the first git → Vercel auto-deploy validation (fix stale source link in welcome post).
+
+### Adding a blog post
+
+1. Drop `personal-site/content/posts/{slug}.mdx` with `export const metadata = { title, description, date }`
+2. Register `"{slug}"` in `personal-site/lib/posts.ts` `postSlugs` array
+3. Push to main — Vercel auto-builds and ships


### PR DESCRIPTION
Daily memory log for the personal-site bring-up. Also serves as a test that Vercel's "Include files outside root directory" toggle being **disabled** correctly skips deploys when the diff is entirely outside `personal-site/`.