### PR TITLE
Reserve scrollbar gutter to prevent cross-page layout shift

### DIFF
--- a/personal-site/app/globals.css
+++ b/personal-site/app/globals.css
@@ -35,6 +35,7 @@
 
 html {
   scroll-behavior: smooth;
+  scrollbar-gutter: stable;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Pages of differing height toggled the vertical scrollbar on/off, which horizontally shifted the centered `max-w-4xl` container by ~7–8px between routes — visible as nav items (Projects / Papers / Blog / About) nudging left/right when navigating.
- Set `scrollbar-gutter: stable` on `<html>` so the scrollbar space is always reserved, eliminating the shift.

## Test plan
- [ ] Navigate between `/`, `/projects`, `/papers`, `/blog`, `/about` and confirm the header nav no longer shifts horizontally.

https://claude.ai/code/session_01LgprY9GRdPfKXe4nioVd5R

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgprY9GRdPfKXe4nioVd5R)_