### PR TITLE
Add mews to AI projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 - 📐 [SkillsBench](https://github.com/benchflow-ai/skillsbench) - A benchmark for evaluating how well AI agents use skills.
 - 🌲 [first-tree](https://github.com/agent-team-foundation/first-tree) - A Git-native context layer for decisions, ownership, and shared team knowledge.
 - 🥷 [DoWhiz](https://github.com/KnoWhiz/DoWhiz) - An agent-native product for getting work done across email, chat, documents, and related tools.
+- 🐈 [mews](https://github.com/bingran-you/mews) - A local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos while you sleep.
 - 🧠 [DeepTutor](https://deeptutor.knowhiz.us/) - An AI research assistant built on Zotero for cited answers, figure and formula understanding, and multi-paper comparison.
 - 🦞 [smolclaw](https://github.com/bingran-you/smolclaw) - Seeded mock environments for testing agent behavior in realistic workflows.
 - 😜 [SBTI CLI](https://github.com/bingran-you/sbti-cli) - An offline CLI for testing agent behavior with bundled logic and exportable results.

--- a/personal-site/lib/content.ts
+++ b/personal-site/lib/content.ts
@@ -48,6 +48,14 @@ export const projects: Project[] = [
     track: "ai",
   },
   {
+    name: "mews",
+    href: "https://github.com/bingran-you/mews",
+    description:
+      "Local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos while you sleep.",
+    emoji: "🐈",
+    track: "ai",
+  },
+  {
     name: "DeepTutor",
     href: "https://deeptutor.knowhiz.us/",
     description:


### PR DESCRIPTION
## Summary
Add the ongoing [mews](https://github.com/bingran-you/mews) project — a local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos — to:

- `personal-site/lib/content.ts` (AI projects array, after DoWhiz so it surfaces in the home Selected Projects highlights)
- `README.md` (AI Builder Selected Work)

## Test plan
- [x] Home Selected Projects renders SkillsBench · first-tree · DoWhiz · mews
- [x] /projects shows mews under AI Builder