### PR TITLE
chore(submodules): point DoWhiz and first-tree to upstream sources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,11 +20,11 @@
 	branch = main
 [submodule "current-projects/first-tree"]
 	path = current-projects/first-tree
-	url = https://github.com/bingran-you/first-tree.git
+	url = https://github.com/agent-team-foundation/first-tree.git
 	branch = main
 [submodule "current-projects/DoWhiz"]
 	path = current-projects/DoWhiz
-	url = https://github.com/bingran-you/DoWhiz.git
+	url = https://github.com/KnoWhiz/DoWhiz.git
 	branch = dev
 [submodule "current-projects/skillsbench"]
 	path = current-projects/skillsbench


### PR DESCRIPTION
## Summary
- Switch `current-projects/DoWhiz` from `bingran-you/DoWhiz` to upstream `KnoWhiz/DoWhiz`
- Switch `current-projects/first-tree` from `bingran-you/first-tree` to upstream `agent-team-foundation/first-tree`
- Pinned submodule SHAs already exist in upstream — no commit-pointer bump needed

## Test plan
- [x] `git submodule sync` for both paths
- [x] Verified pinned SHAs (`5683874`, `612215b`) resolve in upstream repos