### PR TITLE
memory: log skip-deploy verification step

### DIFF
--- a/memory/2026-05-01.md
+++ b/memory/2026-05-01.md
@@ -44,3 +44,7 @@ End-to-end stand-up of the personal site Bingran bought the domain for.
 1. Drop `personal-site/content/posts/{slug}.mdx` with `export const metadata = { title, description, date }`
 2. Register `"{slug}"` in `personal-site/lib/posts.ts` `postSlugs` array
 3. Push to main — Vercel auto-builds and ships
+
+### Skip-deploy verification
+
+Vercel UI toggle alone wasn't reliable; explicit `personal-site/vercel.json` `ignoreCommand` (`git diff --quiet HEAD^ HEAD -- .`) added in PR #75. This commit edits only `memory/` to confirm Vercel now skips the build.


### PR DESCRIPTION
Pure `memory/` change to verify the new `ignoreCommand` in `personal-site/vercel.json` is now skipping non-site deploys.

Preview already showed `Canceled` with log line:
```
Running "git diff --quiet HEAD^ HEAD -- ."
The Deployment has been canceled as a result of running the command defined in the "Ignored Build Step" setting.
```

Merging this also tests production skip.