### PR TITLE
Canonical URLs and www to apex redirect

### DIFF
--- a/personal-site/app/blog/[slug]/page.tsx
+++ b/personal-site/app/blog/[slug]/page.tsx
@@ -22,6 +22,7 @@ export async function generateMetadata({
   return {
     title: mod.metadata.title,
     description: mod.metadata.description,
+    alternates: { canonical: `/blog/${slug}` },
   };
 }
 

--- a/personal-site/app/blog/page.tsx
+++ b/personal-site/app/blog/page.tsx
@@ -5,6 +5,7 @@ import { getAllPostsMetadata } from "@/lib/posts";
 export const metadata: Metadata = {
   title: "Blog",
   description: "Short notes on AI agents, quantum experiments, and craft.",
+  alternates: { canonical: "/blog" },
 };
 
 export default async function BlogPage() {

--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -39,6 +39,9 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     creator: "@bingran_bry",
   },
+  alternates: {
+    canonical: "/",
+  },
   verification: {
     google: "xWQd6sxfEf5jfU4AtrNcPv0jg71Ia8gQvXAcQmWKpyo",
   },

--- a/personal-site/app/papers/page.tsx
+++ b/personal-site/app/papers/page.tsx
@@ -4,6 +4,7 @@ import { papers } from "@/lib/content";
 export const metadata: Metadata = {
   title: "Papers",
   description: "Selected publications across AI agents and trapped-ion physics.",
+  alternates: { canonical: "/papers" },
 };
 
 export default function PapersPage() {

--- a/personal-site/app/projects/page.tsx
+++ b/personal-site/app/projects/page.tsx
@@ -4,6 +4,7 @@ import { projects } from "@/lib/content";
 export const metadata: Metadata = {
   title: "Projects",
   description: "Selected projects across AI systems and trapped-ion experiments.",
+  alternates: { canonical: "/projects" },
 };
 
 export default function ProjectsPage() {

--- a/personal-site/next.config.ts
+++ b/personal-site/next.config.ts
@@ -7,6 +7,16 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname),
   },
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.bingranyou.com" }],
+        destination: "https://bingranyou.com/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 const withMDX = createMDX({


### PR DESCRIPTION
## Summary

Consolidates apex/www signals so search engines and LLM crawlers see one host of record (`bingranyou.com`).

- `metadata.alternates.canonical` set on layout default and each route (`/`, `/projects`, `/papers`, `/blog`, `/blog/[slug]`). Tells crawlers which URL is authoritative when the same content is reachable from multiple hosts or query strings.
- `next.config.ts` `redirects()` adds a permanent (308) host-matched redirect from `www.bingranyou.com/*` to `https://bingranyou.com/*`. Picks the apex as primary so it matches `metadataBase` and the GSC Domain property.

Without this, `https://www.bingranyou.com/sitemap.xml` returned a duplicate 200 (verified via curl), splitting Google's ranking signal across two hosts.

## Test plan

- [ ] After deploy, `curl -sI https://www.bingranyou.com/` returns `HTTP/2 308` with `location: https://bingranyou.com/`.
- [ ] Same redirect for nested paths: `curl -sI https://www.bingranyou.com/projects` → 308 to `https://bingranyou.com/projects`.
- [ ] `curl -s https://bingranyou.com/projects | grep canonical` shows `<link rel="canonical" href="https://bingranyou.com/projects" />`.
- [ ] Apex stays 200; sitemap still valid.