### PR TITLE
Add per-page metadata, canonical URLs, and OpenGraph tags

### DIFF
--- a/personal-site/app/blog/[slug]/page.tsx
+++ b/personal-site/app/blog/[slug]/page.tsx
@@ -19,9 +19,19 @@ export async function generateMetadata({
   const { slug } = await params;
   if (!postSlugs.includes(slug as PostSlug)) return {};
   const mod = await import(`@/content/posts/${slug}.mdx`);
+  const url = `/blog/${slug}`;
   return {
     title: mod.metadata.title,
     description: mod.metadata.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: mod.metadata.title,
+      description: mod.metadata.description,
+      url,
+      type: "article",
+      publishedTime: mod.metadata.date,
+      authors: ["Bingran You"],
+    },
   };
 }
 

--- a/personal-site/app/blog/page.tsx
+++ b/personal-site/app/blog/page.tsx
@@ -4,7 +4,16 @@ import { getAllPostsMetadata } from "@/lib/posts";
 
 export const metadata: Metadata = {
   title: "Blog",
-  description: "Short notes on AI agents, quantum experiments, and craft.",
+  description:
+    "Short notes by Bingran You on AI agents, trapped-ion quantum experiments, and the craft of making complex systems behave on purpose.",
+  alternates: { canonical: "/blog" },
+  openGraph: {
+    title: "Blog · Bingran You",
+    description:
+      "Short notes on AI agents, quantum experiments, and the craft of dependable systems.",
+    url: "/blog",
+    type: "website",
+  },
 };
 
 export default async function BlogPage() {

--- a/personal-site/app/page.tsx
+++ b/personal-site/app/page.tsx
@@ -1,6 +1,21 @@
 import Image from "next/image";
 import Link from "next/link";
+import type { Metadata } from "next";
 import { education, projects, papers } from "@/lib/content";
+
+export const metadata: Metadata = {
+  title: "Bingran You — AI Builder & Ion Trapper",
+  description:
+    "Bingran You is a PhD candidate at UC Berkeley (Haeffner Lab) building reliable AI agent systems and trapped-ion quantum experiments.",
+  alternates: { canonical: "/" },
+  openGraph: {
+    title: "Bingran You — AI Builder & Ion Trapper",
+    description:
+      "PhD candidate at UC Berkeley. Reliable AI agent systems × trapped-ion quantum experiments.",
+    url: "/",
+    type: "profile",
+  },
+};
 
 export default function Home() {
   const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 5);

--- a/personal-site/app/papers/page.tsx
+++ b/personal-site/app/papers/page.tsx
@@ -3,7 +3,16 @@ import { papers } from "@/lib/content";
 
 export const metadata: Metadata = {
   title: "Papers",
-  description: "Selected publications across AI agents and trapped-ion physics.",
+  description:
+    "Selected publications by Bingran You spanning AI agent benchmarks (ClawsBench, SkillsBench) and trapped-ion physics (Nature, Phys. Rev. Lett., npj Nanophotonics).",
+  alternates: { canonical: "/papers" },
+  openGraph: {
+    title: "Papers · Bingran You",
+    description:
+      "Selected publications across AI agents and trapped-ion physics.",
+    url: "/papers",
+    type: "website",
+  },
 };
 
 export default function PapersPage() {

--- a/personal-site/app/projects/page.tsx
+++ b/personal-site/app/projects/page.tsx
@@ -3,7 +3,16 @@ import { projects } from "@/lib/content";
 
 export const metadata: Metadata = {
   title: "Projects",
-  description: "Selected projects across AI systems and trapped-ion experiments.",
+  description:
+    "Open-source projects by Bingran You — AI agent benchmarks and tooling (SkillsBench, first-tree, DoWhiz, DeepTutor, mews) and trapped-ion experiment software (bem, artiq_photonics_integration).",
+  alternates: { canonical: "/projects" },
+  openGraph: {
+    title: "Projects · Bingran You",
+    description:
+      "Open-source AI agent infrastructure and trapped-ion experiment software.",
+    url: "/projects",
+    type: "website",
+  },
 };
 
 export default function ProjectsPage() {


### PR DESCRIPTION
## Summary
P1 step 1. Each route now exports its own metadata so search engines and LLMs see distinct, fact-rich titles, descriptions, canonical URLs, and OpenGraph blocks.

- `/` (home): adds page-level metadata that names "Bingran You", "PhD candidate at UC Berkeley", "Haeffner Lab", "reliable AI agent systems", "trapped-ion quantum experiments". `og:type=profile`.
- `/projects`: lists project names in description (SkillsBench, first-tree, DoWhiz, DeepTutor, mews, bem, artiq_photonics_integration) so they index alongside the homepage.
- `/papers`: enumerates venues (Nature, Phys. Rev. Lett., npj Nanophotonics, ClawsBench, SkillsBench).
- `/blog`: descriptive copy + canonical.
- `/blog/[slug]`: `og:type=article` with `publishedTime` and `authors`.

All five pages now also emit `<link rel="canonical">` so the `bingranyou.com` vs `www.bingranyou.com` ambiguity is resolved in favor of the apex domain.

Zero visual change.

## Test plan
- [x] `npx next build` — TypeScript and prerender pass.
- [x] Verified rendered HTML for `/projects` includes correct `<title>`, `<meta name="description">`, `<link rel="canonical">`, `og:title`, `og:description`, `og:url`, `og:type`.
- [ ] After deploy: spot-check with [Schema Markup Validator](https://validator.schema.org/) and [Twitter card validator](https://cards-dev.twitter.com/validator).

---
_Generated by [Claude Code](https://claude.ai/code/session_018T1sofLeokqohJV4pG8eXA)_