### PR TITLE
Add dynamic OG images for every route

### DIFF
--- a/personal-site/app/blog/[slug]/opengraph-image.tsx
+++ b/personal-site/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+import { postSlugs, type PostSlug } from "@/lib/posts";
+import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = "Blog post — Bingran You";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export function generateStaticParams() {
+  return postSlugs.map((slug) => ({ slug }));
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  if (!postSlugs.includes(slug as PostSlug)) notFound();
+  const mod = await import(`@/content/posts/${slug}.mdx`);
+  return renderOgImage({
+    eyebrow: "Blog",
+    title: mod.metadata.title,
+    subtitle: mod.metadata.description,
+  });
+}

--- a/personal-site/app/blog/opengraph-image.tsx
+++ b/personal-site/app/blog/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = "Blog — Bingran You";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: "Blog",
+    title: "Short notes on agents, ions, and craft.",
+    subtitle: "Things I learn, screw up, or want to remember.",
+  });
+}

--- a/personal-site/app/opengraph-image.tsx
+++ b/personal-site/app/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = "Bingran You — AI Builder & Ion Trapper";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return renderOgImage({
+    title: "Bingran You",
+    subtitle:
+      "PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion quantum experiments.",
+  });
+}

--- a/personal-site/app/papers/opengraph-image.tsx
+++ b/personal-site/app/papers/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = "Papers — Bingran You";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: "Papers",
+    title: "Selected publications.",
+    subtitle: "Across AI agents and trapped-ion physics — Nature, PRL, arXiv.",
+  });
+}

--- a/personal-site/app/projects/opengraph-image.tsx
+++ b/personal-site/app/projects/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = "Projects — Bingran You";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: "Projects",
+    title: "Building reliable AI systems and ion-trap hardware.",
+    subtitle: "Open-source agent tooling, applied AI products, and research code.",
+  });
+}

--- a/personal-site/lib/og.tsx
+++ b/personal-site/lib/og.tsx
@@ -1,0 +1,95 @@
+import { ImageResponse } from "next/og";
+
+export const ogSize = { width: 1200, height: 630 } as const;
+export const ogContentType = "image/png" as const;
+
+export function renderOgImage({
+  eyebrow,
+  title,
+  subtitle,
+}: {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+}) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "80px",
+          background: "#fafaf9",
+          color: "#0a0a0a",
+          fontFamily: "Georgia, 'Times New Roman', serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 22,
+            fontFamily: "ui-monospace, Menlo, monospace",
+            letterSpacing: "0.32em",
+            textTransform: "uppercase",
+            color: "#737373",
+          }}
+        >
+          {eyebrow ?? "bingran.you"}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 32,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 88,
+              lineHeight: 1.05,
+              letterSpacing: "-0.03em",
+              fontWeight: 500,
+              maxWidth: 1000,
+            }}
+          >
+            {title}
+          </div>
+          {subtitle ? (
+            <div
+              style={{
+                fontSize: 32,
+                lineHeight: 1.4,
+                color: "#525252",
+                maxWidth: 980,
+                fontFamily: "ui-sans-serif, system-ui, sans-serif",
+              }}
+            >
+              {subtitle}
+            </div>
+          ) : null}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontSize: 22,
+            color: "#737373",
+            fontFamily: "ui-sans-serif, system-ui, sans-serif",
+          }}
+        >
+          <span>Bingran You · Berkeley, CA</span>
+          <span style={{ fontFamily: "ui-monospace, Menlo, monospace" }}>
+            bingranyou.com
+          </span>
+        </div>
+      </div>
+    ),
+    ogSize,
+  );
+}


### PR DESCRIPTION
## Summary

Adds 1200×630 Open Graph images generated at build time via `next/og`'s `ImageResponse` for every route — root, `/projects`, `/papers`, `/blog`, and per-post `/blog/[slug]`.

- `lib/og.tsx` — one shared `renderOgImage` helper that lays out the site aesthetic (cream paper, serif display title, mono eyebrow + footer wordmark).
- One `opengraph-image.tsx` per route segment that calls the helper with route-specific copy.
- Per-post images pull title + description from the post's MDX metadata.

Next.js auto-emits `og:image` and `twitter:image` meta tags pointing at these routes, so X, LinkedIn, Slack, Discord, iMessage, Claude/Perplexity/ChatGPT previews all get a clean card instead of the existing `summary_large_image` placeholder.

The on-site visual design is unchanged — these are off-page assets only.

## Test plan

- [ ] Vercel preview builds; visit `/opengraph-image` directly to see the rendered PNG.
- [ ] `curl -s https://bingranyou.com/ | grep og:image` returns the image URL.
- [ ] Open https://www.opengraph.xyz/ and paste each URL — preview shows correct card.
- [ ] Per-post card test: `https://bingranyou.com/blog/welcome` preview shows the welcome post title.