### PR TITLE
Add /llms.txt and /llms-full.txt for LLM crawlers

### DIFF
--- a/personal-site/app/llms-full.txt/route.ts
+++ b/personal-site/app/llms-full.txt/route.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { papers, projects, education } from "@/lib/content";
+import { getAllPostsMetadata } from "@/lib/posts";
+
+const SITE = "https://bingranyou.com";
+
+export const dynamic = "force-static";
+
+async function readPostMdx(slug: string): Promise<string> {
+  const path = join(process.cwd(), "content", "posts", `${slug}.mdx`);
+  return readFile(path, "utf8");
+}
+
+export async function GET() {
+  const posts = await getAllPostsMetadata();
+  const postBodies = await Promise.all(
+    posts.map(async (post) => {
+      const raw = await readPostMdx(post.slug);
+      // Strip the leading metadata export so the file is pure content.
+      const body = raw.replace(/^export const metadata[\s\S]*?};?\n+/, "");
+      return { ...post, body };
+    }),
+  );
+
+  const body = `# Bingran You — full index
+
+> PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments. This file is intended for LLM and search crawlers and contains the same index as /llms.txt plus the full text of every blog post.
+
+## Identity
+
+- Name: Bingran You
+- Role: PhD Candidate, Applied Science & Technology, UC Berkeley
+- Lab: Haeffner Lab (https://haeffnerlab.berkeley.edu/)
+- Location: Berkeley, California, USA
+- Site: ${SITE}/
+- Email: bingran.you@berkeley.edu
+- ORCID: https://orcid.org/0000-0002-0316-2115
+- Google Scholar: https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en
+- GitHub: https://github.com/bingran-you
+- X / Twitter: https://x.com/bingran_bry
+- LinkedIn: https://www.linkedin.com/in/bingran-you-775b4017b/
+- Hugging Face: https://huggingface.co/bingran-you
+- YouTube: https://www.youtube.com/@BingranBRY
+
+## Education
+
+${education
+  .map(
+    (e) =>
+      `- ${e.institution} (${e.location}) — ${e.degree}, ${e.period}. ${e.summary}${e.metrics?.length ? ` (${e.metrics.join(", ")})` : ""}`,
+  )
+  .join("\n")}
+
+## Selected papers
+
+${papers
+  .map(
+    (p) =>
+      `- ${p.title}\n  Venue: ${p.venue}\n  URL: ${p.href}${p.blurb ? `\n  Note: ${p.blurb}` : ""}`,
+  )
+  .join("\n\n")}
+
+## Projects
+
+${projects
+  .map((p) => `- ${p.name} (${p.href})\n  ${p.description}`)
+  .join("\n\n")}
+
+## Blog posts
+
+${postBodies
+  .map(
+    (post) =>
+      `### ${post.title}\n\nDate: ${post.date}\nURL: ${SITE}/blog/${post.slug}\n${post.description ? `Description: ${post.description}\n` : ""}\n${post.body.trim()}`,
+  )
+  .join("\n\n---\n\n")}
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=0, must-revalidate",
+    },
+  });
+}

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -1,0 +1,63 @@
+import { papers, projects } from "@/lib/content";
+import { getAllPostsMetadata } from "@/lib/posts";
+
+const SITE = "https://bingranyou.com";
+
+export const dynamic = "force-static";
+
+export async function GET() {
+  const posts = await getAllPostsMetadata();
+
+  const body = `# Bingran You
+
+> PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.
+
+I work on two tracks: reliable AI agent systems, and trapped-ion quantum hardware. Different materials, same craft — turning complex, noisy systems into something that behaves on purpose.
+
+## Identity
+
+- Name: Bingran You
+- Role: PhD Candidate, Applied Science & Technology, UC Berkeley
+- Lab: Haeffner Lab (https://haeffnerlab.berkeley.edu/)
+- Location: Berkeley, California, USA
+- Site: ${SITE}/
+- Email: bingran.you@berkeley.edu
+- ORCID: https://orcid.org/0000-0002-0316-2115
+- Google Scholar: https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en
+- GitHub: https://github.com/bingran-you
+- X / Twitter: https://x.com/bingran_bry
+- LinkedIn: https://www.linkedin.com/in/bingran-you-775b4017b/
+- Hugging Face: https://huggingface.co/bingran-you
+- YouTube: https://www.youtube.com/@BingranBRY
+
+## Pages
+
+- [Home](${SITE}/)
+- [Projects](${SITE}/projects)
+- [Papers](${SITE}/papers)
+- [Blog](${SITE}/blog)
+
+## Selected papers
+
+${papers.map((p) => `- [${p.title}](${p.href}) — ${p.venue}${p.blurb ? `. ${p.blurb}` : ""}`).join("\n")}
+
+## Projects
+
+${projects.map((p) => `- [${p.name}](${p.href}) — ${p.description}`).join("\n")}
+
+## Blog posts
+
+${posts.map((p) => `- [${p.title}](${SITE}/blog/${p.slug}) (${p.date})${p.description ? ` — ${p.description}` : ""}`).join("\n")}
+
+## Optional
+
+- [llms-full.txt](${SITE}/llms-full.txt) — same index plus full text of every blog post.
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=0, must-revalidate",
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adopts the [llmstxt.org](https://llmstxt.org) convention so AI assistants and answer engines (Claude, Perplexity, ChatGPT search, Cursor, Phind, etc.) get a clean, machine-readable index of the site without parsing HTML or following links.

- `/llms.txt` — short markdown index (identity, profiles, pages, papers, projects, blog posts).
- `/llms-full.txt` — the same index plus full text of every blog post, read directly from the `.mdx` source.

Both are static-generated at build time (`export const dynamic = "force-static"`) and regenerate on every deploy as content changes.

This is the GEO equivalent of `sitemap.xml` for traditional search — a discoverable, conventional URL that crawlers actively look for. Visual design unchanged (these are off-page text routes).

## Test plan

- [ ] After deploy, `curl -s https://bingranyou.com/llms.txt | head -30` returns markdown.
- [ ] `curl -sI https://bingranyou.com/llms.txt | grep -i content-type` returns `text/markdown; charset=utf-8`.
- [ ] `curl -s https://bingranyou.com/llms-full.txt | grep "## Blog posts"` finds the section.
- [ ] `/llms-full.txt` includes the body text of `welcome.mdx`.