### PR TITLE
Add sitemap.ts and robots.ts for personal-site

### DIFF
--- a/personal-site/app/robots.ts
+++ b/personal-site/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://bingranyou.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+import { getAllPostsMetadata } from "@/lib/posts";
+
+const SITE_URL = "https://bingranyou.com";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+  const posts = await getAllPostsMetadata();
+
+  const staticEntries: MetadataRoute.Sitemap = [
+    { url: `${SITE_URL}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/projects`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${SITE_URL}/papers`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${SITE_URL}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
+  ];
+
+  const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    changeFrequency: "yearly",
+    priority: 0.6,
+  }));
+
+  return [...staticEntries, ...postEntries];
+}


### PR DESCRIPTION
## Summary
First step of the SEO/GEO baseline plan for `bingranyou.com`.

- `app/sitemap.ts` — generates `/sitemap.xml` from static routes (`/`, `/projects`, `/papers`, `/blog`) plus every MDX post returned by `getAllPostsMetadata()`.
- `app/robots.ts` — emits a permissive `/robots.txt` (`User-Agent: *`, `Allow: /`) and points to the sitemap. No LLM crawlers (GPTBot / ClaudeBot / PerplexityBot / Google-Extended) are blocked, since the goal is to be discoverable in AI answers.

Zero visual change.

## Test plan
- [x] `npx next build` — both routes prerendered (`/sitemap.xml`, `/robots.txt`).
- [x] Verified body of `sitemap.xml` lists `/`, `/projects`, `/papers`, `/blog`, `/blog/welcome` with correct lastmod / changefreq / priority.
- [x] Verified body of `robots.txt` is `User-Agent: * / Allow: / / Host / Sitemap`.
- [ ] After deploy: confirm `https://bingranyou.com/sitemap.xml` and `/robots.txt` are reachable; submit sitemap to Google Search Console + Bing Webmaster Tools.

---
_Generated by [Claude Code](https://claude.ai/code/session_018T1sofLeokqohJV4pG8eXA)_