### PR TITLE
Add YouTube channel to social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 <p align="center">
   <a href="https://x.com/bingran_bry"><img alt="X" src="https://img.shields.io/badge/-X-000000?style=flat-square&logo=x&logoColor=white" /></a>
   <a href="https://xhslink.com/m/gFj0Vwr2Ak"><img alt="Rednote" src="https://img.shields.io/badge/-Rednote-FF2442?style=flat-square&logo=xiaohongshu&logoColor=white" /></a>
+  <a href="https://www.youtube.com/@BingranBRY"><img alt="YouTube" src="https://img.shields.io/badge/-YouTube-FF0000?style=flat-square&logo=youtube&logoColor=white" /></a>
   <a href="https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en&authuser=2"><img alt="Google Scholar" src="https://img.shields.io/badge/-Google%20Scholar-4285F4?style=flat-square&logo=googlescholar&logoColor=white" /></a>
   <a href="https://orcid.org/0000-0002-0316-2115"><img alt="ORCID" src="https://img.shields.io/badge/-ORCID-A6CE39?style=flat-square&logo=orcid&logoColor=white" /></a>
   <a href="https://huggingface.co/bingran-you"><img alt="Hugging Face" src="https://img.shields.io/badge/-Hugging%20Face-FFD21E?style=flat-square&logo=huggingface&logoColor=black" /></a>

--- a/personal-site/components/social-links.tsx
+++ b/personal-site/components/social-links.tsx
@@ -32,6 +32,14 @@ function OrcidIcon({ className }: IconProps) {
   );
 }
 
+function YouTubeIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+    </svg>
+  );
+}
+
 function HuggingFaceIcon({ className }: IconProps) {
   return (
     <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
@@ -71,6 +79,11 @@ const links = [
     href: "https://xhslink.com/m/gFj0Vwr2Ak",
     label: "Xiaohongshu",
     icon: XiaohongshuIcon,
+  },
+  {
+    href: "https://www.youtube.com/@BingranBRY",
+    label: "YouTube",
+    icon: YouTubeIcon,
   },
   { href: "https://github.com/bingran-you", label: "GitHub", icon: GitHubIcon },
   {


### PR DESCRIPTION
## Summary
Append @BingranBRY to the personal-site footer (right after Xiaohongshu so social / broadcast platforms stay grouped) and add the matching YouTube badge to the README Connect row.

## Test plan
- [x] Footer renders 9 icons (X · Xiaohongshu · YouTube · GitHub · Scholar · ORCID · HF · LinkedIn · Email)