### PR TITLE
Add paper venues and reorder Current Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 - 📐 [SkillsBench](https://github.com/benchflow-ai/skillsbench) - A benchmark for evaluating how well AI agents use skills.
 - 🌲 [first-tree](https://github.com/agent-team-foundation/first-tree) - A Git-native context layer for decisions, ownership, and shared team knowledge.
 - 🥷 [DoWhiz](https://github.com/KnoWhiz/DoWhiz) - An agent-native product for getting work done across email, chat, documents, and related tools.
-- 🐈 [mews](https://github.com/bingran-you/mews) - A local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos while you sleep.
 - 🧠 [DeepTutor](https://deeptutor.knowhiz.us/) - An AI research assistant built on Zotero for cited answers, figure and formula understanding, and multi-paper comparison.
+- 🐈 [mews](https://github.com/bingran-you/mews) - A local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos while you sleep.
 - 🦞 [smolclaw](https://github.com/bingran-you/smolclaw) - Seeded mock environments for testing agent behavior in realistic workflows.
 - 😜 [SBTI CLI](https://github.com/bingran-you/sbti-cli) - An offline CLI for testing agent behavior with bundled logic and exportable results.
 - 💻 [bem](https://github.com/HaeffnerLab/bem) - Scientific computing code for boundary element and fast multipole methods in Python.
@@ -44,8 +44,8 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 
 ### Selected Papers
 
-- 📑 [ClawsBench: Evaluating Capability and Safety of LLM Productivity Agents in Simulated Workspaces](https://arxiv.org/abs/2604.05172)
-- 📑 [SkillsBench: Benchmarking How Well Agent Skills Work Across Diverse Tasks](https://arxiv.org/abs/2602.12670)
+- 📑 *arXiv* · [ClawsBench: Evaluating Capability and Safety of LLM Productivity Agents in Simulated Workspaces](https://arxiv.org/abs/2604.05172)
+- 📑 *arXiv* · [SkillsBench: Benchmarking How Well Agent Skills Work Across Diverse Tasks](https://arxiv.org/abs/2602.12670)
 
 ## ⚛︎ Ion Trapper
 
@@ -74,10 +74,10 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 
 ### Selected Papers
 
-- 📑 [Individual trapped-ion addressing with adjoint-optimized multimode photonic circuits](https://www.nature.com/articles/s44310-025-00102-4) - Integrated photonic circuits for scalable trapped-ion addressing.
-- 📑 [Temporally multiplexed ion-photon quantum interface via fast ion-chain transport](https://arxiv.org/abs/2405.10501) - Multiplexed ion-photon interface based on fast ion-chain transport.
-- 📑 [3D-Printed Micro Ion Trap Technology for Scalable Quantum Information Processing](https://www.nature.com/articles/s41586-025-09474-1) - 3D-printed micro ion trap technology for scalable quantum information processing.
-- 📑 [Test of Causal Non-Linear Quantum Mechanics by Ramsey Interferometry on the Vibrational Mode of a Trapped Ion](https://doi.org/10.1103/PhysRevLett.130.200201) - Trapped-ion Ramsey interferometry probing causal non-linear quantum mechanics.
+- 📑 *npj Nanophotonics* · [Individual trapped-ion addressing with adjoint-optimized multimode photonic circuits](https://www.nature.com/articles/s44310-025-00102-4) - Integrated photonic circuits for scalable trapped-ion addressing.
+- 📑 *arXiv* · [Temporally multiplexed ion-photon quantum interface via fast ion-chain transport](https://arxiv.org/abs/2405.10501) - Multiplexed ion-photon interface based on fast ion-chain transport.
+- 📑 *Nature* · [3D-Printed Micro Ion Trap Technology for Scalable Quantum Information Processing](https://www.nature.com/articles/s41586-025-09474-1) - 3D-printed micro ion trap technology for scalable quantum information processing.
+- 📑 *Phys. Rev. Lett.* · [Test of Causal Non-Linear Quantum Mechanics by Ramsey Interferometry on the Vibrational Mode of a Trapped Ion](https://doi.org/10.1103/PhysRevLett.130.200201) - Trapped-ion Ramsey interferometry probing causal non-linear quantum mechanics.
 
 ## Connect
 

--- a/personal-site/app/page.tsx
+++ b/personal-site/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { education, projects, papers } from "@/lib/content";
 
 export default function Home() {
-  const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 4);
+  const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 5);
   const paperHighlights = papers.filter((p) => p.track === "ai").slice(0, 2);
 
   return (
@@ -67,7 +67,7 @@ export default function Home() {
       <section>
         <div className="flex items-baseline justify-between gap-4">
           <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
-            Selected projects
+            Current projects
           </h2>
           <Link
             href="/projects"
@@ -118,6 +118,9 @@ export default function Home() {
                 rel="noopener noreferrer"
                 className="flex flex-col gap-1 py-5 group"
               >
+                <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">
+                  {p.venue}
+                </span>
                 <span className="text-base font-medium leading-snug group-hover:underline underline-offset-4">
                   {p.title}
                 </span>

--- a/personal-site/app/papers/page.tsx
+++ b/personal-site/app/papers/page.tsx
@@ -55,6 +55,9 @@ function Section({
               rel="noopener noreferrer"
               className="flex flex-col gap-1 py-5 group"
             >
+              <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">
+                {p.venue}
+              </span>
               <span className="text-base font-medium leading-snug group-hover:underline underline-offset-4">
                 {p.title}
               </span>

--- a/personal-site/lib/content.ts
+++ b/personal-site/lib/content.ts
@@ -9,6 +9,7 @@ export type Project = {
 export type Paper = {
   title: string;
   href: string;
+  venue: string;
   blurb?: string;
   track: "ai" | "ion";
 };
@@ -48,19 +49,19 @@ export const projects: Project[] = [
     track: "ai",
   },
   {
-    name: "mews",
-    href: "https://github.com/bingran-you/mews",
-    description:
-      "Local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos while you sleep.",
-    emoji: "🐈",
-    track: "ai",
-  },
-  {
     name: "DeepTutor",
     href: "https://deeptutor.knowhiz.us/",
     description:
       "An AI research assistant built on Zotero for cited answers, figure and formula understanding, and multi-paper comparison.",
     emoji: "🧠",
+    track: "ai",
+  },
+  {
+    name: "mews",
+    href: "https://github.com/bingran-you/mews",
+    description:
+      "Local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos while you sleep.",
+    emoji: "🐈",
     track: "ai",
   },
   {
@@ -102,17 +103,20 @@ export const papers: Paper[] = [
     title:
       "ClawsBench: Evaluating Capability and Safety of LLM Productivity Agents in Simulated Workspaces",
     href: "https://arxiv.org/abs/2604.05172",
+    venue: "arXiv",
     track: "ai",
   },
   {
     title: "SkillsBench: Benchmarking How Well Agent Skills Work Across Diverse Tasks",
     href: "https://arxiv.org/abs/2602.12670",
+    venue: "arXiv",
     track: "ai",
   },
   {
     title:
       "Individual trapped-ion addressing with adjoint-optimized multimode photonic circuits",
     href: "https://www.nature.com/articles/s44310-025-00102-4",
+    venue: "npj Nanophotonics",
     blurb: "Integrated photonic circuits for scalable trapped-ion addressing.",
     track: "ion",
   },
@@ -120,6 +124,7 @@ export const papers: Paper[] = [
     title:
       "Temporally multiplexed ion-photon quantum interface via fast ion-chain transport",
     href: "https://arxiv.org/abs/2405.10501",
+    venue: "arXiv",
     blurb:
       "Multiplexed ion-photon interface based on fast ion-chain transport.",
     track: "ion",
@@ -128,6 +133,7 @@ export const papers: Paper[] = [
     title:
       "3D-Printed Micro Ion Trap Technology for Scalable Quantum Information Processing",
     href: "https://www.nature.com/articles/s41586-025-09474-1",
+    venue: "Nature",
     blurb:
       "3D-printed micro ion trap technology for scalable quantum information processing.",
     track: "ion",
@@ -136,6 +142,7 @@ export const papers: Paper[] = [
     title:
       "Test of Causal Non-Linear Quantum Mechanics by Ramsey Interferometry on the Vibrational Mode of a Trapped Ion",
     href: "https://doi.org/10.1103/PhysRevLett.130.200201",
+    venue: "Phys. Rev. Lett.",
     blurb:
       "Trapped-ion Ramsey interferometry probing causal non-linear quantum mechanics.",
     track: "ion",


### PR DESCRIPTION
## Summary
- Add a \`venue\` field to the Paper type (arXiv, npj Nanophotonics, Nature, Phys. Rev. Lett.) and render as a small mono uppercase eyebrow above each paper title on the home and \`/papers\` pages.
- Mirror the venue in README paper bullets as an italic \`*Venue* ·\` prefix for both AI and Ion sections.
- Rename home Selected Projects → Current Projects, bump slice to five, and reorder AI projects so DeepTutor sits before mews (matches the order Bingran requested).

## Test plan
- [x] \`npm run build\` passes
- [x] Home Current Projects renders SkillsBench · first-tree · DoWhiz · DeepTutor · mews
- [x] Selected Papers eyebrows show ARXIV / NATURE / NPJ NANOPHOTONICS / PHYS. REV. LETT.
- [x] README order and venue prefixes match