### PR TITLE
Add Person and WebSite JSON-LD to root layout

### DIFF
--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -41,6 +41,61 @@ export const metadata: Metadata = {
   },
 };
 
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Bingran You",
+  givenName: "Bingran",
+  familyName: "You",
+  url: "https://bingranyou.com",
+  image: "https://bingranyou.com/images/profile/bingran-you-portrait.jpg",
+  jobTitle: "PhD Candidate",
+  description:
+    "PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.",
+  alumniOf: [
+    {
+      "@type": "CollegeOrUniversity",
+      name: "University of California, Berkeley",
+      sameAs: "https://www.berkeley.edu/",
+    },
+    {
+      "@type": "CollegeOrUniversity",
+      name: "University of Chinese Academy of Sciences",
+      sameAs: "https://english.ucas.ac.cn/",
+    },
+  ],
+  affiliation: {
+    "@type": "Organization",
+    name: "Haeffner Lab, University of California, Berkeley",
+    url: "https://haeffnerlab.berkeley.edu/",
+  },
+  knowsAbout: [
+    "Reliable AI Systems",
+    "AI Agents",
+    "Trapped-Ion Quantum Computing",
+    "Integrated Photonics",
+    "Quantum Networking",
+  ],
+  sameAs: [
+    "https://x.com/bingran_bry",
+    "https://github.com/bingran-you",
+    "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",
+    "https://orcid.org/0000-0002-0316-2115",
+    "https://huggingface.co/bingran-you",
+    "https://www.linkedin.com/in/bingran-you-775b4017b/",
+    "https://www.youtube.com/@BingranBRY",
+  ],
+};
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Bingran You",
+  url: "https://bingranyou.com",
+  inLanguage: "en",
+  author: { "@type": "Person", name: "Bingran You" },
+};
+
 const nav = [
   { href: "/", label: "Home" },
   { href: "/projects", label: "Projects" },
@@ -59,6 +114,18 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} ${newsreader.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(personJsonLd).replace(/</g, "\\u003c"),
+          }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(websiteJsonLd).replace(/</g, "\\u003c"),
+          }}
+        />
         <header className="sticky top-0 z-20 border-b border-[var(--border)] bg-[var(--background)]/85 backdrop-blur">
           <div className="mx-auto max-w-4xl px-6 py-5 flex items-center justify-between">
             <Link


### PR DESCRIPTION
## Summary
Step 2 of the SEO/GEO baseline. Inline structured data on every page so Google's Knowledge Graph and LLM crawlers can resolve identity unambiguously.

- `Person` schema: name, jobTitle, description, image, `alumniOf` (Berkeley + UCAS), `affiliation` (Haeffner Lab), `knowsAbout`, and `sameAs` linking out to Scholar, ORCID, GitHub, X, LinkedIn, Hugging Face, YouTube.
- `WebSite` schema: identifies `bingranyou.com` itself with author back-reference.
- Rendered as inline `<script type="application/ld+json">` per the official Next.js JSON-LD guide; `<` is unicode-escaped to prevent XSS.

Zero visual change.

## Test plan
- [x] `npx next build` — TypeScript and prerender pass.
- [x] Verified rendered HTML at `/index.html` contains both `application/ld+json` blocks with the expected fields.
- [ ] After deploy: validate with [Schema Markup Validator](https://validator.schema.org/) and [Google Rich Results Test](https://search.google.com/test/rich-results).

---
_Generated by [Claude Code](https://claude.ai/code/session_018T1sofLeokqohJV4pG8eXA)_