### PR TITLE
Add /about page with ProfilePage schema

### DIFF
--- a/personal-site/app/about/opengraph-image.tsx
+++ b/personal-site/app/about/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = "About — Bingran You";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: "About",
+    title: "Bingran You.",
+    subtitle:
+      "PhD candidate at UC Berkeley, Haeffner Lab. Reliable AI systems × trapped-ion quantum.",
+  });
+}

--- a/personal-site/app/about/page.tsx
+++ b/personal-site/app/about/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from "next";
+import { education } from "@/lib/content";
+import { jsonLdScriptContent } from "@/lib/jsonld";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Bingran You — PhD candidate at UC Berkeley working on reliable AI systems and trapped-ion quantum experiments.",
+  alternates: { canonical: "/about" },
+};
+
+const profilePageJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  url: "https://bingranyou.com/about",
+  mainEntity: {
+    "@type": "Person",
+    name: "Bingran You",
+    url: "https://bingranyou.com",
+    jobTitle: "PhD Candidate",
+    description:
+      "PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.",
+    affiliation: {
+      "@type": "Organization",
+      name: "Haeffner Lab, University of California, Berkeley",
+      url: "https://haeffnerlab.berkeley.edu/",
+    },
+    knowsAbout: [
+      "Reliable AI Systems",
+      "AI Agents",
+      "Trapped-Ion Quantum Computing",
+      "Integrated Photonics",
+      "Quantum Networking",
+    ],
+    sameAs: [
+      "https://x.com/bingran_bry",
+      "https://github.com/bingran-you",
+      "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",
+      "https://orcid.org/0000-0002-0316-2115",
+      "https://huggingface.co/bingran-you",
+      "https://www.linkedin.com/in/bingran-you-775b4017b/",
+      "https://www.youtube.com/@BingranBRY",
+    ],
+  },
+};
+
+const facts = [
+  "I am Bingran You, a PhD candidate in Applied Science & Technology at UC Berkeley, advised in the Haeffner Lab.",
+  "I build reliable AI systems — agent infrastructure, evaluation harnesses, and applied AI products that need to behave under noisy real-world conditions.",
+  "I run trapped-ion quantum experiments — integrated photonics for individual ion addressing, ion-photon interfaces for networking, and 3D-printed micro ion traps for scalable hardware.",
+  "Both tracks share one craft: turning complex, noisy systems into something that behaves on purpose.",
+];
+
+const focusAreas = [
+  {
+    label: "AI Builder",
+    items: [
+      "Agent skills and tool use, with an emphasis on evaluation that mirrors real workflows.",
+      "Productivity agents that triage notifications, dispatch background work, and stay out of the way.",
+      "Open-source benchmarks for measuring agent capability and safety in simulated workspaces.",
+    ],
+  },
+  {
+    label: "Ion Trapper",
+    items: [
+      "Adjoint-optimized integrated photonic circuits for individual trapped-ion addressing.",
+      "Temporally multiplexed ion-photon interfaces via fast ion-chain transport.",
+      "3D-printed micro ion trap technology for scalable quantum information processing.",
+      "Trapped-ion Ramsey interferometry probing causal non-linear quantum mechanics.",
+    ],
+  },
+];
+
+export default function AboutPage() {
+  return (
+    <div className="space-y-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLdScriptContent(profilePageJsonLd),
+        }}
+      />
+
+      <header>
+        <h1 className="text-3xl font-semibold tracking-tight">About</h1>
+        <div className="mt-6 space-y-4 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          {facts.map((fact) => (
+            <p key={fact}>{fact}</p>
+          ))}
+        </div>
+      </header>
+
+      <section>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)] mb-6">
+          Focus
+        </h2>
+        <div className="space-y-10">
+          {focusAreas.map((area) => (
+            <div key={area.label}>
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">
+                {area.label}
+              </p>
+              <ul className="mt-3 divide-y divide-[var(--border)] border-y border-[var(--border)]">
+                {area.items.map((item) => (
+                  <li
+                    key={item}
+                    className="py-4 text-base leading-relaxed text-[var(--muted)]"
+                  >
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)] mb-6">
+          Education
+        </h2>
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          {education.map((item) => (
+            <li
+              key={`${item.institution}-${item.period}`}
+              className="grid gap-1 py-5 sm:grid-cols-[10rem_1fr] sm:gap-6"
+            >
+              <span className="font-mono text-xs text-[var(--muted)] tabular-nums">
+                {item.period}
+              </span>
+              <div>
+                <p className="text-base font-medium">{item.institution}</p>
+                <p className="mt-1 text-sm text-[var(--muted)]">
+                  {item.degree} · {item.location}
+                </p>
+                <p className="mt-2 text-sm text-[var(--muted)] leading-relaxed">
+                  {item.summary}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)] mb-6">
+          Contact
+        </h2>
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)] text-sm">
+          <li className="grid gap-1 py-4 sm:grid-cols-[10rem_1fr] sm:gap-6">
+            <span className="font-mono text-xs text-[var(--muted)]">Email</span>
+            <a
+              className="underline underline-offset-4 decoration-[var(--border)] hover:decoration-foreground"
+              href="mailto:bingran.you@berkeley.edu"
+            >
+              bingran.you@berkeley.edu
+            </a>
+          </li>
+          <li className="grid gap-1 py-4 sm:grid-cols-[10rem_1fr] sm:gap-6">
+            <span className="font-mono text-xs text-[var(--muted)]">Lab</span>
+            <a
+              className="underline underline-offset-4 decoration-[var(--border)] hover:decoration-foreground"
+              href="https://haeffnerlab.berkeley.edu/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Haeffner Lab, UC Berkeley
+            </a>
+          </li>
+          <li className="grid gap-1 py-4 sm:grid-cols-[10rem_1fr] sm:gap-6">
+            <span className="font-mono text-xs text-[var(--muted)]">
+              Elsewhere
+            </span>
+            <span className="text-[var(--muted)]">
+              Profiles linked in the footer.
+            </span>
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -107,6 +107,7 @@ const nav = [
   { href: "/projects", label: "Projects" },
   { href: "/papers", label: "Papers" },
   { href: "/blog", label: "Blog" },
+  { href: "/about", label: "About" },
 ];
 
 export default function RootLayout({

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -33,6 +33,7 @@ I work on two tracks: reliable AI agent systems, and trapped-ion quantum hardwar
 ## Pages
 
 - [Home](${SITE}/)
+- [About](${SITE}/about)
 - [Projects](${SITE}/projects)
 - [Papers](${SITE}/papers)
 - [Blog](${SITE}/blog)

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -9,6 +9,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const staticEntries: MetadataRoute.Sitemap = [
     { url: `${SITE_URL}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/about`, lastModified: now, changeFrequency: "monthly", priority: 0.9 },
     { url: `${SITE_URL}/projects`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: `${SITE_URL}/papers`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: `${SITE_URL}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },


### PR DESCRIPTION
## Summary

A canonical entity page for "Bingran You" — gives Google Knowledge Graph and LLM answer engines a single, dense, factual surface to ground a person query against.

- `app/about/page.tsx` — minimal list-and-divider layout matching the rest of the site. First-person factual sentences (LLM grounding-friendly), focus areas split by AI / Ion track, education, and contact. Embeds `ProfilePage` JSON-LD with a `mainEntity` `Person` carrying `jobTitle`, `affiliation`, `knowsAbout`, and the full `sameAs` profile set.
- `app/about/opengraph-image.tsx` — matching OG card.
- Header nav, `sitemap.ts`, and `/llms.txt` all updated to link `/about` so crawlers discover it through existing entry points.

This is the only PR in this series that adds visible UI. The page is intentionally austere — same eyebrow / divider / mono-label vocabulary as the existing pages.

## Test plan

- [ ] `/about` renders, nav highlights work.
- [ ] `curl -s https://bingranyou.com/about | grep ProfilePage` returns the JSON-LD.
- [ ] Google Rich Results Test on `/about` shows ProfilePage detected.
- [ ] `curl -s https://bingranyou.com/sitemap.xml | grep about` finds the entry.
- [ ] `curl -s https://bingranyou.com/llms.txt | grep About` finds the link.