### PR TITLE
ci(personal-site): add ignoreCommand to skip non-site deploys

### DIFF
--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+}


### PR DESCRIPTION
Vercel's UI toggle 'Skip deployments when there are no changes to the root directory' isn't skipping our memory-only / README-only commits — they all trigger full builds.

This adds an explicit `personal-site/vercel.json` with:

```json
{
  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
}
```

`git diff --quiet -- .` returns 0 when nothing inside the current dir (Root Directory = `personal-site`) changed. Vercel interprets exit code 0 as 'skip this deployment'. So commits that only touch `memory/`, `README.md`, `AGENTS.md` etc. will skip the build.

This PR itself touches `personal-site/` so it'll deploy normally. The skip behavior takes effect for the next non-site commit.