### PR TITLE
Add per-entity JSON-LD for papers, projects, posts

### DIFF
--- a/personal-site/app/blog/[slug]/page.tsx
+++ b/personal-site/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { postSlugs, type PostSlug } from "@/lib/posts";
+import { blogPostingJsonLd, jsonLdScriptContent } from "@/lib/jsonld";
 
 export const dynamicParams = false;
 
@@ -32,9 +33,21 @@ export default async function PostPage({ params }: { params: Params }) {
   const { default: Post, metadata } = await import(
     `@/content/posts/${slug}.mdx`
   );
+  const jsonLd = jsonLdScriptContent(
+    blogPostingJsonLd({
+      slug,
+      title: metadata.title,
+      description: metadata.description,
+      date: metadata.date,
+    }),
+  );
 
   return (
     <article className="space-y-10">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
       <header className="space-y-3">
         <Link
           href="/blog"

--- a/personal-site/app/papers/page.tsx
+++ b/personal-site/app/papers/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { papers } from "@/lib/content";
+import { graphScriptContent, paperJsonLd } from "@/lib/jsonld";
 
 export const metadata: Metadata = {
   title: "Papers",
@@ -10,9 +11,14 @@ export const metadata: Metadata = {
 export default function PapersPage() {
   const ai = papers.filter((p) => p.track === "ai");
   const ion = papers.filter((p) => p.track === "ion");
+  const jsonLd = graphScriptContent(papers.map(paperJsonLd));
 
   return (
     <div className="space-y-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
       <header>
         <h1 className="text-3xl font-semibold tracking-tight">Papers</h1>
         <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">

--- a/personal-site/app/projects/page.tsx
+++ b/personal-site/app/projects/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { projects } from "@/lib/content";
+import { graphScriptContent, projectJsonLd } from "@/lib/jsonld";
 
 export const metadata: Metadata = {
   title: "Projects",
@@ -10,9 +11,14 @@ export const metadata: Metadata = {
 export default function ProjectsPage() {
   const ai = projects.filter((p) => p.track === "ai");
   const ion = projects.filter((p) => p.track === "ion");
+  const jsonLd = graphScriptContent(projects.map(projectJsonLd));
 
   return (
     <div className="space-y-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
       <header>
         <h1 className="text-3xl font-semibold tracking-tight">Projects</h1>
         <p className="mt-3 text-base text-[var(--muted)] max-w-2xl">

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -1,0 +1,70 @@
+import type { Paper, Project } from "@/lib/content";
+
+const SITE_URL = "https://bingranyou.com";
+
+const author = {
+  "@type": "Person" as const,
+  name: "Bingran You",
+  url: SITE_URL,
+};
+
+export function paperJsonLd(paper: Paper) {
+  return {
+    "@type": "ScholarlyArticle",
+    headline: paper.title,
+    name: paper.title,
+    url: paper.href,
+    sameAs: paper.href,
+    author,
+    isPartOf: {
+      "@type": "Periodical",
+      name: paper.venue,
+    },
+    ...(paper.blurb ? { abstract: paper.blurb } : {}),
+  } as const;
+}
+
+export function projectJsonLd(project: Project) {
+  const isGitHub = project.href.startsWith("https://github.com/");
+  return {
+    "@type": "SoftwareSourceCode",
+    name: project.name,
+    description: project.description,
+    url: project.href,
+    ...(isGitHub ? { codeRepository: project.href } : {}),
+    author,
+  } as const;
+}
+
+export function blogPostingJsonLd(args: {
+  slug: string;
+  title: string;
+  description?: string;
+  date: string;
+}) {
+  const url = `${SITE_URL}/blog/${args.slug}`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: args.title,
+    ...(args.description ? { description: args.description } : {}),
+    datePublished: args.date,
+    dateModified: args.date,
+    url,
+    mainEntityOfPage: url,
+    author,
+    publisher: author,
+  } as const;
+}
+
+export function graphScriptContent(items: ReadonlyArray<object>) {
+  const graph = {
+    "@context": "https://schema.org",
+    "@graph": items,
+  };
+  return JSON.stringify(graph).replace(/</g, "\\u003c");
+}
+
+export function jsonLdScriptContent(item: object) {
+  return JSON.stringify(item).replace(/</g, "\\u003c");
+}


### PR DESCRIPTION
## Summary

Adds schema.org structured data so search engines (Google rich results, Bing) and LLM crawlers (Perplexity, Claude, ChatGPT, Gemini) can parse each paper, project, and blog post as a discrete entity, not just as text in a list.

- `lib/jsonld.ts` — helpers that emit `ScholarlyArticle` for papers, `SoftwareSourceCode` for projects (with `codeRepository` set for GitHub-hosted ones), and `BlogPosting` for posts. Each entity references the existing Person from the layout via a shared author block.
- `app/papers/page.tsx` — emits a `@graph` of every paper as `ScholarlyArticle`, each with `isPartOf` pointing to the venue (arXiv / Nature / npj / PRL / journal).
- `app/projects/page.tsx` — emits a `@graph` of every project as `SoftwareSourceCode`.
- `app/blog/[slug]/page.tsx` — emits one `BlogPosting` per post with `datePublished`, `dateModified`, and `mainEntityOfPage`.

All hidden in `<script type=\"application/ld+json\">` — visual design is unchanged.

## Test plan

- [ ] Vercel preview builds without TS errors.
- [ ] `curl -s https://bingranyou.com/papers | grep -o ScholarlyArticle | head` shows entries.
- [ ] Run https://bingranyou.com/papers through https://search.google.com/test/rich-results — no errors, ScholarlyArticles detected.
- [ ] Same for `/projects` (SoftwareSourceCode) and `/blog/welcome` (BlogPosting).