### PR TITLE
Highlight two AI papers on home

### DIFF
--- a/personal-site/app/page.tsx
+++ b/personal-site/app/page.tsx
@@ -4,7 +4,7 @@ import { education, projects, papers } from "@/lib/content";
 
 export default function Home() {
   const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 4);
-  const ionHighlights = papers.filter((p) => p.track === "ion").slice(0, 3);
+  const paperHighlights = papers.filter((p) => p.track === "ai").slice(0, 2);
 
   return (
     <div className="space-y-24">
@@ -110,7 +110,7 @@ export default function Home() {
           </Link>
         </div>
         <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
-          {ionHighlights.map((p) => (
+          {paperHighlights.map((p) => (
             <li key={p.href}>
               <a
                 href={p.href}


### PR DESCRIPTION
## Summary
The home Selected Papers list was filtering on \`track === \"ion\"\` and slicing 3, which surfaced quantum work that already lives on \`/papers\`. Filter on \`track === \"ai\"\` and slice 2 so the home highlights match the AI-builder framing of the rest of the page; the full ion list remains on \`/papers\`.

## Test plan
- [x] \`npm run build\` passes
- [x] Home renders two AI papers under Selected Papers