### PR TITLE
Add Skills tab — live App Store-style catalog of agent skills

### DIFF
--- a/personal-site/app/(personal)/layout.tsx
+++ b/personal-site/app/(personal)/layout.tsx
@@ -5,6 +5,7 @@ const nav = [
   { href: "/", label: "Home" },
   { href: "/projects", label: "Projects" },
   { href: "/papers", label: "Papers" },
+  { href: "/skills", label: "Skills" },
   { href: "/blog", label: "Blog" },
   { href: "/about", label: "About" },
 ];

--- a/personal-site/app/(personal)/skills/[slug]/page.tsx
+++ b/personal-site/app/(personal)/skills/[slug]/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getAllSkills, getSkill } from "@/lib/skills";
+
+export function generateStaticParams() {
+  return getAllSkills().map((s) => ({ slug: s.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const skill = getSkill(slug);
+  if (!skill) return { title: "Skill not found" };
+
+  const description =
+    skill.description.length > 200
+      ? `${skill.description.slice(0, 197).trimEnd()}…`
+      : skill.description;
+
+  return {
+    title: skill.name,
+    description,
+    alternates: { canonical: `/skills/${skill.slug}` },
+  };
+}
+
+export default async function SkillDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const skill = getSkill(slug);
+  if (!skill) notFound();
+
+  const all = getAllSkills();
+  const idx = all.findIndex((s) => s.slug === skill.slug);
+  const prev = idx > 0 ? all[idx - 1] : null;
+  const next = idx < all.length - 1 ? all[idx + 1] : null;
+
+  return (
+    <article className="space-y-10">
+      <Link
+        href="/skills"
+        className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)] transition hover:text-foreground"
+      >
+        ← Skills
+      </Link>
+
+      <header className="space-y-4">
+        <span className="inline-flex font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          {skill.category}
+        </span>
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+          {skill.name}
+        </h1>
+        <p className="font-mono text-[12px] text-[var(--muted)]">
+          {skill.slug}
+        </p>
+      </header>
+
+      <section>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)] mb-4">
+          Description
+        </h2>
+        <p className="text-base leading-relaxed text-foreground">
+          {skill.description}
+        </p>
+      </section>
+
+      {skill.triggers && skill.triggers.length > 0 ? (
+        <section>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)] mb-4">
+            Triggers
+          </h2>
+          <ul className="flex flex-wrap gap-1.5">
+            {skill.triggers.map((t) => (
+              <li
+                key={t}
+                className="rounded-full border border-[var(--border)] px-3 py-1 font-mono text-[11px] text-[var(--muted)]"
+              >
+                {t}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <nav className="flex items-stretch justify-between gap-3 border-t border-[var(--border)] pt-8">
+        {prev ? (
+          <Link
+            href={`/skills/${prev.slug}`}
+            className="group flex flex-col gap-1 text-left"
+          >
+            <span className="font-mono text-[10px] uppercase tracking-[0.32em] text-[var(--muted)]">
+              ← Prev
+            </span>
+            <span className="text-sm group-hover:underline underline-offset-4">
+              {prev.name}
+            </span>
+          </Link>
+        ) : (
+          <span />
+        )}
+        {next ? (
+          <Link
+            href={`/skills/${next.slug}`}
+            className="group flex flex-col gap-1 text-right"
+          >
+            <span className="font-mono text-[10px] uppercase tracking-[0.32em] text-[var(--muted)]">
+              Next →
+            </span>
+            <span className="text-sm group-hover:underline underline-offset-4">
+              {next.name}
+            </span>
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </article>
+  );
+}

--- a/personal-site/app/(personal)/skills/_components/skills-browser.tsx
+++ b/personal-site/app/(personal)/skills/_components/skills-browser.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import Link from "next/link";
+import { useDeferredValue, useMemo, useState } from "react";
+import type { Skill, SkillCategory } from "@/lib/skills";
+
+type Props = {
+  skills: Skill[];
+  categories: SkillCategory[];
+};
+
+export function SkillsBrowser({ skills, categories }: Props) {
+  const [query, setQuery] = useState("");
+  const [activeCategory, setActiveCategory] = useState<SkillCategory | "All">(
+    "All",
+  );
+  const deferredQuery = useDeferredValue(query);
+
+  const filtered = useMemo(() => {
+    const q = deferredQuery.trim().toLowerCase();
+    return skills.filter((s) => {
+      if (activeCategory !== "All" && s.category !== activeCategory)
+        return false;
+      if (!q) return true;
+      return (
+        s.name.toLowerCase().includes(q) ||
+        s.slug.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q) ||
+        (s.triggers?.some((t) => t.toLowerCase().includes(q)) ?? false)
+      );
+    });
+  }, [skills, deferredQuery, activeCategory]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<SkillCategory, Skill[]>();
+    for (const cat of categories) map.set(cat, []);
+    for (const s of filtered) {
+      if (!map.has(s.category)) map.set(s.category, []);
+      map.get(s.category)!.push(s);
+    }
+    return Array.from(map.entries()).filter(([, list]) => list.length > 0);
+  }, [filtered, categories]);
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4">
+        <div className="relative">
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search skills, triggers, descriptions…"
+            aria-label="Search skills"
+            className="w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 pl-10 text-sm placeholder:text-[var(--muted)] focus:border-foreground/40 focus:outline-none focus:ring-0"
+          />
+          <SearchIcon className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--muted)]" />
+        </div>
+
+        <div className="-mx-1 flex flex-wrap gap-1.5">
+          <CategoryChip
+            label={`All · ${skills.length}`}
+            active={activeCategory === "All"}
+            onClick={() => setActiveCategory("All")}
+          />
+          {categories.map((cat) => {
+            const count = skills.filter((s) => s.category === cat).length;
+            return (
+              <CategoryChip
+                key={cat}
+                label={`${cat} · ${count}`}
+                active={activeCategory === cat}
+                onClick={() => setActiveCategory(cat)}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="py-16 text-center text-sm text-[var(--muted)]">
+          No skills match{" "}
+          <span className="font-mono">&ldquo;{deferredQuery}&rdquo;</span>.
+        </p>
+      ) : (
+        <div className="space-y-12">
+          {grouped.map(([cat, list]) => (
+            <section key={cat}>
+              <div className="mb-4 flex items-baseline justify-between">
+                <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+                  {cat}
+                </h2>
+                <span className="font-mono text-[11px] text-[var(--muted)]">
+                  {list.length}
+                </span>
+              </div>
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {list.map((s) => (
+                  <li key={s.slug}>
+                    <SkillCard skill={s} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SkillCard({ skill }: { skill: Skill }) {
+  return (
+    <Link
+      href={`/skills/${skill.slug}`}
+      className="group flex h-full flex-col gap-3 rounded-2xl border border-[var(--border)] bg-[var(--background)] p-5 transition hover:border-foreground/30 hover:shadow-[0_1px_0_rgba(0,0,0,0.02),0_8px_24px_-12px_rgba(0,0,0,0.12)]"
+    >
+      <div className="flex items-start gap-3">
+        <SkillIcon slug={skill.slug} />
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-[15px] font-medium leading-tight tracking-tight">
+            {skill.name}
+          </h3>
+          <p className="mt-0.5 truncate font-mono text-[11px] text-[var(--muted)]">
+            {skill.slug}
+          </p>
+        </div>
+      </div>
+      <p className="line-clamp-3 text-[13px] leading-relaxed text-[var(--muted)]">
+        {skill.description}
+      </p>
+      <div className="mt-auto flex items-center justify-between pt-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">
+          {skill.category}
+        </span>
+        <span className="text-xs text-[var(--muted)] opacity-0 transition group-hover:opacity-100">
+          Open →
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+function CategoryChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1 text-xs transition ${
+        active
+          ? "border-foreground bg-foreground text-[var(--background)]"
+          : "border-[var(--border)] text-[var(--muted)] hover:border-foreground/30 hover:text-foreground"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function SkillIcon({ slug }: { slug: string }) {
+  const initials = slug
+    .split("-")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("");
+  const hue = hashHue(slug);
+  return (
+    <span
+      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border font-mono text-[11px] font-semibold tracking-tight"
+      style={{
+        background: `hsl(${hue} 70% 96%)`,
+        color: `hsl(${hue} 60% 32%)`,
+        borderColor: `hsl(${hue} 50% 88%)`,
+      }}
+      aria-hidden
+    >
+      {initials || "·"}
+    </span>
+  );
+}
+
+function hashHue(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  }
+  return h % 360;
+}
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      <circle cx="7.25" cy="7.25" r="4.75" />
+      <path d="m11 11 3 3" />
+    </svg>
+  );
+}

--- a/personal-site/app/(personal)/skills/page.tsx
+++ b/personal-site/app/(personal)/skills/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import {
+  SKILL_CATEGORIES,
+  getAllSkills,
+  type SkillCategory,
+} from "@/lib/skills";
+import { SkillsBrowser } from "./_components/skills-browser";
+
+export const metadata: Metadata = {
+  title: "Skills",
+  description:
+    "A live catalog of the skills loaded into Bingran's AI agents — each one a packaged capability the agents can pick up at runtime.",
+  alternates: { canonical: "/skills" },
+};
+
+export default function SkillsPage() {
+  const skills = getAllSkills();
+  const categoriesInUse: SkillCategory[] = SKILL_CATEGORIES.filter((cat) =>
+    skills.some((s) => s.category === cat),
+  );
+
+  return (
+    <div className="space-y-12">
+      <header>
+        <h1 className="text-3xl font-semibold tracking-tight">Skills</h1>
+        <p className="mt-3 max-w-2xl text-base text-[var(--muted)]">
+          A live catalog of the {skills.length} skills loaded into my AI agents
+          army. Each is a packaged capability — a self-contained set of
+          instructions, references, and helper scripts — that any agent in this
+          workspace can pick up at runtime.
+        </p>
+        <p className="mt-2 max-w-2xl text-sm text-[var(--muted)]">
+          This page rebuilds whenever{" "}
+          <code className="font-mono text-[12px]">.agents/skills/</code>{" "}
+          changes.
+        </p>
+      </header>
+
+      <SkillsBrowser skills={skills} categories={categoriesInUse} />
+    </div>
+  );
+}

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -5,6 +5,7 @@ import {
   getAllPostsMetadata,
   getPostLastModified,
 } from "@/lib/posts";
+import { getAllSkills, getSkillsLastModified } from "@/lib/skills";
 
 const SITE_URL = "https://bingranyou.com";
 
@@ -94,6 +95,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     },
     {
+      url: `${SITE_URL}/skills`,
+      lastModified: getSkillsLastModified(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/aegis`,
       lastModified: aegisLastModified,
       changeFrequency: "weekly",
@@ -149,5 +156,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  return [...staticEntries, ...postEntries];
+  const skillEntries: MetadataRoute.Sitemap = getAllSkills().map((skill) => ({
+    url: `${SITE_URL}/skills/${skill.slug}`,
+    lastModified: new Date(skill.updatedAt),
+    changeFrequency: "monthly" as const,
+    priority: 0.5,
+  }));
+
+  return [...staticEntries, ...postEntries, ...skillEntries];
 }

--- a/personal-site/lib/skills.ts
+++ b/personal-site/lib/skills.ts
@@ -1,0 +1,228 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+export type Skill = {
+  slug: string;
+  name: string;
+  description: string;
+  category: SkillCategory;
+  triggers?: string[];
+  updatedAt: string;
+};
+
+export const SKILL_CATEGORIES = [
+  "Marketing & Growth",
+  "Design Systems",
+  "Slides & Decks",
+  "Apps & Web",
+  "Documents",
+  "Browser & Testing",
+  "Engineering",
+  "Reviews & Plans",
+  "Security",
+  "Media",
+  "Other",
+] as const;
+
+export type SkillCategory = (typeof SKILL_CATEGORIES)[number];
+
+const SKILLS_DIR = path.join(
+  process.cwd(),
+  "..",
+  ".agents",
+  "skills",
+);
+
+function inferCategory(slug: string): SkillCategory {
+  if (
+    slug.startsWith("html-ppt") ||
+    /^(simple-deck|replit-deck|frontend-slides|weekly-update|guizang-ppt|magazine-poster|pptx-html-fidelity-audit|social-carousel)$/.test(
+      slug,
+    )
+  ) {
+    return "Slides & Decks";
+  }
+
+  if (
+    /^(docx|pdf|pptx|xlsx|jupyter-notebook|blog-post|digital-eguide|finance-report|hr-onboarding|invoice|landing-report|make-pdf|meeting-notes|pm-spec|team-okrs|eng-runbook|document-release)$/.test(
+      slug,
+    )
+  ) {
+    return "Documents";
+  }
+
+  if (
+    slug.startsWith("web-prototype") ||
+    /^(dashboard|dating-web|gamified-app|mobile-app|mobile-onboarding|kanban-board|pricing-page|docs-page|saas-landing|web-artifacts-builder|email-marketing|sprite-animation|wireframe-sketch|tweaks)$/.test(
+      slug,
+    )
+  ) {
+    return "Apps & Web";
+  }
+
+  if (
+    slug.startsWith("playwright") ||
+    /^(browse|gstack|gstack-upgrade|webapp-testing|scrape|hackernews-frontpage|screenshot|setup-browser-cookies|connect-chrome|open-gstack-browser|canary|benchmark|benchmark-models|qa|qa-only|skillify)$/.test(
+      slug,
+    )
+  ) {
+    return "Browser & Testing";
+  }
+
+  if (
+    /^(audio-jingle|video|video-shortform|image|image-poster|hyperframes|motion-frames)$/.test(
+      slug,
+    )
+  ) {
+    return "Media";
+  }
+
+  if (
+    /^(critique|design-review|devex-review|plan-ceo-review|plan-design-review|plan-devex-review|plan-eng-review|plan-tune|review|autoplan|office-hours|gstack-openclaw-ceo-review|gstack-openclaw-office-hours|gstack-openclaw-investigate|gstack-openclaw-retro|retro|investigate|learn)$/.test(
+      slug,
+    )
+  ) {
+    return "Reviews & Plans";
+  }
+
+  if (
+    /^(security-best-practices|security-ownership-map|security-threat-model|cso)$/.test(
+      slug,
+    )
+  ) {
+    return "Security";
+  }
+
+  if (
+    /^(design-brief|design-consultation|design-html|design-shotgun|frontend-design|theme-factory)$/.test(
+      slug,
+    )
+  ) {
+    return "Design Systems";
+  }
+
+  if (
+    /^(ad-creative|ai-seo|analytics-tracking|aso-audit|churn-prevention|cold-email|community-marketing|competitor-alternatives|competitor-profiling|content-strategy|copy-editing|copywriting|customer-research|directory-submissions|email-sequence|free-tool-strategy|lead-magnets|launch-strategy|marketing-ideas|marketing-psychology|page-cro|paid-ads|paywall-upgrade-cro|popup-cro|programmatic-seo|referral-program|revops|sales-enablement|schema-markup|seo-audit|signup-flow-cro|social-content|ab-test-setup|form-cro|onboarding-cro|pricing-strategy|product-marketing-context|xiaohongshu-knowledge|site-architecture)$/.test(
+      slug,
+    )
+  ) {
+    return "Marketing & Growth";
+  }
+
+  if (
+    /^(careful|freeze|unfreeze|guard|ship|land-and-deploy|vercel-deploy|setup-deploy|setup-gbrain|gh-address-comments|gh-fix-ci|cli-creator|codex|plugin-creator|skill-creator|skill-installer|mcp-builder|simplify|fewer-permission-prompts|update-config|keybindings-help|loop|schedule|context-save|context-restore|hatch-pet|health|pair-agent)$/.test(
+      slug,
+    )
+  ) {
+    return "Engineering";
+  }
+
+  return "Other";
+}
+
+function normalizeDescription(raw: unknown): string {
+  if (typeof raw !== "string") return "";
+  return raw.replace(/\s+/g, " ").trim();
+}
+
+function normalizeTriggers(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const list = raw
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter((item) => item.length > 0);
+  return list.length > 0 ? list : undefined;
+}
+
+let cached: Skill[] | null = null;
+
+export function getAllSkills(): Skill[] {
+  if (cached) return cached;
+
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(SKILLS_DIR);
+  } catch {
+    cached = [];
+    return cached;
+  }
+
+  const skills: Skill[] = [];
+
+  for (const slug of entries) {
+    if (slug.startsWith(".")) continue;
+    const skillPath = path.join(SKILLS_DIR, slug);
+    let skillStat;
+    try {
+      skillStat = statSync(skillPath);
+    } catch {
+      continue;
+    }
+    if (!skillStat.isDirectory()) continue;
+
+    const skillFile = path.join(skillPath, "SKILL.md");
+    let raw: string;
+    let mtime: Date;
+    try {
+      raw = readFileSync(skillFile, "utf8");
+      mtime = statSync(skillFile).mtime;
+    } catch {
+      continue;
+    }
+
+    let parsed;
+    try {
+      parsed = matter(raw);
+    } catch {
+      continue;
+    }
+
+    const data = parsed.data ?? {};
+    const name =
+      typeof data.name === "string" && data.name.trim().length > 0
+        ? data.name.trim()
+        : slug;
+    const description = normalizeDescription(data.description);
+    if (!description) continue;
+    const triggers = normalizeTriggers(data.triggers);
+
+    skills.push({
+      slug,
+      name,
+      description,
+      category: inferCategory(slug),
+      triggers,
+      updatedAt: mtime.toISOString(),
+    });
+  }
+
+  skills.sort((a, b) => a.name.localeCompare(b.name));
+  cached = skills;
+  return cached;
+}
+
+export function getSkill(slug: string): Skill | null {
+  return getAllSkills().find((s) => s.slug === slug) ?? null;
+}
+
+export function getSkillsLastModified(): Date {
+  const skills = getAllSkills();
+  if (skills.length === 0) return new Date();
+  const max = skills.reduce((acc, s) => {
+    const t = new Date(s.updatedAt).getTime();
+    return t > acc ? t : acc;
+  }, 0);
+  return new Date(max);
+}
+
+export function groupByCategory(skills: Skill[]): Map<SkillCategory, Skill[]> {
+  const map = new Map<SkillCategory, Skill[]>();
+  for (const cat of SKILL_CATEGORIES) map.set(cat, []);
+  for (const skill of skills) {
+    map.get(skill.category)?.push(skill);
+  }
+  for (const cat of SKILL_CATEGORIES) {
+    if (map.get(cat)?.length === 0) map.delete(cat);
+  }
+  return map;
+}

--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../.agents/skills"
 }


### PR DESCRIPTION
## Summary
- New `/skills` tab listing all 175 skills from `.agents/skills/` as searchable, category-filtered cards in an App Store style
- Each card links to a detail page that surfaces only frontmatter (`name`, `description`, `triggers`) — SKILL.md bodies are never rendered, so internal scripts and paths stay off the public site
- `vercel.json` now triggers rebuilds on `.agents/skills/` changes too, so the catalog stays in sync without touching `personal-site/`

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run build\` — 175 skill detail pages prerendered, sitemap includes all of them
- [x] Local browser check: list page, search filter (\"ppt\" narrows Slides & Decks 26 → 23), category chips, detail page nav
- [x] Privacy: grepped for \`bingran-you-private\` and credential-shaped strings under \`.agents/skills/\` — zero hits
- [ ] Vercel preview deploy verifies build with the new \`ignoreCommand\`