### PR TITLE
Improve personal-site metadata quality

### DIFF
--- a/personal-site/app/blog/[slug]/page.tsx
+++ b/personal-site/app/blog/[slug]/page.tsx
@@ -1,8 +1,20 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { postSlugs, type PostSlug } from "@/lib/posts";
-import { blogPostingJsonLd, jsonLdScriptContent } from "@/lib/jsonld";
+import {
+  getPostLastModified,
+  getPostMetadata,
+  postSlugs,
+  type PostSlug,
+} from "@/lib/posts";
+import {
+  blogPostingJsonLd,
+  jsonLdScriptContent,
+  OG_IMAGE_URL,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+} from "@/lib/jsonld";
 
 export const dynamicParams = false;
 
@@ -19,26 +31,50 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   if (!postSlugs.includes(slug as PostSlug)) return {};
-  const mod = await import(`@/content/posts/${slug}.mdx`);
+  const postSlug = slug as PostSlug;
+  const metadata = await getPostMetadata(postSlug);
+  const modifiedTime = (await getPostLastModified(postSlug)).toISOString();
+  const description = metadata.description ?? SITE_DESCRIPTION;
+
   return {
-    title: mod.metadata.title,
-    description: mod.metadata.description,
+    title: metadata.title,
+    description,
     alternates: { canonical: `/blog/${slug}` },
+    openGraph: {
+      title: `${metadata.title} · ${SITE_NAME}`,
+      description,
+      url: `${SITE_URL}/blog/${slug}`,
+      type: "article",
+      publishedTime: new Date(metadata.date).toISOString(),
+      modifiedTime,
+      authors: [SITE_NAME],
+      images: [OG_IMAGE_URL],
+    },
+    twitter: {
+      card: "summary_large_image",
+      creator: "@bingran_bry",
+      title: `${metadata.title} · ${SITE_NAME}`,
+      description,
+      images: [OG_IMAGE_URL],
+    },
   };
 }
 
 export default async function PostPage({ params }: { params: Params }) {
   const { slug } = await params;
   if (!postSlugs.includes(slug as PostSlug)) notFound();
+  const postSlug = slug as PostSlug;
   const { default: Post, metadata } = await import(
     `@/content/posts/${slug}.mdx`
   );
+  const modifiedTime = (await getPostLastModified(postSlug)).toISOString();
   const jsonLd = jsonLdScriptContent(
     blogPostingJsonLd({
       slug,
       title: metadata.title,
       description: metadata.description,
       date: metadata.date,
+      modifiedTime,
     }),
   );
 

--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -3,6 +3,17 @@ import { Geist, Geist_Mono, Newsreader } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
 import { SocialLinks } from "@/components/social-links";
+import {
+  jsonLdScriptContent,
+  OG_IMAGE_URL,
+  personJsonLd,
+  SITE_DESCRIPTION,
+  SITE_KEYWORDS,
+  SITE_NAME,
+  SITE_OG_DESCRIPTION,
+  SITE_URL,
+  websiteJsonLd,
+} from "@/lib/jsonld";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -20,86 +31,39 @@ const newsreader = Newsreader({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://bingranyou.com"),
+  metadataBase: new URL(SITE_URL),
+  applicationName: SITE_NAME,
   title: {
     default: "Bingran You — AI Builder & Ion Trapper",
-    template: "%s · Bingran You",
+    template: `%s · ${SITE_NAME}`,
   },
-  description:
-    "Bingran You — PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.",
+  description: SITE_DESCRIPTION,
   openGraph: {
-    title: "Bingran You",
-    description:
-      "PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion quantum experiments.",
-    url: "https://bingranyou.com",
-    siteName: "Bingran You",
+    title: SITE_NAME,
+    description: SITE_OG_DESCRIPTION,
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    locale: "en_US",
     type: "website",
+    images: [OG_IMAGE_URL],
   },
   twitter: {
     card: "summary_large_image",
     creator: "@bingran_bry",
+    title: SITE_NAME,
+    description: SITE_OG_DESCRIPTION,
+    images: [OG_IMAGE_URL],
   },
   alternates: {
     canonical: "/",
   },
+  authors: [{ name: SITE_NAME, url: SITE_URL }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
+  keywords: [...SITE_KEYWORDS],
   verification: {
     google: "xWQd6sxfEf5jfU4AtrNcPv0jg71Ia8gQvXAcQmWKpyo",
   },
-};
-
-const personJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Person",
-  name: "Bingran You",
-  givenName: "Bingran",
-  familyName: "You",
-  url: "https://bingranyou.com",
-  image: "https://bingranyou.com/images/profile/bingran-you-portrait.jpg",
-  jobTitle: "PhD Candidate",
-  description:
-    "PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.",
-  alumniOf: [
-    {
-      "@type": "CollegeOrUniversity",
-      name: "University of California, Berkeley",
-      sameAs: "https://www.berkeley.edu/",
-    },
-    {
-      "@type": "CollegeOrUniversity",
-      name: "University of Chinese Academy of Sciences",
-      sameAs: "https://english.ucas.ac.cn/",
-    },
-  ],
-  affiliation: {
-    "@type": "Organization",
-    name: "Haeffner Lab, University of California, Berkeley",
-    url: "https://haeffnerlab.berkeley.edu/",
-  },
-  knowsAbout: [
-    "Reliable AI Systems",
-    "AI Agents",
-    "Trapped-Ion Quantum Computing",
-    "Integrated Photonics",
-    "Quantum Networking",
-  ],
-  sameAs: [
-    "https://x.com/bingran_bry",
-    "https://github.com/bingran-you",
-    "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",
-    "https://orcid.org/0000-0002-0316-2115",
-    "https://huggingface.co/bingran-you",
-    "https://www.linkedin.com/in/bingran-you-775b4017b/",
-    "https://www.youtube.com/@BingranBRY",
-  ],
-};
-
-const websiteJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  name: "Bingran You",
-  url: "https://bingranyou.com",
-  inLanguage: "en",
-  author: { "@type": "Person", name: "Bingran You" },
 };
 
 const nav = [
@@ -124,13 +88,13 @@ export default function RootLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(personJsonLd).replace(/</g, "\\u003c"),
+            __html: jsonLdScriptContent(personJsonLd()),
           }}
         />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(websiteJsonLd).replace(/</g, "\\u003c"),
+            __html: jsonLdScriptContent(websiteJsonLd()),
           }}
         />
         <header className="sticky top-0 z-20 border-b border-[var(--border)] bg-[var(--background)]/85 backdrop-blur">

--- a/personal-site/app/page.tsx
+++ b/personal-site/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { education, projects, papers } from "@/lib/content";
+import { jsonLdScriptContent, profilePageJsonLd } from "@/lib/jsonld";
 
 export default function Home() {
   const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 5);
@@ -8,6 +9,12 @@ export default function Home() {
 
   return (
     <div className="space-y-24">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLdScriptContent(profilePageJsonLd("/")),
+        }}
+      />
       <section className="grid gap-10 sm:grid-cols-[1fr_auto] sm:items-start">
         <div>
           <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -1,26 +1,94 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
 import type { MetadataRoute } from "next";
-import { getAllPostsMetadata } from "@/lib/posts";
+import {
+  getAllPostsMetadata,
+  getPostLastModified,
+} from "@/lib/posts";
 
 const SITE_URL = "https://bingranyou.com";
 
+async function getFileLastModified(relativePath: string) {
+  const { mtime } = await stat(
+    path.join(/* turbopackIgnore: true */ process.cwd(), relativePath),
+  );
+  return mtime;
+}
+
+async function getLatestLastModified(relativePaths: string[]) {
+  const values = await Promise.all(
+    relativePaths.map((relativePath) => getFileLastModified(relativePath)),
+  );
+
+  return new Date(Math.max(...values.map((value) => value.getTime())));
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const now = new Date();
   const posts = await getAllPostsMetadata();
+  const postEntries = await Promise.all(
+    posts.map(async (post) => ({
+      url: `${SITE_URL}/blog/${post.slug}`,
+      lastModified: await getPostLastModified(post.slug),
+      changeFrequency: "yearly" as const,
+      priority: 0.6,
+    })),
+  );
+  const blogLastModified = new Date(
+    Math.max(
+      (
+        await getLatestLastModified([
+          "app/blog/page.tsx",
+          "lib/posts.ts",
+        ])
+      ).getTime(),
+      ...postEntries.map((entry) => entry.lastModified.getTime()),
+    ),
+  );
 
   const staticEntries: MetadataRoute.Sitemap = [
-    { url: `${SITE_URL}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
-    { url: `${SITE_URL}/about`, lastModified: now, changeFrequency: "monthly", priority: 0.9 },
-    { url: `${SITE_URL}/projects`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${SITE_URL}/papers`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${SITE_URL}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
+    {
+      url: `${SITE_URL}/`,
+      lastModified: await getLatestLastModified([
+        "app/layout.tsx",
+        "app/page.tsx",
+      ]),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: await getLatestLastModified([
+        "app/layout.tsx",
+        "app/about/page.tsx",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/projects`,
+      lastModified: await getLatestLastModified([
+        "app/projects/page.tsx",
+        "lib/content.ts",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/papers`,
+      lastModified: await getLatestLastModified([
+        "app/papers/page.tsx",
+        "lib/content.ts",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/blog`,
+      lastModified: blogLastModified,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
   ];
-
-  const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: `${SITE_URL}/blog/${post.slug}`,
-    lastModified: new Date(post.date),
-    changeFrequency: "yearly",
-    priority: 0.6,
-  }));
 
   return [...staticEntries, ...postEntries];
 }

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -1,12 +1,124 @@
 import type { Paper, Project } from "@/lib/content";
 
-const SITE_URL = "https://bingranyou.com";
+export const SITE_URL = "https://bingranyou.com";
+export const SITE_NAME = "Bingran You";
+export const SITE_DESCRIPTION =
+  "Bingran You — PhD candidate at UC Berkeley building reliable AI systems and trapped-ion quantum experiments.";
+export const SITE_OG_DESCRIPTION =
+  "PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion quantum experiments.";
+export const OG_IMAGE_URL = `${SITE_URL}/images/profile/bingran-you-portrait.jpg`;
+export const PERSON_ID = `${SITE_URL}#person`;
+export const WEBSITE_ID = `${SITE_URL}#website`;
+export const PROFILE_PAGE_ID = `${SITE_URL}#profile`;
+export const SITE_KEYWORDS = [
+  "Bingran You",
+  "AI agents",
+  "reliable AI systems",
+  "agent evaluation",
+  "SkillsBench",
+  "first-tree",
+  "DoWhiz",
+  "trapped-ion quantum computing",
+  "integrated photonics",
+  "quantum networking",
+  "UC Berkeley",
+  "Haeffner Lab",
+] as const;
+
+function isoDate(value: string) {
+  return new Date(value).toISOString();
+}
 
 const author = {
   "@type": "Person" as const,
-  name: "Bingran You",
+  "@id": PERSON_ID,
+  name: SITE_NAME,
   url: SITE_URL,
 };
+
+export function personJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": PERSON_ID,
+    name: SITE_NAME,
+    givenName: "Bingran",
+    familyName: "You",
+    url: SITE_URL,
+    image: OG_IMAGE_URL,
+    jobTitle: "PhD Candidate",
+    description: SITE_DESCRIPTION,
+    identifier: {
+      "@type": "PropertyValue",
+      propertyID: "ORCID",
+      value: "0000-0002-0316-2115",
+      url: "https://orcid.org/0000-0002-0316-2115",
+    },
+    alumniOf: [
+      {
+        "@type": "CollegeOrUniversity",
+        name: "University of California, Berkeley",
+        sameAs: "https://www.berkeley.edu/",
+      },
+      {
+        "@type": "CollegeOrUniversity",
+        name: "University of Chinese Academy of Sciences",
+        sameAs: "https://english.ucas.ac.cn/",
+      },
+    ],
+    affiliation: {
+      "@type": "Organization",
+      name: "Haeffner Lab, University of California, Berkeley",
+      url: "https://haeffnerlab.berkeley.edu/",
+    },
+    knowsAbout: [
+      "Reliable AI Systems",
+      "AI Agents",
+      "Trapped-Ion Quantum Computing",
+      "Integrated Photonics",
+      "Quantum Networking",
+    ],
+    sameAs: [
+      "https://x.com/bingran_bry",
+      "https://github.com/bingran-you",
+      "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",
+      "https://orcid.org/0000-0002-0316-2115",
+      "https://huggingface.co/bingran-you",
+      "https://www.linkedin.com/in/bingran-you-775b4017b/",
+      "https://www.youtube.com/@BingranBRY",
+    ],
+  } as const;
+}
+
+export function websiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": WEBSITE_ID,
+    name: SITE_NAME,
+    alternateName: ["bingranyou.com", "bingran.you"],
+    url: SITE_URL,
+    inLanguage: "en",
+    author: { "@id": PERSON_ID },
+    about: { "@id": PERSON_ID },
+  } as const;
+}
+
+export function profilePageJsonLd(path: "/" | "/about" = "/") {
+  const url = path === "/" ? SITE_URL : `${SITE_URL}${path}`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": path === "/" ? PROFILE_PAGE_ID : `${url}#profile`,
+    url,
+    name: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    inLanguage: "en",
+    isPartOf: { "@id": WEBSITE_ID },
+    about: { "@id": PERSON_ID },
+    mainEntity: { "@id": PERSON_ID },
+  } as const;
+}
 
 export function paperJsonLd(paper: Paper) {
   return {
@@ -41,19 +153,27 @@ export function blogPostingJsonLd(args: {
   title: string;
   description?: string;
   date: string;
+  modifiedTime?: string;
 }) {
   const url = `${SITE_URL}/blog/${args.slug}`;
+  const publishedTime = isoDate(args.date);
   return {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
+    "@id": `${url}#article`,
     headline: args.title,
     ...(args.description ? { description: args.description } : {}),
-    datePublished: args.date,
-    dateModified: args.date,
+    datePublished: publishedTime,
+    dateModified: args.modifiedTime ?? publishedTime,
     url,
-    mainEntityOfPage: url,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${url}#webpage`,
+    },
     author,
     publisher: author,
+    image: [OG_IMAGE_URL],
+    isAccessibleForFree: true,
   } as const;
 }
 

--- a/personal-site/lib/posts.ts
+++ b/personal-site/lib/posts.ts
@@ -1,3 +1,6 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+
 export const postSlugs = [
   "seo-and-geo-for-a-personal-site",
   "welcome",
@@ -28,4 +31,10 @@ export async function getAllPostsMetadata(): Promise<
     })),
   );
   return all.sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
+export async function getPostLastModified(slug: PostSlug) {
+  const filePath = path.join(process.cwd(), "content", "posts", `${slug}.mdx`);
+  const { mtime } = await stat(filePath);
+  return mtime;
 }


### PR DESCRIPTION
## Summary
- enrich root metadata and structured data without changing the site's visual presentation
- add home ProfilePage schema plus better blog post article metadata and timestamps
- make sitemap lastmod values reflect actual file updates instead of every build timestamp

## Testing
- npm run lint
- npm run build
- verified local canonical/article metadata via curl
- verified sitemap lastmod output via curl
- visual output unchanged (no CSS/className/layout edits); local Safari spot-check remained identical to production for the page templates reviewed

## Notes
- supersedes #99 after overlapping SEO PRs landed on main while that branch was in flight