### PR TITLE
Replace hero bio with monochrome icon one-liner

### DIFF
--- a/personal-site/app/page.tsx
+++ b/personal-site/app/page.tsx
@@ -2,6 +2,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { education, projects, papers } from "@/lib/content";
 import { jsonLdScriptContent, profilePageJsonLd } from "@/lib/jsonld";
+import {
+  AtomIcon,
+  GraduationCapIcon,
+  LaptopIcon,
+} from "@/components/bio-icons";
 
 export default function Home() {
   const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 5);
@@ -17,17 +22,28 @@ export default function Home() {
       />
       <section className="grid gap-10 sm:grid-cols-[1fr_auto] sm:items-start">
         <div>
-          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
-            Berkeley · PhD Candidate
-          </p>
-          <h1 className="mt-5 font-display text-5xl leading-[1.02] tracking-[-0.035em] sm:text-6xl">
+          <h1 className="font-display text-5xl leading-[1.02] tracking-[-0.035em] sm:text-6xl">
             Bingran You
           </h1>
-          <p className="mt-6 max-w-xl text-base leading-relaxed text-[var(--muted)] text-pretty">
-            I build reliable AI systems and trapped-ion quantum experiments.
-            Different materials, same craft: turning complex, noisy systems
-            into something that behaves on purpose.
-          </p>
+          <ul className="mt-7 space-y-3 text-base text-[var(--muted)]">
+            <li className="flex flex-wrap items-center gap-x-6 gap-y-2">
+              <span className="inline-flex items-center gap-2">
+                <LaptopIcon className="h-[18px] w-[18px] shrink-0" />
+                Agentic Builder
+              </span>
+              <span className="inline-flex items-center gap-2">
+                <AtomIcon className="h-[18px] w-[18px] shrink-0" />
+                Ion Trapper
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <GraduationCapIcon className="h-[18px] w-[18px] shrink-0 mt-[3px]" />
+              <span>
+                PhD Candidate in Applied Science &amp; Technology at UC
+                Berkeley
+              </span>
+            </li>
+          </ul>
         </div>
 
         <div className="relative h-44 w-44 shrink-0 overflow-hidden rounded-full ring-1 ring-[var(--border)] sm:h-52 sm:w-52">

--- a/personal-site/components/bio-icons.tsx
+++ b/personal-site/components/bio-icons.tsx
@@ -1,0 +1,52 @@
+type IconProps = { className?: string };
+
+const baseProps = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.75,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+export function LaptopIcon({ className }: IconProps) {
+  return (
+    <svg {...baseProps} aria-hidden className={className}>
+      <rect x="3" y="4" width="18" height="12" rx="2" />
+      <path d="M2 20h20" />
+    </svg>
+  );
+}
+
+export function AtomIcon({ className }: IconProps) {
+  return (
+    <svg {...baseProps} aria-hidden className={className}>
+      <circle cx="12" cy="12" r="1" fill="currentColor" stroke="none" />
+      <ellipse cx="12" cy="12" rx="10" ry="4" />
+      <ellipse
+        cx="12"
+        cy="12"
+        rx="10"
+        ry="4"
+        transform="rotate(60 12 12)"
+      />
+      <ellipse
+        cx="12"
+        cy="12"
+        rx="10"
+        ry="4"
+        transform="rotate(120 12 12)"
+      />
+    </svg>
+  );
+}
+
+export function GraduationCapIcon({ className }: IconProps) {
+  return (
+    <svg {...baseProps} aria-hidden className={className}>
+      <path d="M22 10v6" />
+      <path d="M2 10l10-5 10 5-10 5z" />
+      <path d="M6 12v5c3 3 9 3 12 0v-5" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Tightens the home hero to a two-line bio led by stroke-outline icons that match the existing footer social-icon set:

- 💻 **laptop** + *Agentic Builder*
- ⚛️ **atom** + *Ion Trapper*
- 🎓 **graduation cap** + *PhD Candidate in Applied Science & Technology at UC Berkeley*

(Glyphs are real SVGs, not emoji — `currentColor` + `text-[var(--muted)]` so they land in the same grey-white tone as the X / GitHub / Scholar / ORCID / etc. icons in the footer.)

- New `components/bio-icons.tsx` exports `LaptopIcon`, `AtomIcon`, `GraduationCapIcon` in the same stroke-outline style as the existing `EmailIcon`, so the whole site reads as one icon set.
- `app/page.tsx`: replaces the hero's eyebrow ("Berkeley · PhD Candidate") and prose tagline with the new icon-led list. Headline `Bingran You` and the rest of the page (Education / Current projects / Selected papers) are unchanged.

The richer first-person prose that used to live in the hero remains on `/about` (and in `/llms-full.txt`), so SEO/GEO factual surfaces aren't affected.

## Test plan

- [ ] Deploy preview renders the three icons inline with text, in the muted grey tone, hover does nothing (they're not links).
- [ ] On mobile, the laptop + atom row wraps cleanly; the cap + degree line stays single-anchor with hanging indent.
- [ ] No layout shift on the portrait column (still 11rem / 13rem at the same breakpoint).