### PR TITLE
Add marketingskills workspace source

### DIFF
--- a/.agents/skills/ab-test-setup
+++ b/.agents/skills/ab-test-setup
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/ab-test-setup

--- a/.agents/skills/ad-creative
+++ b/.agents/skills/ad-creative
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/ad-creative

--- a/.agents/skills/ai-seo
+++ b/.agents/skills/ai-seo
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/ai-seo

--- a/.agents/skills/analytics-tracking
+++ b/.agents/skills/analytics-tracking
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/analytics-tracking

--- a/.agents/skills/aso-audit
+++ b/.agents/skills/aso-audit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/aso-audit

--- a/.agents/skills/churn-prevention
+++ b/.agents/skills/churn-prevention
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/churn-prevention

--- a/.agents/skills/cold-email
+++ b/.agents/skills/cold-email
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/cold-email

--- a/.agents/skills/community-marketing
+++ b/.agents/skills/community-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/community-marketing

--- a/.agents/skills/competitor-alternatives
+++ b/.agents/skills/competitor-alternatives
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/competitor-alternatives

--- a/.agents/skills/competitor-profiling
+++ b/.agents/skills/competitor-profiling
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/competitor-profiling

--- a/.agents/skills/content-strategy
+++ b/.agents/skills/content-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/content-strategy

--- a/.agents/skills/copy-editing
+++ b/.agents/skills/copy-editing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/copy-editing

--- a/.agents/skills/copywriting
+++ b/.agents/skills/copywriting
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/copywriting

--- a/.agents/skills/customer-research
+++ b/.agents/skills/customer-research
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/customer-research

--- a/.agents/skills/design-brief
+++ b/.agents/skills/design-brief
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/design-brief

--- a/.agents/skills/directory-submissions
+++ b/.agents/skills/directory-submissions
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/directory-submissions

--- a/.agents/skills/email-sequence
+++ b/.agents/skills/email-sequence
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/email-sequence

--- a/.agents/skills/form-cro
+++ b/.agents/skills/form-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/form-cro

--- a/.agents/skills/free-tool-strategy
+++ b/.agents/skills/free-tool-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/free-tool-strategy

--- a/.agents/skills/html-ppt
+++ b/.agents/skills/html-ppt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt

--- a/.agents/skills/html-ppt-course-module
+++ b/.agents/skills/html-ppt-course-module
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-course-module

--- a/.agents/skills/html-ppt-dir-key-nav-minimal
+++ b/.agents/skills/html-ppt-dir-key-nav-minimal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-dir-key-nav-minimal

--- a/.agents/skills/html-ppt-graphify-dark-graph
+++ b/.agents/skills/html-ppt-graphify-dark-graph
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-graphify-dark-graph

--- a/.agents/skills/html-ppt-hermes-cyber-terminal
+++ b/.agents/skills/html-ppt-hermes-cyber-terminal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-hermes-cyber-terminal

--- a/.agents/skills/html-ppt-knowledge-arch-blueprint
+++ b/.agents/skills/html-ppt-knowledge-arch-blueprint
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-knowledge-arch-blueprint

--- a/.agents/skills/html-ppt-obsidian-claude-gradient
+++ b/.agents/skills/html-ppt-obsidian-claude-gradient
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-obsidian-claude-gradient

--- a/.agents/skills/html-ppt-pitch-deck
+++ b/.agents/skills/html-ppt-pitch-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-pitch-deck

--- a/.agents/skills/html-ppt-presenter-mode-reveal
+++ b/.agents/skills/html-ppt-presenter-mode-reveal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-presenter-mode-reveal

--- a/.agents/skills/html-ppt-product-launch
+++ b/.agents/skills/html-ppt-product-launch
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-product-launch

--- a/.agents/skills/html-ppt-tech-sharing
+++ b/.agents/skills/html-ppt-tech-sharing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-tech-sharing

--- a/.agents/skills/html-ppt-testing-safety-alert
+++ b/.agents/skills/html-ppt-testing-safety-alert
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-testing-safety-alert

--- a/.agents/skills/html-ppt-weekly-report
+++ b/.agents/skills/html-ppt-weekly-report
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-weekly-report

--- a/.agents/skills/html-ppt-xhs-pastel-card
+++ b/.agents/skills/html-ppt-xhs-pastel-card
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-xhs-pastel-card

--- a/.agents/skills/html-ppt-xhs-post
+++ b/.agents/skills/html-ppt-xhs-post
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-xhs-post

--- a/.agents/skills/html-ppt-xhs-white-editorial
+++ b/.agents/skills/html-ppt-xhs-white-editorial
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-xhs-white-editorial

--- a/.agents/skills/image
+++ b/.agents/skills/image
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/image

--- a/.agents/skills/launch-strategy
+++ b/.agents/skills/launch-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/launch-strategy

--- a/.agents/skills/lead-magnets
+++ b/.agents/skills/lead-magnets
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/lead-magnets

--- a/.agents/skills/marketing-ideas
+++ b/.agents/skills/marketing-ideas
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/marketing-ideas

--- a/.agents/skills/marketing-psychology
+++ b/.agents/skills/marketing-psychology
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/marketing-psychology

--- a/.agents/skills/onboarding-cro
+++ b/.agents/skills/onboarding-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/onboarding-cro

--- a/.agents/skills/page-cro
+++ b/.agents/skills/page-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/page-cro

--- a/.agents/skills/paid-ads
+++ b/.agents/skills/paid-ads
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/paid-ads

--- a/.agents/skills/paywall-upgrade-cro
+++ b/.agents/skills/paywall-upgrade-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/paywall-upgrade-cro

--- a/.agents/skills/popup-cro
+++ b/.agents/skills/popup-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/popup-cro

--- a/.agents/skills/pricing-strategy
+++ b/.agents/skills/pricing-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/pricing-strategy

--- a/.agents/skills/product-marketing-context
+++ b/.agents/skills/product-marketing-context
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/product-marketing-context

--- a/.agents/skills/programmatic-seo
+++ b/.agents/skills/programmatic-seo
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/programmatic-seo

--- a/.agents/skills/referral-program
+++ b/.agents/skills/referral-program
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/referral-program

--- a/.agents/skills/revops
+++ b/.agents/skills/revops
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/revops

--- a/.agents/skills/sales-enablement
+++ b/.agents/skills/sales-enablement
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/sales-enablement

--- a/.agents/skills/schema-markup
+++ b/.agents/skills/schema-markup
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/schema-markup

--- a/.agents/skills/seo-audit
+++ b/.agents/skills/seo-audit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/seo-audit

--- a/.agents/skills/signup-flow-cro
+++ b/.agents/skills/signup-flow-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/signup-flow-cro

--- a/.agents/skills/site-architecture
+++ b/.agents/skills/site-architecture
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/site-architecture

--- a/.agents/skills/social-content
+++ b/.agents/skills/social-content
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/social-content

--- a/.agents/skills/video
+++ b/.agents/skills/video
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/video

--- a/.claude/skills/ab-test-setup
+++ b/.claude/skills/ab-test-setup
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/ab-test-setup

--- a/.claude/skills/ad-creative
+++ b/.claude/skills/ad-creative
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/ad-creative

--- a/.claude/skills/ai-seo
+++ b/.claude/skills/ai-seo
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/ai-seo

--- a/.claude/skills/analytics-tracking
+++ b/.claude/skills/analytics-tracking
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/analytics-tracking

--- a/.claude/skills/aso-audit
+++ b/.claude/skills/aso-audit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/aso-audit

--- a/.claude/skills/churn-prevention
+++ b/.claude/skills/churn-prevention
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/churn-prevention

--- a/.claude/skills/cold-email
+++ b/.claude/skills/cold-email
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/cold-email

--- a/.claude/skills/community-marketing
+++ b/.claude/skills/community-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/community-marketing

--- a/.claude/skills/competitor-alternatives
+++ b/.claude/skills/competitor-alternatives
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/competitor-alternatives

--- a/.claude/skills/competitor-profiling
+++ b/.claude/skills/competitor-profiling
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/competitor-profiling

--- a/.claude/skills/content-strategy
+++ b/.claude/skills/content-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/content-strategy

--- a/.claude/skills/copy-editing
+++ b/.claude/skills/copy-editing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/copy-editing

--- a/.claude/skills/copywriting
+++ b/.claude/skills/copywriting
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/copywriting

--- a/.claude/skills/customer-research
+++ b/.claude/skills/customer-research
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/customer-research

--- a/.claude/skills/design-brief
+++ b/.claude/skills/design-brief
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/design-brief

--- a/.claude/skills/directory-submissions
+++ b/.claude/skills/directory-submissions
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/directory-submissions

--- a/.claude/skills/email-sequence
+++ b/.claude/skills/email-sequence
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/email-sequence

--- a/.claude/skills/form-cro
+++ b/.claude/skills/form-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/form-cro

--- a/.claude/skills/free-tool-strategy
+++ b/.claude/skills/free-tool-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/free-tool-strategy

--- a/.claude/skills/html-ppt
+++ b/.claude/skills/html-ppt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt

--- a/.claude/skills/html-ppt-course-module
+++ b/.claude/skills/html-ppt-course-module
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-course-module

--- a/.claude/skills/html-ppt-dir-key-nav-minimal
+++ b/.claude/skills/html-ppt-dir-key-nav-minimal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-dir-key-nav-minimal

--- a/.claude/skills/html-ppt-graphify-dark-graph
+++ b/.claude/skills/html-ppt-graphify-dark-graph
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-graphify-dark-graph

--- a/.claude/skills/html-ppt-hermes-cyber-terminal
+++ b/.claude/skills/html-ppt-hermes-cyber-terminal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-hermes-cyber-terminal

--- a/.claude/skills/html-ppt-knowledge-arch-blueprint
+++ b/.claude/skills/html-ppt-knowledge-arch-blueprint
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-knowledge-arch-blueprint

--- a/.claude/skills/html-ppt-obsidian-claude-gradient
+++ b/.claude/skills/html-ppt-obsidian-claude-gradient
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-obsidian-claude-gradient

--- a/.claude/skills/html-ppt-pitch-deck
+++ b/.claude/skills/html-ppt-pitch-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-pitch-deck

--- a/.claude/skills/html-ppt-presenter-mode-reveal
+++ b/.claude/skills/html-ppt-presenter-mode-reveal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-presenter-mode-reveal

--- a/.claude/skills/html-ppt-product-launch
+++ b/.claude/skills/html-ppt-product-launch
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-product-launch

--- a/.claude/skills/html-ppt-tech-sharing
+++ b/.claude/skills/html-ppt-tech-sharing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-tech-sharing

--- a/.claude/skills/html-ppt-testing-safety-alert
+++ b/.claude/skills/html-ppt-testing-safety-alert
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-testing-safety-alert

--- a/.claude/skills/html-ppt-weekly-report
+++ b/.claude/skills/html-ppt-weekly-report
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-weekly-report

--- a/.claude/skills/html-ppt-xhs-pastel-card
+++ b/.claude/skills/html-ppt-xhs-pastel-card
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-xhs-pastel-card

--- a/.claude/skills/html-ppt-xhs-post
+++ b/.claude/skills/html-ppt-xhs-post
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-xhs-post

--- a/.claude/skills/html-ppt-xhs-white-editorial
+++ b/.claude/skills/html-ppt-xhs-white-editorial
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-xhs-white-editorial

--- a/.claude/skills/image
+++ b/.claude/skills/image
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/image

--- a/.claude/skills/launch-strategy
+++ b/.claude/skills/launch-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/launch-strategy

--- a/.claude/skills/lead-magnets
+++ b/.claude/skills/lead-magnets
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/lead-magnets

--- a/.claude/skills/marketing-ideas
+++ b/.claude/skills/marketing-ideas
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/marketing-ideas

--- a/.claude/skills/marketing-psychology
+++ b/.claude/skills/marketing-psychology
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/marketing-psychology

--- a/.claude/skills/onboarding-cro
+++ b/.claude/skills/onboarding-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/onboarding-cro

--- a/.claude/skills/page-cro
+++ b/.claude/skills/page-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/page-cro

--- a/.claude/skills/paid-ads
+++ b/.claude/skills/paid-ads
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/paid-ads

--- a/.claude/skills/paywall-upgrade-cro
+++ b/.claude/skills/paywall-upgrade-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/paywall-upgrade-cro

--- a/.claude/skills/popup-cro
+++ b/.claude/skills/popup-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/popup-cro

--- a/.claude/skills/pricing-strategy
+++ b/.claude/skills/pricing-strategy
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/pricing-strategy

--- a/.claude/skills/product-marketing-context
+++ b/.claude/skills/product-marketing-context
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/product-marketing-context

--- a/.claude/skills/programmatic-seo
+++ b/.claude/skills/programmatic-seo
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/programmatic-seo

--- a/.claude/skills/referral-program
+++ b/.claude/skills/referral-program
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/referral-program

--- a/.claude/skills/revops
+++ b/.claude/skills/revops
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/revops

--- a/.claude/skills/sales-enablement
+++ b/.claude/skills/sales-enablement
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/sales-enablement

--- a/.claude/skills/schema-markup
+++ b/.claude/skills/schema-markup
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/schema-markup

--- a/.claude/skills/seo-audit
+++ b/.claude/skills/seo-audit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/seo-audit

--- a/.claude/skills/signup-flow-cro
+++ b/.claude/skills/signup-flow-cro
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/signup-flow-cro

--- a/.claude/skills/site-architecture
+++ b/.claude/skills/site-architecture
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/site-architecture

--- a/.claude/skills/social-content
+++ b/.claude/skills/social-content
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/social-content

--- a/.claude/skills/video
+++ b/.claude/skills/video
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/video

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 	path = trusted-external-repos/open-design
 	url = https://github.com/bingran-you/open-design.git
 	branch = main
+[submodule "trusted-external-repos/marketingskills"]
+	path = trusted-external-repos/marketingskills
+	url = https://github.com/bingran-you/marketingskills.git
+	branch = main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ No permission needed. Just read. If `bingran-you-private/` looks empty, run `git
 └── memory/                       # Daily logs + heartbeat state
 ```
 
-Repo-managed skill sources live in `repo-skills/` and `trusted-external-repos/open-design/skills/`. Mirror them into `.agents/skills` and `.claude/skills` via `scripts/sync_skills.sh` instead of editing the entrypoints by hand.
+Repo-managed skill sources live in `repo-skills/`, `trusted-external-repos/open-design/skills/`, and `trusted-external-repos/marketingskills/skills/`. Mirror them into `.agents/skills` and `.claude/skills` via `scripts/sync_skills.sh` instead of editing the entrypoints by hand.
 
 ### Submodules (see `.gitmodules`)
 
@@ -58,6 +58,7 @@ Repo-managed skill sources live in `repo-skills/` and `trusted-external-repos/op
 - `current-projects/skillsbench` — active project submodule.
 - `trusted-external-repos/skills` — shared skills library.
 - `trusted-external-repos/claude-skills` — Anthropic/Claude example skills reference library.
+- `trusted-external-repos/marketingskills` — trusted external marketing skills library; mirrored into workspace skill entrypoints via `scripts/sync_skills.sh`.
 - `trusted-external-repos/gstack` — gstack tooling.
 - `trusted-external-repos/gbrain` — gbrain tooling.
 - `trusted-external-repos/open-design` — local-first open-source design workflow / design systems repo.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,7 +6,7 @@ Main-session only. Keep this file high-signal and durable.
 
 - `current-projects/` holds active project submodules such as `DoWhiz`, `first-tree`, `mews`, and `skillsbench`.
 - `personal-site/` hosts `bingranyou.com` (Next.js 16 + MDX, deployed on Vercel from this repo with Root Directory `personal-site`). Pushes to `main` trigger production builds; the `personal-site/vercel.json` `ignoreCommand` skips builds when nothing inside `personal-site/` changes.
-- Repo-managed skills live in `repo-skills/` and `trusted-external-repos/open-design/skills/`.
+- Repo-managed skills live in `repo-skills/`, `trusted-external-repos/open-design/skills/`, and `trusted-external-repos/marketingskills/skills/`.
 - `scripts/sync_skills.sh` mirrors valid skill directories into `.agents/skills` and `.claude/skills`.
 - Session-start hooks in `.claude/settings.json` and `.codex/config.toml` attempt to run `scripts/sync_skills.sh init` automatically.
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -11,7 +11,7 @@ Fill in as you learn. Delete sections that don't apply.
 - **Primary stack:** Codex + GPT-5.5 **and** Claude Code + Opus 4.7 (both prompt-cache-heavy; pick per task — Codex for long-horizon autonomous runs, Claude Code for interactive pair work)
 - **Secondary:** Anthropic SDK and OpenAI SDK for custom tooling
 - **Reference skill libraries:** `trusted-external-repos/skills/`, `trusted-external-repos/claude-skills/` (submodules)
-- **Workspace skills:** source lives in `repo-skills/` and `trusted-external-repos/open-design/skills/`; `scripts/sync_skills.sh` mirrors valid skills into `.claude/skills` and `.agents/skills` as per-skill directory symlinks
+- **Workspace skills:** source lives in `repo-skills/`, `trusted-external-repos/open-design/skills/`, and `trusted-external-repos/marketingskills/skills/`; `scripts/sync_skills.sh` mirrors valid skills into `.claude/skills` and `.agents/skills` as per-skill directory symlinks
 - **Auto-bootstrap hooks:** `.claude/settings.json` and `.codex/config.toml` both attempt `scripts/sync_skills.sh init` on session start; if skills look stale, run that command manually
 - **Harness/tooling repos:** `trusted-external-repos/gstack/`, `trusted-external-repos/gbrain/`
 

--- a/memory/2026-05-02.md
+++ b/memory/2026-05-02.md
@@ -1,0 +1,9 @@
+# 2026-05-02
+
+- Added `trusted-external-repos/marketingskills` as a git submodule tracking `main`.
+- Extended `scripts/sync_skills.sh` so workspace skill discovery now includes `trusted-external-repos/marketingskills/skills` and manages that submodule during `init` / `update`.
+- Refreshed `.agents/skills` and `.claude/skills`; the workspace now mirrors 118 skills total:
+  - 26 from `repo-skills/`
+  - 52 from `trusted-external-repos/open-design/skills/`
+  - 40 from `trusted-external-repos/marketingskills/skills/`
+- Updated `AGENTS.md`, `TOOLS.md`, and `MEMORY.md` so future sessions know `marketingskills` is part of the trusted external skill sources.

--- a/scripts/sync_skills.sh
+++ b/scripts/sync_skills.sh
@@ -8,10 +8,12 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
 SOURCE_ROOTS=(
   "repo-skills"
   "trusted-external-repos/open-design/skills"
+  "trusted-external-repos/marketingskills/skills"
 )
 
 MANAGED_SUBMODULES=(
   "trusted-external-repos/open-design"
+  "trusted-external-repos/marketingskills"
 )
 
 ENTRYPOINT_DIRS=(


### PR DESCRIPTION
## Summary
- add `trusted-external-repos/marketingskills` as a tracked submodule
- mirror `trusted-external-repos/marketingskills/skills` into workspace skill discovery
- refresh `.agents/skills` and `.claude/skills`, and document the new source

## Validation
- `scripts/sync_skills.sh refresh`
- `scripts/sync_skills.sh status`