### PR TITLE
Align all docs and labels to Agentic Builder + AMO physics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Hi, I'm Bingran 👋
 
-📍 Berkeley | 🎓 PhD Candidate @ UC Berkeley | 🖥️ AI Builder | ⚛︎ Ion Trapper
+📍 Berkeley | 🎓 PhD Candidate @ UC Berkeley | 💻 Agentic Builder | ⚛︎ Ion Trapper
 
-I build reliable AI systems and trapped-ion quantum experiments. This page is a short snapshot of projects and papers I've been lucky to work on across both tracks.
+I build reliable AI systems and run trapped-ion experiments in atomic, molecular and optical physics. This page is a short snapshot of projects and papers I've been lucky to work on across both tracks.
 
-## 💻 AI Builder
+## 💻 Agentic Builder
 
 ### How I Build
 
@@ -58,26 +58,26 @@ I build reliable AI systems and trapped-ion quantum experiments. This page is a 
 <p align="center">
   <img alt="Integrated photonics" src="https://img.shields.io/badge/Integrated%20Photonics-1E7F5C?style=flat-square" />
   <img alt="Ion shuttling" src="https://img.shields.io/badge/Ion%20Shuttling-0F766E?style=flat-square" />
-  <img alt="Quantum networking" src="https://img.shields.io/badge/Quantum%20Networking-0369A1?style=flat-square" />
+  <img alt="Ion-photon interfaces" src="https://img.shields.io/badge/Ion--Photon%20Interfaces-0369A1?style=flat-square" />
   <img alt="3D Printing" src="https://img.shields.io/badge/3D%20Printing-92400E?style=flat-square" />
 </p>
 
 <p align="center">
-  <sub>From control stack to integrated photonics, quantum interfaces, and microtrap design.</sub>
+  <sub>From control stack to integrated photonics, ion-photon interfaces, and microtrap design.</sub>
 </p>
 
 ### Current Focus
 
 - ⚛️ Integrated photonics for trapped-ion systems
-- 🔗 Ion-photon interfaces and multiplexed quantum networking
+- 🔗 Ion-photon interfaces and multiplexed networking
 - 🧩 Novel ion trap architectures, including 3D-printed microtraps
 
 ### Selected Papers
 
 - 📑 *npj Nanophotonics* · [Individual trapped-ion addressing with adjoint-optimized multimode photonic circuits](https://www.nature.com/articles/s44310-025-00102-4) - Integrated photonic circuits for scalable trapped-ion addressing.
 - 📑 *arXiv* · [Temporally multiplexed ion-photon quantum interface via fast ion-chain transport](https://arxiv.org/abs/2405.10501) - Multiplexed ion-photon interface based on fast ion-chain transport.
-- 📑 *Nature* · [3D-Printed Micro Ion Trap Technology for Scalable Quantum Information Processing](https://www.nature.com/articles/s41586-025-09474-1) - 3D-printed micro ion trap technology for scalable quantum information processing.
-- 📑 *Phys. Rev. Lett.* · [Test of Causal Non-Linear Quantum Mechanics by Ramsey Interferometry on the Vibrational Mode of a Trapped Ion](https://doi.org/10.1103/PhysRevLett.130.200201) - Trapped-ion Ramsey interferometry probing causal non-linear quantum mechanics.
+- 📑 *Nature* · [3D-Printed Micro Ion Trap Technology for Scalable Quantum Information Processing](https://www.nature.com/articles/s41586-025-09474-1) - 3D-printed micro ion trap technology for scalable atomic-physics platforms.
+- 📑 *Phys. Rev. Lett.* · [Test of Causal Non-Linear Quantum Mechanics by Ramsey Interferometry on the Vibrational Mode of a Trapped Ion](https://doi.org/10.1103/PhysRevLett.130.200201) - Trapped-ion Ramsey interferometry probing fundamental physics of single-ion vibrational modes.
 
 ## Connect
 

--- a/USER.md
+++ b/USER.md
@@ -14,8 +14,8 @@ _The one you serve. Keep this living and current._
 
 - PhD Candidate, UC Berkeley
 - **Two tracks, both active:**
-  - 🖥️ **AI Builder** — agent evaluation, skills-based benchmarking, deterministic test environments for long-horizon workflows, applied AI systems across existing tools.
-  - ⚛︎ **Ion Trapper** — trapped-ion quantum experiments, integrated photonics, ion-photon interfaces, multiplexed quantum networking, 3D-printed microtraps. Member of HaeffnerLab.
+  - 💻 **Agentic Builder** — agent evaluation, skills-based benchmarking, deterministic test environments for long-horizon workflows, applied AI systems across existing tools.
+  - ⚛︎ **Ion Trapper** — trapped-ion experiments in atomic, molecular and optical (AMO) physics: integrated photonics, ion-photon interfaces, multiplexed networking, 3D-printed microtraps. Member of HaeffnerLab.
 
 ## Primary Stack
 

--- a/personal-site/app/about/page.tsx
+++ b/personal-site/app/about/page.tsx
@@ -55,7 +55,7 @@ const facts = [
 
 const focusAreas = [
   {
-    label: "AI Builder",
+    label: "Agentic Builder",
     items: [
       "Agent skills and tool use, with an emphasis on evaluation that mirrors real workflows.",
       "Productivity agents that triage notifications, dispatch background work, and stay out of the way.",

--- a/personal-site/app/opengraph-image.tsx
+++ b/personal-site/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
 
-export const alt = "Bingran You — AI Builder & Ion Trapper";
+export const alt = "Bingran You — Agentic Builder & Ion Trapper";
 export const size = ogSize;
 export const contentType = ogContentType;
 

--- a/personal-site/app/papers/page.tsx
+++ b/personal-site/app/papers/page.tsx
@@ -35,7 +35,7 @@ export default function PapersPage() {
         </p>
       </header>
 
-      <Section title="AI Builder" items={ai} />
+      <Section title="Agentic Builder" items={ai} />
       <Section title="Ion Trapper" items={ion} />
     </div>
   );

--- a/personal-site/app/projects/page.tsx
+++ b/personal-site/app/projects/page.tsx
@@ -27,7 +27,7 @@ export default function ProjectsPage() {
         </p>
       </header>
 
-      <Section title="AI Builder" items={ai} />
+      <Section title="Agentic Builder" items={ai} />
       <Section title="Ion Trapper" items={ion} />
     </div>
   );


### PR DESCRIPTION
## Summary

Aligns the rest of the workspace with the home-page copy already shipped in #110 / #111. Two consistent changes everywhere:

- **"AI Builder" → "Agentic Builder"** (matches the new home-hero icon-led bio).
- **"quantum" / "quantum networking" / "quantum experiments" → "atomic, molecular and optical (AMO) physics"** in self-descriptions. Real publication titles are preserved verbatim — the three Nature / npj / PRL paper titles still contain "Quantum" because that's how the journals published them.

### Top-level docs

- **`README.md`**:
  - Header chip: `🖥️ AI Builder` → `💻 Agentic Builder`.
  - Section heading: `## 💻 AI Builder`.
  - Intro line: now mentions trapped-ion AMO physics instead of "quantum experiments".
  - Badge: `Quantum networking` → `Ion-photon interfaces`.
  - Sub-caption + Current Focus bullet: drop "quantum networking".
  - Two paper *blurbs* under `## ⚛︎ Ion Trapper` (the trailing self-descriptions after `-`) reworded.

- **`USER.md`**:
  - `🖥️ **AI Builder**` track → `💻 **Agentic Builder**`.
  - `⚛︎ **Ion Trapper**` track reworded ("trapped-ion experiments in atomic, molecular and optical (AMO) physics").

### Personal site labels

- `app/about/page.tsx` — focusAreas label "AI Builder" → "Agentic Builder".
- `app/papers/page.tsx` + `app/projects/page.tsx` — Section title.
- `app/opengraph-image.tsx` — alt text "Bingran You — AI Builder & Ion Trapper" → "Agentic Builder & Ion Trapper".

### Verified clean (no changes needed)

`IDENTITY.md`, `SOUL.md`, `TOOLS.md`, `MEMORY.md`, `HEARTBEAT.md`, `personal-site/AGENTS.md`, `personal-site/CLAUDE.md`. Daily memory journal entries under `memory/YYYY-MM-DD.md` are historical and intentionally not rewritten.

## Test plan

- [ ] After deploy, `curl -s https://bingranyou.com/projects | grep -A1 'Agentic Builder'` shows the new section heading.
- [ ] Same for `/papers` and `/about`.
- [ ] `curl -s https://raw.githubusercontent.com/bingran-you/bingran-you/main/README.md | grep -E 'AI Builder|Quantum%20Networking'` returns nothing.
- [ ] Real paper titles (Nature, PRL) still contain `Quantum` on `/papers`.