### PR TITLE
Improve personal-site SEO/GEO signals

### DIFF
--- a/personal-site/app/blog/[slug]/page.tsx
+++ b/personal-site/app/blog/[slug]/page.tsx
@@ -1,7 +1,15 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { postSlugs, type PostSlug } from "@/lib/posts";
+import { JsonLd } from "@/components/json-ld";
+import {
+  getPostLastModified,
+  getPostMetadata,
+  postSlugs,
+  type PostSlug,
+} from "@/lib/posts";
+import { createArticleMetadata, siteConfig } from "@/lib/site";
+import { getBlogPostingJsonLd } from "@/lib/structured-data";
 
 export const dynamicParams = false;
 
@@ -18,39 +26,56 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   if (!postSlugs.includes(slug as PostSlug)) return {};
-  const mod = await import(`@/content/posts/${slug}.mdx`);
-  return {
-    title: mod.metadata.title,
-    description: mod.metadata.description,
-  };
+  const postSlug = slug as PostSlug;
+  const metadata = await getPostMetadata(postSlug);
+  const modifiedTime = (await getPostLastModified(postSlug)).toISOString();
+
+  return createArticleMetadata({
+    title: metadata.title,
+    description: metadata.description ?? siteConfig.description,
+    path: `/blog/${postSlug}`,
+    publishedTime: new Date(metadata.date).toISOString(),
+    modifiedTime,
+  });
 }
 
 export default async function PostPage({ params }: { params: Params }) {
   const { slug } = await params;
   if (!postSlugs.includes(slug as PostSlug)) notFound();
+  const postSlug = slug as PostSlug;
   const { default: Post, metadata } = await import(
     `@/content/posts/${slug}.mdx`
   );
+  const modifiedTime = (await getPostLastModified(postSlug)).toISOString();
 
   return (
-    <article className="space-y-10">
-      <header className="space-y-3">
-        <Link
-          href="/blog"
-          className="inline-block font-mono text-xs uppercase tracking-widest text-[var(--muted)] hover:text-foreground transition"
-        >
-          ← Blog
-        </Link>
-        <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight leading-tight">
-          {metadata.title}
-        </h1>
-        <time className="block font-mono text-sm text-[var(--muted)] tabular-nums">
-          {metadata.date}
-        </time>
-      </header>
-      <div className="prose prose-zinc dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:underline-offset-4 prose-a:decoration-[var(--border)] hover:prose-a:decoration-foreground">
-        <Post />
-      </div>
-    </article>
+    <>
+      <JsonLd
+        data={getBlogPostingJsonLd({
+          slug: postSlug,
+          metadata,
+          modifiedTime,
+        })}
+      />
+      <article className="space-y-10">
+        <header className="space-y-3">
+          <Link
+            href="/blog"
+            className="inline-block font-mono text-xs uppercase tracking-widest text-[var(--muted)] hover:text-foreground transition"
+          >
+            ← Blog
+          </Link>
+          <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight leading-tight">
+            {metadata.title}
+          </h1>
+          <time className="block font-mono text-sm text-[var(--muted)] tabular-nums">
+            {metadata.date}
+          </time>
+        </header>
+        <div className="prose prose-zinc dark:prose-invert max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:underline-offset-4 prose-a:decoration-[var(--border)] hover:prose-a:decoration-foreground">
+          <Post />
+        </div>
+      </article>
+    </>
   );
 }

--- a/personal-site/app/blog/page.tsx
+++ b/personal-site/app/blog/page.tsx
@@ -1,49 +1,59 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { JsonLd } from "@/components/json-ld";
 import { getAllPostsMetadata } from "@/lib/posts";
+import { createPageMetadata } from "@/lib/site";
+import { getBlogJsonLd } from "@/lib/structured-data";
 
-export const metadata: Metadata = {
+const description = "Short notes on AI agents, quantum experiments, and craft.";
+
+export const metadata: Metadata = createPageMetadata({
   title: "Blog",
-  description: "Short notes on AI agents, quantum experiments, and craft.",
-};
+  description,
+  path: "/blog",
+});
 
 export default async function BlogPage() {
   const posts = await getAllPostsMetadata();
+  const blogJsonLd = getBlogJsonLd(posts);
 
   return (
-    <div className="space-y-12">
-      <header>
-        <h1 className="text-3xl font-semibold tracking-tight">Blog</h1>
-        <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">
-          Short notes — on agents, ions, and the craft of making complex things
-          dependable.
-        </p>
-      </header>
+    <>
+      <JsonLd data={blogJsonLd} />
+      <div className="space-y-12">
+        <header>
+          <h1 className="text-3xl font-semibold tracking-tight">Blog</h1>
+          <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">
+            Short notes — on agents, ions, and the craft of making complex
+            things dependable.
+          </p>
+        </header>
 
-      <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
-        {posts.map((post) => (
-          <li key={post.slug}>
-            <Link
-              href={`/blog/${post.slug}`}
-              className="flex flex-col gap-1 py-5 group"
-            >
-              <span className="flex items-baseline gap-3">
-                <time className="font-mono text-xs text-[var(--muted)] tabular-nums">
-                  {post.date}
-                </time>
-                <span className="text-base font-medium group-hover:underline underline-offset-4">
-                  {post.title}
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <Link
+                href={`/blog/${post.slug}`}
+                className="flex flex-col gap-1 py-5 group"
+              >
+                <span className="flex items-baseline gap-3">
+                  <time className="font-mono text-xs text-[var(--muted)] tabular-nums">
+                    {post.date}
+                  </time>
+                  <span className="text-base font-medium group-hover:underline underline-offset-4">
+                    {post.title}
+                  </span>
                 </span>
-              </span>
-              {post.description ? (
-                <span className="text-sm text-[var(--muted)] leading-relaxed">
-                  {post.description}
-                </span>
-              ) : null}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+                {post.description ? (
+                  <span className="text-sm text-[var(--muted)] leading-relaxed">
+                    {post.description}
+                  </span>
+                ) : null}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
   );
 }

--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -2,7 +2,17 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Newsreader } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
+import { JsonLd } from "@/components/json-ld";
 import { SocialLinks } from "@/components/social-links";
+import {
+  getPersonJsonLd,
+  getWebsiteJsonLd,
+} from "@/lib/structured-data";
+import {
+  ogImageUrl,
+  siteAuthors,
+  siteConfig,
+} from "@/lib/site";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -20,80 +30,41 @@ const newsreader = Newsreader({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://bingranyou.com"),
+  metadataBase: new URL(siteConfig.url),
+  applicationName: siteConfig.name,
   title: {
-    default: "Bingran You — AI Builder & Ion Trapper",
-    template: "%s · Bingran You",
+    default: siteConfig.title,
+    template: `%s · ${siteConfig.name}`,
   },
-  description:
-    "Bingran You — PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.",
+  description: siteConfig.description,
+  alternates: { canonical: "/" },
+  authors: siteAuthors,
+  creator: siteConfig.name,
+  publisher: siteConfig.name,
+  keywords: [...siteConfig.keywords],
   openGraph: {
-    title: "Bingran You",
-    description:
-      "PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion quantum experiments.",
-    url: "https://bingranyou.com",
-    siteName: "Bingran You",
+    title: siteConfig.name,
+    description: siteConfig.openGraphDescription,
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    locale: siteConfig.locale,
     type: "website",
+    images: [
+      {
+        url: ogImageUrl,
+        width: siteConfig.ogImageWidth,
+        height: siteConfig.ogImageHeight,
+        alt: siteConfig.ogImageAlt,
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
-    creator: "@bingran_bry",
+    creator: siteConfig.twitterHandle,
+    title: siteConfig.name,
+    description: siteConfig.openGraphDescription,
+    images: [ogImageUrl],
   },
-};
-
-const personJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Person",
-  name: "Bingran You",
-  givenName: "Bingran",
-  familyName: "You",
-  url: "https://bingranyou.com",
-  image: "https://bingranyou.com/images/profile/bingran-you-portrait.jpg",
-  jobTitle: "PhD Candidate",
-  description:
-    "PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.",
-  alumniOf: [
-    {
-      "@type": "CollegeOrUniversity",
-      name: "University of California, Berkeley",
-      sameAs: "https://www.berkeley.edu/",
-    },
-    {
-      "@type": "CollegeOrUniversity",
-      name: "University of Chinese Academy of Sciences",
-      sameAs: "https://english.ucas.ac.cn/",
-    },
-  ],
-  affiliation: {
-    "@type": "Organization",
-    name: "Haeffner Lab, University of California, Berkeley",
-    url: "https://haeffnerlab.berkeley.edu/",
-  },
-  knowsAbout: [
-    "Reliable AI Systems",
-    "AI Agents",
-    "Trapped-Ion Quantum Computing",
-    "Integrated Photonics",
-    "Quantum Networking",
-  ],
-  sameAs: [
-    "https://x.com/bingran_bry",
-    "https://github.com/bingran-you",
-    "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",
-    "https://orcid.org/0000-0002-0316-2115",
-    "https://huggingface.co/bingran-you",
-    "https://www.linkedin.com/in/bingran-you-775b4017b/",
-    "https://www.youtube.com/@BingranBRY",
-  ],
-};
-
-const websiteJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  name: "Bingran You",
-  url: "https://bingranyou.com",
-  inLanguage: "en",
-  author: { "@type": "Person", name: "Bingran You" },
 };
 
 const nav = [
@@ -114,18 +85,8 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} ${newsreader.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(personJsonLd).replace(/</g, "\\u003c"),
-          }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(websiteJsonLd).replace(/</g, "\\u003c"),
-          }}
-        />
+        <JsonLd data={getPersonJsonLd()} />
+        <JsonLd data={getWebsiteJsonLd()} />
         <header className="sticky top-0 z-20 border-b border-[var(--border)] bg-[var(--background)]/85 backdrop-blur">
           <div className="mx-auto max-w-4xl px-6 py-5 flex items-center justify-between">
             <Link

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -1,0 +1,49 @@
+import { getAllPostsMetadata } from "@/lib/posts";
+import { papers, projects } from "@/lib/content";
+import { absoluteUrl, siteConfig } from "@/lib/site";
+
+export async function GET() {
+  const posts = await getAllPostsMetadata();
+
+  const lines = [
+    `# ${siteConfig.name}`,
+    `> ${siteConfig.description}`,
+    "",
+    "## Canonical site",
+    `- Home: ${absoluteUrl("/")}`,
+    `- Projects: ${absoluteUrl("/projects")}`,
+    `- Papers: ${absoluteUrl("/papers")}`,
+    `- Blog: ${absoluteUrl("/blog")}`,
+    "",
+    "## Focus areas",
+    ...siteConfig.focusAreas.map((area) => `- ${area}`),
+    "",
+    "## Selected projects",
+    ...projects.map(
+      (project) =>
+        `- ${project.name}: ${project.description} (${project.href})`,
+    ),
+    "",
+    "## Selected papers",
+    ...papers.map(
+      (paper) =>
+        `- ${paper.title}: ${paper.venue}${paper.blurb ? ` — ${paper.blurb}` : ""} (${paper.href})`,
+    ),
+    "",
+    "## Blog posts",
+    ...posts.map(
+      (post) =>
+        `- ${post.title}: ${post.description ?? "Short note"} (${absoluteUrl(`/blog/${post.slug}`)})`,
+    ),
+    "",
+    "## External profiles",
+    ...siteConfig.sameAs.map((profile) => `- ${profile}`),
+  ];
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=0, s-maxage=3600",
+    },
+  });
+}

--- a/personal-site/app/page.tsx
+++ b/personal-site/app/page.tsx
@@ -1,139 +1,144 @@
 import Image from "next/image";
 import Link from "next/link";
+import { JsonLd } from "@/components/json-ld";
 import { education, projects, papers } from "@/lib/content";
+import { getProfilePageJsonLd } from "@/lib/structured-data";
 
 export default function Home() {
   const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 5);
   const paperHighlights = papers.filter((p) => p.track === "ai").slice(0, 2);
 
   return (
-    <div className="space-y-24">
-      <section className="grid gap-10 sm:grid-cols-[1fr_auto] sm:items-start">
-        <div>
-          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
-            Berkeley · PhD Candidate
-          </p>
-          <h1 className="mt-5 font-display text-5xl leading-[1.02] tracking-[-0.035em] sm:text-6xl">
-            Bingran You
-          </h1>
-          <p className="mt-6 max-w-xl text-base leading-relaxed text-[var(--muted)] text-pretty">
-            I build reliable AI systems and trapped-ion quantum experiments.
-            Different materials, same craft: turning complex, noisy systems
-            into something that behaves on purpose.
-          </p>
-        </div>
+    <>
+      <JsonLd data={getProfilePageJsonLd()} />
+      <div className="space-y-24">
+        <section className="grid gap-10 sm:grid-cols-[1fr_auto] sm:items-start">
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+              Berkeley · PhD Candidate
+            </p>
+            <h1 className="mt-5 font-display text-5xl leading-[1.02] tracking-[-0.035em] sm:text-6xl">
+              Bingran You
+            </h1>
+            <p className="mt-6 max-w-xl text-base leading-relaxed text-[var(--muted)] text-pretty">
+              I build reliable AI systems and trapped-ion quantum experiments.
+              Different materials, same craft: turning complex, noisy systems
+              into something that behaves on purpose.
+            </p>
+          </div>
 
-        <div className="relative h-44 w-44 shrink-0 overflow-hidden rounded-full ring-1 ring-[var(--border)] sm:h-52 sm:w-52">
-          <Image
-            src="/images/profile/bingran-you-portrait.jpg"
-            alt="Bingran You"
-            fill
-            priority
-            sizes="(max-width: 640px) 11rem, 13rem"
-            className="object-cover object-[50%_28%]"
-          />
-        </div>
-      </section>
+          <div className="relative h-44 w-44 shrink-0 overflow-hidden rounded-full ring-1 ring-[var(--border)] sm:h-52 sm:w-52">
+            <Image
+              src="/images/profile/bingran-you-portrait.jpg"
+              alt="Bingran You"
+              fill
+              priority
+              sizes="(max-width: 640px) 11rem, 13rem"
+              className="object-cover object-[50%_28%]"
+            />
+          </div>
+        </section>
 
-      <section>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
-          Education
-        </h2>
-        <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
-          {education.map((item) => (
-            <li
-              key={`${item.institution}-${item.period}`}
-              className="grid gap-1 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6"
-            >
-              <span className="font-mono text-xs text-[var(--muted)] tabular-nums">
-                {item.period}
-              </span>
-              <div>
-                <p className="text-base font-medium">{item.institution}</p>
-                <p className="mt-1 text-sm text-[var(--muted)]">
-                  {item.degree} · {item.location}
-                </p>
-                {item.metrics?.length ? (
-                  <p className="mt-1 font-mono text-xs text-[var(--muted)]">
-                    {item.metrics.join(" · ")}
+        <section>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+            Education
+          </h2>
+          <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
+            {education.map((item) => (
+              <li
+                key={`${item.institution}-${item.period}`}
+                className="grid gap-1 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6"
+              >
+                <span className="font-mono text-xs text-[var(--muted)] tabular-nums">
+                  {item.period}
+                </span>
+                <div>
+                  <p className="text-base font-medium">{item.institution}</p>
+                  <p className="mt-1 text-sm text-[var(--muted)]">
+                    {item.degree} · {item.location}
                   </p>
-                ) : null}
-              </div>
-            </li>
-          ))}
-        </ul>
-      </section>
+                  {item.metrics?.length ? (
+                    <p className="mt-1 font-mono text-xs text-[var(--muted)]">
+                      {item.metrics.join(" · ")}
+                    </p>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
 
-      <section>
-        <div className="flex items-baseline justify-between gap-4">
-          <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
-            Current projects
-          </h2>
-          <Link
-            href="/projects"
-            className="text-xs text-[var(--muted)] hover:text-foreground transition"
-          >
-            All →
-          </Link>
-        </div>
-        <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
-          {aiHighlights.map((p) => (
-            <li key={p.href}>
-              <a
-                href={p.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex flex-col gap-1 py-5 group"
-              >
-                <span className="text-base font-medium group-hover:underline underline-offset-4">
-                  {p.name}
-                </span>
-                <span className="text-sm text-[var(--muted)] leading-relaxed">
-                  {p.description}
-                </span>
-              </a>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section>
-        <div className="flex items-baseline justify-between gap-4">
-          <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
-            Selected papers
-          </h2>
-          <Link
-            href="/papers"
-            className="text-xs text-[var(--muted)] hover:text-foreground transition"
-          >
-            All →
-          </Link>
-        </div>
-        <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
-          {paperHighlights.map((p) => (
-            <li key={p.href}>
-              <a
-                href={p.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex flex-col gap-1 py-5 group"
-              >
-                <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">
-                  {p.venue}
-                </span>
-                <span className="text-base font-medium leading-snug group-hover:underline underline-offset-4">
-                  {p.title}
-                </span>
-                {p.blurb ? (
-                  <span className="text-sm text-[var(--muted)] leading-relaxed">
-                    {p.blurb}
+        <section>
+          <div className="flex items-baseline justify-between gap-4">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+              Current projects
+            </h2>
+            <Link
+              href="/projects"
+              className="text-xs text-[var(--muted)] hover:text-foreground transition"
+            >
+              All →
+            </Link>
+          </div>
+          <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
+            {aiHighlights.map((p) => (
+              <li key={p.href}>
+                <a
+                  href={p.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex flex-col gap-1 py-5 group"
+                >
+                  <span className="text-base font-medium group-hover:underline underline-offset-4">
+                    {p.name}
                   </span>
-                ) : null}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </section>
-    </div>
+                  <span className="text-sm text-[var(--muted)] leading-relaxed">
+                    {p.description}
+                  </span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <div className="flex items-baseline justify-between gap-4">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+              Selected papers
+            </h2>
+            <Link
+              href="/papers"
+              className="text-xs text-[var(--muted)] hover:text-foreground transition"
+            >
+              All →
+            </Link>
+          </div>
+          <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
+            {paperHighlights.map((p) => (
+              <li key={p.href}>
+                <a
+                  href={p.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex flex-col gap-1 py-5 group"
+                >
+                  <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">
+                    {p.venue}
+                  </span>
+                  <span className="text-base font-medium leading-snug group-hover:underline underline-offset-4">
+                    {p.title}
+                  </span>
+                  {p.blurb ? (
+                    <span className="text-sm text-[var(--muted)] leading-relaxed">
+                      {p.blurb}
+                    </span>
+                  ) : null}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </>
   );
 }

--- a/personal-site/app/papers/page.tsx
+++ b/personal-site/app/papers/page.tsx
@@ -1,36 +1,56 @@
 import type { Metadata } from "next";
+import { JsonLd } from "@/components/json-ld";
 import { papers } from "@/lib/content";
+import { createPageMetadata } from "@/lib/site";
+import { getCollectionPageJsonLd } from "@/lib/structured-data";
 
-export const metadata: Metadata = {
+const description =
+  "Selected publications across AI agents and trapped-ion physics.";
+
+export const metadata: Metadata = createPageMetadata({
   title: "Papers",
-  description: "Selected publications across AI agents and trapped-ion physics.",
-};
+  description,
+  path: "/papers",
+});
 
 export default function PapersPage() {
   const ai = papers.filter((p) => p.track === "ai");
   const ion = papers.filter((p) => p.track === "ion");
+  const collectionPageJsonLd = getCollectionPageJsonLd({
+    path: "/papers",
+    name: "Papers",
+    description,
+    items: papers.map((paper) => ({
+      name: paper.title,
+      url: paper.href,
+      description: paper.blurb ?? paper.venue,
+    })),
+  });
 
   return (
-    <div className="space-y-16">
-      <header>
-        <h1 className="text-3xl font-semibold tracking-tight">Papers</h1>
-        <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">
-          Selected publications. See{" "}
-          <a
-            className="underline underline-offset-4"
-            href="https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Google Scholar
-          </a>{" "}
-          for the full list.
-        </p>
-      </header>
+    <>
+      <JsonLd data={collectionPageJsonLd} />
+      <div className="space-y-16">
+        <header>
+          <h1 className="text-3xl font-semibold tracking-tight">Papers</h1>
+          <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">
+            Selected publications. See{" "}
+            <a
+              className="underline underline-offset-4"
+              href="https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Google Scholar
+            </a>{" "}
+            for the full list.
+          </p>
+        </header>
 
-      <Section title="AI Builder" items={ai} />
-      <Section title="Ion Trapper" items={ion} />
-    </div>
+        <Section title="AI Builder" items={ai} />
+        <Section title="Ion Trapper" items={ion} />
+      </div>
+    </>
   );
 }
 

--- a/personal-site/app/projects/page.tsx
+++ b/personal-site/app/projects/page.tsx
@@ -1,28 +1,48 @@
 import type { Metadata } from "next";
+import { JsonLd } from "@/components/json-ld";
 import { projects } from "@/lib/content";
+import { createPageMetadata } from "@/lib/site";
+import { getCollectionPageJsonLd } from "@/lib/structured-data";
 
-export const metadata: Metadata = {
+const description =
+  "Selected projects across AI systems and trapped-ion experiments.";
+
+export const metadata: Metadata = createPageMetadata({
   title: "Projects",
-  description: "Selected projects across AI systems and trapped-ion experiments.",
-};
+  description,
+  path: "/projects",
+});
 
 export default function ProjectsPage() {
   const ai = projects.filter((p) => p.track === "ai");
   const ion = projects.filter((p) => p.track === "ion");
+  const collectionPageJsonLd = getCollectionPageJsonLd({
+    path: "/projects",
+    name: "Projects",
+    description,
+    items: projects.map((project) => ({
+      name: project.name,
+      url: project.href,
+      description: project.description,
+    })),
+  });
 
   return (
-    <div className="space-y-16">
-      <header>
-        <h1 className="text-3xl font-semibold tracking-tight">Projects</h1>
-        <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">
-          A snapshot of the things I&apos;m lucky to work on. Most are open
-          source; the rest will be when they&apos;re ready.
-        </p>
-      </header>
+    <>
+      <JsonLd data={collectionPageJsonLd} />
+      <div className="space-y-16">
+        <header>
+          <h1 className="text-3xl font-semibold tracking-tight">Projects</h1>
+          <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">
+            A snapshot of the things I&apos;m lucky to work on. Most are open
+            source; the rest will be when they&apos;re ready.
+          </p>
+        </header>
 
-      <Section title="AI Builder" items={ai} />
-      <Section title="Ion Trapper" items={ion} />
-    </div>
+        <Section title="AI Builder" items={ai} />
+        <Section title="Ion Trapper" items={ion} />
+      </div>
+    </>
   );
 }
 

--- a/personal-site/app/robots.ts
+++ b/personal-site/app/robots.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
-
-const SITE_URL = "https://bingranyou.com";
+import { siteConfig } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -10,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
         allow: "/",
       },
     ],
-    sitemap: `${SITE_URL}/sitemap.xml`,
-    host: SITE_URL,
+    sitemap: `${siteConfig.url}/sitemap.xml`,
+    host: siteConfig.url,
   };
 }

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -1,25 +1,87 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
 import type { MetadataRoute } from "next";
-import { getAllPostsMetadata } from "@/lib/posts";
+import {
+  getAllPostsMetadata,
+  getPostLastModified,
+} from "@/lib/posts";
+import { absoluteUrl } from "@/lib/site";
 
-const SITE_URL = "https://bingranyou.com";
+async function getFileLastModified(relativePath: string) {
+  const { mtime } = await stat(
+    path.join(/* turbopackIgnore: true */ process.cwd(), relativePath),
+  );
+  return mtime;
+}
+
+async function getLatestLastModified(relativePaths: string[]) {
+  const lastModifiedValues = await Promise.all(
+    relativePaths.map((relativePath) => getFileLastModified(relativePath)),
+  );
+
+  return new Date(
+    Math.max(...lastModifiedValues.map((value) => value.getTime())),
+  );
+}
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const now = new Date();
   const posts = await getAllPostsMetadata();
+  const postEntries = await Promise.all(
+    posts.map(async (post) => ({
+      url: absoluteUrl(`/blog/${post.slug}`),
+      lastModified: await getPostLastModified(post.slug),
+      changeFrequency: "yearly" as const,
+      priority: 0.6,
+    })),
+  );
+  const blogLastModified = new Date(
+    Math.max(
+      (
+        await getLatestLastModified([
+          "app/blog/page.tsx",
+          "lib/posts.ts",
+        ])
+      ).getTime(),
+      ...postEntries.map((entry) => entry.lastModified.getTime()),
+    ),
+  );
 
   const staticEntries: MetadataRoute.Sitemap = [
-    { url: `${SITE_URL}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
-    { url: `${SITE_URL}/projects`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${SITE_URL}/papers`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${SITE_URL}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
+    {
+      url: absoluteUrl("/"),
+      lastModified: await getLatestLastModified([
+        "app/layout.tsx",
+        "app/page.tsx",
+        "lib/content.ts",
+      ]),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: absoluteUrl("/projects"),
+      lastModified: await getLatestLastModified([
+        "app/projects/page.tsx",
+        "lib/content.ts",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: absoluteUrl("/papers"),
+      lastModified: await getLatestLastModified([
+        "app/papers/page.tsx",
+        "lib/content.ts",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: absoluteUrl("/blog"),
+      lastModified: blogLastModified,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
   ];
-
-  const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: `${SITE_URL}/blog/${post.slug}`,
-    lastModified: new Date(post.date),
-    changeFrequency: "yearly",
-    priority: 0.6,
-  }));
 
   return [...staticEntries, ...postEntries];
 }

--- a/personal-site/components/json-ld.tsx
+++ b/personal-site/components/json-ld.tsx
@@ -1,0 +1,18 @@
+type JsonLdValue =
+  | Record<string, unknown>
+  | Array<Record<string, unknown>>;
+
+type JsonLdProps = {
+  data: JsonLdValue;
+};
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}

--- a/personal-site/lib/posts.ts
+++ b/personal-site/lib/posts.ts
@@ -1,3 +1,6 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+
 export const postSlugs = ["welcome"] as const;
 
 export type PostSlug = (typeof postSlugs)[number];
@@ -13,6 +16,15 @@ export async function getPostMetadata(
 ): Promise<PostMetadata> {
   const mod = await import(`@/content/posts/${slug}.mdx`);
   return mod.metadata as PostMetadata;
+}
+
+export function getPostFilePath(slug: PostSlug) {
+  return path.join(process.cwd(), "content", "posts", `${slug}.mdx`);
+}
+
+export async function getPostLastModified(slug: PostSlug) {
+  const { mtime } = await stat(getPostFilePath(slug));
+  return mtime;
 }
 
 export async function getAllPostsMetadata(): Promise<

--- a/personal-site/lib/site.ts
+++ b/personal-site/lib/site.ts
@@ -1,0 +1,157 @@
+import type { Metadata } from "next";
+
+export const siteConfig = {
+  name: "Bingran You",
+  domain: "bingranyou.com",
+  url: "https://bingranyou.com",
+  title: "Bingran You — AI Builder & Ion Trapper",
+  description:
+    "Bingran You — PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.",
+  openGraphDescription:
+    "PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion quantum experiments.",
+  locale: "en_US",
+  language: "en",
+  location: "Berkeley, CA",
+  ogImagePath: "/images/profile/bingran-you-portrait.jpg",
+  ogImageAlt: "Portrait of Bingran You",
+  ogImageWidth: 2702,
+  ogImageHeight: 2702,
+  twitterHandle: "@bingran_bry",
+  email: "bingran.bry@gmail.com",
+  orcid: "0000-0002-0316-2115",
+  alternateNames: ["bingranyou.com", "bingran.you"],
+  focusAreas: [
+    "Reliable AI Systems",
+    "AI Agents",
+    "Trapped-Ion Quantum Computing",
+    "Integrated Photonics",
+    "Quantum Networking",
+  ],
+  keywords: [
+    "Bingran You",
+    "AI agents",
+    "reliable AI systems",
+    "agent evaluation",
+    "SkillsBench",
+    "first-tree",
+    "DoWhiz",
+    "trapped-ion quantum computing",
+    "integrated photonics",
+    "quantum networking",
+    "UC Berkeley",
+    "Haeffner Lab",
+  ],
+  sameAs: [
+    "https://x.com/bingran_bry",
+    "https://github.com/bingran-you",
+    "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",
+    "https://orcid.org/0000-0002-0316-2115",
+    "https://huggingface.co/bingran-you",
+    "https://www.linkedin.com/in/bingran-you-775b4017b/",
+    "https://www.youtube.com/@BingranBRY",
+  ],
+} as const;
+
+export const personId = `${siteConfig.url}#person`;
+export const websiteId = `${siteConfig.url}#website`;
+export const profilePageId = `${siteConfig.url}#profile`;
+export const siteAuthors = [{ name: siteConfig.name, url: siteConfig.url }];
+
+export function absoluteUrl(path = "/") {
+  return new URL(path, siteConfig.url).toString();
+}
+
+export const ogImageUrl = absoluteUrl(siteConfig.ogImagePath);
+
+function getSharedOpenGraphFields(description: string) {
+  return {
+    description,
+    siteName: siteConfig.name,
+    locale: siteConfig.locale,
+    images: [
+      {
+        url: ogImageUrl,
+        width: siteConfig.ogImageWidth,
+        height: siteConfig.ogImageHeight,
+        alt: siteConfig.ogImageAlt,
+      },
+    ],
+  };
+}
+
+export function createPageMetadata({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}): Metadata {
+  const url = absoluteUrl(path);
+  const fullTitle = `${title} · ${siteConfig.name}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    authors: siteAuthors,
+    creator: siteConfig.name,
+    publisher: siteConfig.name,
+    openGraph: {
+      title: fullTitle,
+      url,
+      type: "website",
+      ...getSharedOpenGraphFields(description),
+    },
+    twitter: {
+      card: "summary_large_image",
+      creator: siteConfig.twitterHandle,
+      title: fullTitle,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}
+
+export function createArticleMetadata({
+  title,
+  description,
+  path,
+  publishedTime,
+  modifiedTime,
+}: {
+  title: string;
+  description: string;
+  path: string;
+  publishedTime: string;
+  modifiedTime: string;
+}): Metadata {
+  const url = absoluteUrl(path);
+  const fullTitle = `${title} · ${siteConfig.name}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    authors: siteAuthors,
+    creator: siteConfig.name,
+    publisher: siteConfig.name,
+    openGraph: {
+      title: fullTitle,
+      url,
+      type: "article",
+      publishedTime,
+      modifiedTime,
+      authors: [siteConfig.name],
+      ...getSharedOpenGraphFields(description),
+    },
+    twitter: {
+      card: "summary_large_image",
+      creator: siteConfig.twitterHandle,
+      title: fullTitle,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}

--- a/personal-site/lib/structured-data.ts
+++ b/personal-site/lib/structured-data.ts
@@ -1,0 +1,188 @@
+import type { PostMetadata, PostSlug } from "@/lib/posts";
+import {
+  absoluteUrl,
+  ogImageUrl,
+  personId,
+  profilePageId,
+  siteConfig,
+  websiteId,
+} from "@/lib/site";
+
+type CollectionEntry = {
+  name: string;
+  url: string;
+  description?: string;
+};
+
+function toIsoDate(date: string) {
+  return new Date(date).toISOString();
+}
+
+export function getPersonJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": personId,
+    name: siteConfig.name,
+    givenName: "Bingran",
+    familyName: "You",
+    url: siteConfig.url,
+    image: ogImageUrl,
+    jobTitle: "PhD Candidate",
+    description: siteConfig.description,
+    homeLocation: siteConfig.location,
+    email: siteConfig.email,
+    identifier: {
+      "@type": "PropertyValue",
+      propertyID: "ORCID",
+      value: siteConfig.orcid,
+      url: `https://orcid.org/${siteConfig.orcid}`,
+    },
+    alumniOf: [
+      {
+        "@type": "CollegeOrUniversity",
+        name: "University of California, Berkeley",
+        sameAs: "https://www.berkeley.edu/",
+      },
+      {
+        "@type": "CollegeOrUniversity",
+        name: "University of Chinese Academy of Sciences",
+        sameAs: "https://english.ucas.ac.cn/",
+      },
+    ],
+    affiliation: {
+      "@type": "Organization",
+      name: "Haeffner Lab, University of California, Berkeley",
+      url: "https://haeffnerlab.berkeley.edu/",
+    },
+    knowsAbout: siteConfig.focusAreas,
+    sameAs: siteConfig.sameAs,
+  };
+}
+
+export function getWebsiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": websiteId,
+    name: siteConfig.name,
+    alternateName: siteConfig.alternateNames,
+    url: siteConfig.url,
+    inLanguage: siteConfig.language,
+    author: { "@id": personId },
+    about: { "@id": personId },
+  };
+}
+
+export function getProfilePageJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": profilePageId,
+    url: siteConfig.url,
+    name: siteConfig.name,
+    description: siteConfig.description,
+    inLanguage: siteConfig.language,
+    isPartOf: { "@id": websiteId },
+    about: { "@id": personId },
+    mainEntity: { "@id": personId },
+  };
+}
+
+export function getCollectionPageJsonLd({
+  path,
+  name,
+  description,
+  items,
+}: {
+  path: string;
+  name: string;
+  description: string;
+  items: CollectionEntry[];
+}) {
+  const url = absoluteUrl(path);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${url}#webpage`,
+    url,
+    name,
+    description,
+    inLanguage: siteConfig.language,
+    isPartOf: { "@id": websiteId },
+    about: { "@id": personId },
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: items.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: item.url,
+        name: item.name,
+        description: item.description,
+      })),
+    },
+  };
+}
+
+export function getBlogJsonLd(
+  posts: Array<PostMetadata & { slug: PostSlug }>,
+) {
+  const url = absoluteUrl("/blog");
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "@id": `${url}#blog`,
+    url,
+    name: `${siteConfig.name} Blog`,
+    description: "Short notes on AI agents, quantum experiments, and craft.",
+    inLanguage: siteConfig.language,
+    isPartOf: { "@id": websiteId },
+    author: { "@id": personId },
+    blogPost: posts.map((post) => ({
+      "@type": "BlogPosting",
+      "@id": `${absoluteUrl(`/blog/${post.slug}`)}#article`,
+      headline: post.title,
+      description: post.description,
+      url: absoluteUrl(`/blog/${post.slug}`),
+      datePublished: toIsoDate(post.date),
+      author: { "@id": personId },
+      image: [ogImageUrl],
+    })),
+  };
+}
+
+export function getBlogPostingJsonLd({
+  slug,
+  metadata,
+  modifiedTime,
+}: {
+  slug: PostSlug;
+  metadata: PostMetadata;
+  modifiedTime: string;
+}) {
+  const url = absoluteUrl(`/blog/${slug}`);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "@id": `${url}#article`,
+    url,
+    headline: metadata.title,
+    description: metadata.description,
+    datePublished: toIsoDate(metadata.date),
+    dateModified: modifiedTime,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${url}#webpage`,
+    },
+    inLanguage: siteConfig.language,
+    isPartOf: { "@id": websiteId },
+    isAccessibleForFree: true,
+    author: { "@id": personId },
+    publisher: { "@id": personId },
+    image: [ogImageUrl],
+    about: siteConfig.focusAreas,
+  };
+}

--- a/personal-site/next.config.ts
+++ b/personal-site/next.config.ts
@@ -4,6 +4,17 @@ import path from "node:path";
 
 const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.bingranyou.com" }],
+        destination: "https://bingranyou.com/:path*",
+        permanent: true,
+        basePath: false,
+      },
+    ];
+  },
   turbopack: {
     root: path.resolve(__dirname),
   },


### PR DESCRIPTION
## Summary
- add canonical metadata, richer Open Graph/Twitter metadata, and reusable JSON-LD helpers
- add ProfilePage/CollectionPage/Blog/BlogPosting structured data plus an llms.txt endpoint
- normalize www -> apex redirects and make sitemap lastmod values reflect real file changes

## Testing
- npm run lint
- npm run build
- visual compare of local vs current production for /, /projects, and /blog/welcome in Safari
- verified canonical tags, article metadata, llms.txt, and www redirect locally with curl