### PR TITLE
Link Wikidata Q139620371 from Person sameAs and llms.txt

### DIFF
--- a/personal-site/app/about/page.tsx
+++ b/personal-site/app/about/page.tsx
@@ -33,6 +33,7 @@ const profilePageJsonLd = {
       "Quantum Networking",
     ],
     sameAs: [
+      "https://www.wikidata.org/wiki/Q139620371",
       "https://x.com/bingran_bry",
       "https://github.com/bingran-you",
       "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",

--- a/personal-site/app/llms-full.txt/route.ts
+++ b/personal-site/app/llms-full.txt/route.ts
@@ -35,6 +35,7 @@ export async function GET() {
 - Location: Berkeley, California, USA
 - Site: ${SITE}/
 - Email: bingran.you@berkeley.edu
+- Wikidata: https://www.wikidata.org/wiki/Q139620371
 - ORCID: https://orcid.org/0000-0002-0316-2115
 - Google Scholar: https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en
 - GitHub: https://github.com/bingran-you

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -22,6 +22,7 @@ I work on two tracks: reliable AI agent systems, and trapped-ion quantum hardwar
 - Location: Berkeley, California, USA
 - Site: ${SITE}/
 - Email: bingran.you@berkeley.edu
+- Wikidata: https://www.wikidata.org/wiki/Q139620371
 - ORCID: https://orcid.org/0000-0002-0316-2115
 - Google Scholar: https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en
 - GitHub: https://github.com/bingran-you

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -79,6 +79,7 @@ export function personJsonLd() {
       "Quantum Networking",
     ],
     sameAs: [
+      "https://www.wikidata.org/wiki/Q139620371",
       "https://x.com/bingran_bry",
       "https://github.com/bingran-you",
       "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",


### PR DESCRIPTION
## Summary

Closes the entity-recognition loop now that the Wikidata item exists at https://www.wikidata.org/wiki/Q139620371.

- The site declares the Wikidata QID outward in `Person.sameAs` (root layout) and `ProfilePage.mainEntity.sameAs` (`/about`).
- The Wikidata item already declares the site inward via P856 (official website).

Both sides now reference each other — what Google Knowledge Graph and most LLM entity tables look for to collapse the duplicate-identity problem and recognize "Bingran You" across the web as one entity.

- `lib/jsonld.ts` personJsonLd: prepend Wikidata URL to `sameAs`.
- `app/about/page.tsx` `ProfilePage.mainEntity`: same prepend.
- `app/llms.txt` + `app/llms-full.txt`: add `Wikidata:` line under Identity.

The Wikidata item also carries: `instance of: human`, `ORCID iD`, `Google Scholar author ID`, `official website: https://bingranyou.com`, `occupation: researcher / scientist`, `field of work: artificial intelligence`, `educated at: UC Berkeley`, `GitHub`, `LinkedIn`, and `X (Twitter)` — each with a reference URL to `bingranyou.com/about` or the relevant authoritative source.

## Test plan

- [ ] After deploy, `curl -s https://bingranyou.com/ | grep wikidata` shows the Wikidata URL inside the Person JSON-LD.
- [ ] Same for `/about` (inside ProfilePage JSON-LD).
- [ ] `curl -s https://bingranyou.com/llms.txt | grep -i wikidata` finds the line.
- [ ] Visit https://www.wikidata.org/wiki/Q139620371 — page loads, statements present.