### PR TITLE
Document personal-site/ in workspace docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 ├── current-projects/             # Active project submodules / local checkouts
 ├── trusted-external-repos/       # Vendored trusted repos and references
 ├── repo-skills/                  # First-party workspace skills
+├── personal-site/                # bingranyou.com — Next.js + MDX, deployed on Vercel
 ├── papers/                       # Research paper workspace
 ├── reading/                      # Reading notes and materials
 ├── scripts/                      # Utility scripts (including skill sync)

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,6 +5,7 @@ Main-session only. Keep this file high-signal and durable.
 ## Workspace
 
 - `current-projects/` holds active project submodules such as `DoWhiz`, `first-tree`, `mews`, and `skillsbench`.
+- `personal-site/` hosts `bingranyou.com` (Next.js 16 + MDX, deployed on Vercel from this repo with Root Directory `personal-site`). Pushes to `main` trigger production builds; the `personal-site/vercel.json` `ignoreCommand` skips builds when nothing inside `personal-site/` changes.
 - Repo-managed skills live in `repo-skills/` and `trusted-external-repos/open-design/skills/`.
 - `scripts/sync_skills.sh` mirrors valid skill directories into `.agents/skills` and `.claude/skills`.
 - Session-start hooks in `.claude/settings.json` and `.codex/config.toml` attempt to run `scripts/sync_skills.sh init` automatically.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -21,6 +21,7 @@ Fill in as you learn. Delete sections that don't apply.
 - **Worktrees root:** `~/Downloads/GitHub/Claude-Worktrees/bingran-you/` — parallel sessions, per-branch.
 - **Private submodule:** `bingran-you-private/` — confidential, never exfiltrate.
 - **Active project submodules:** `current-projects/DoWhiz`, `current-projects/first-tree`, `current-projects/mews`, `current-projects/skillsbench`
+- **Personal site:** `personal-site/` — Next.js + MDX source for `bingranyou.com`, deployed on Vercel (project `personal-site` under team `bingran-yous-projects`)
 
 ## Ion-Trap Environment
 


### PR DESCRIPTION
## Summary

Audited workspace docs against the actual repo state. The only stale spot was `personal-site/` — it ships `bingranyou.com` (Next.js 16 + MDX, deployed on Vercel from this repo, present since the migration recorded in `memory/2026-05-01.md`) but never made it into the curated docs.

- `AGENTS.md`: add `personal-site/` to Workspace Layout.
- `MEMORY.md`: lift the durable Vercel deployment context (Root Directory, `vercel.json` `ignoreCommand`) into curated workspace memory.
- `TOOLS.md`: add `personal-site/` under "Repos & Workspaces" alongside the other active checkouts.

Everything else (USER.md projects, README.md profile, `.gitmodules` vs AGENTS.md submodule list, `sync_skills.sh` references in TOOLS.md/MEMORY.md/repo-skills/README.md, hook configs in `.claude/settings.json` and `.codex/config.toml`, `personal-site/README.md` vs `personal-site/package.json`) is already aligned and was left alone.

## Test plan

- [x] `git diff` reviewed — three single-line additions, no churn elsewhere.
- [x] Verified `personal-site/` exists at repo root and is referenced consistently with `memory/2026-05-01.md` (Vercel project + Root Directory + `ignoreCommand`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUZ49mwcB3Wqq7ecz9DmgE)_