### PR TITLE
Add Google + Bing site verification

### DIFF
--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -39,6 +39,9 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     creator: "@bingran_bry",
   },
+  verification: {
+    google: "xWQd6sxfEf5jfU4AtrNcPv0jg71Ia8gQvXAcQmWKpyo",
+  },
 };
 
 const personJsonLd = {

--- a/personal-site/public/BingSiteAuth.xml
+++ b/personal-site/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>C77A0761D7E8AC083CAFB4431C78EC54</user>
+</users>


### PR DESCRIPTION
## Summary

Adds search engine ownership verification so we can manage indexing in Google Search Console (GSC) and Bing Webmaster Tools.

- `metadata.verification.google` in [layout.tsx](personal-site/app/layout.tsx) emits the GSC verification meta tag (redundant with the DNS TXT record already in place — survives DNS provider changes).
- `personal-site/public/BingSiteAuth.xml` is served at `https://bingranyou.com/BingSiteAuth.xml` for Bing site ownership.

Both are required for the larger SEO/GEO push: GSC unlocks sitemap submission, indexing reports, and Core Web Vitals; Bing Webmaster covers ChatGPT search, Copilot, and DuckDuckGo, which all index via Bing.

## Test plan

- [ ] After deploy, `curl -s https://bingranyou.com/ | grep google-site-verification` returns the meta tag.
- [ ] `curl https://bingranyou.com/BingSiteAuth.xml` returns the XML file.
- [ ] In Bing Webmaster Tools, "Import from Google Search Console" or XML File verification succeeds for `bingranyou.com`.