### PR TITLE
Aegis: reframe as two-person founding team

### DIFF
--- a/personal-site/app/aegis/_components/footer.tsx
+++ b/personal-site/app/aegis/_components/footer.tsx
@@ -30,7 +30,7 @@ const cols: { heading: string; links: { href: string; label: string }[] }[] = [
   {
     heading: "Company",
     links: [
-      { href: "/aegis/company", label: "About + founder" },
+      { href: "/aegis/company", label: "About + founders" },
       { href: "/aegis/company#prior-work", label: "Prior work" },
       { href: "/aegis/waitlist", label: "Send us your incident" },
       { href: "/", label: "Bingran You" },
@@ -75,7 +75,7 @@ export function AegisFooter() {
               className="ag-mono mt-6 text-[11px] uppercase tracking-[0.28em]"
               style={{ color: "var(--ag-fg-faint)" }}
             >
-              Solo-founded · Berkeley · v0.1
+              Co-founded · Berkeley · v0.1
             </p>
           </div>
           {cols.map((col) => (

--- a/personal-site/app/aegis/company/page.tsx
+++ b/personal-site/app/aegis/company/page.tsx
@@ -5,9 +5,9 @@ import { CTASection } from "../_components/cta";
 import { ShieldIcon } from "../_components/icons";
 
 export const metadata: Metadata = {
-  title: "Company · solo founder · Berkeley",
+  title: "Company · two-person team · Berkeley",
   description:
-    "Aegis is an independent security-infrastructure project for AI agents. Solo-founded by Bingran You at UC Berkeley.",
+    "Aegis is an independent security-infrastructure project for AI agents. Co-founded by Bingran You and Serena Ke at UC Berkeley.",
   alternates: { canonical: "/aegis/company" },
 };
 
@@ -70,15 +70,15 @@ const PRINCIPLES = [
 const FAQS = [
   {
     q: "Is this a company yet?",
-    a: "It&rsquo;s a solo-founded research preview. Aegis is being built openly out of UC Berkeley while we calibrate the threat catalog with early-access partners. Incorporation follows real customer pull, not the other way around.",
+    a: "It&rsquo;s a two-person research preview. Aegis is being built openly out of UC Berkeley while we calibrate the threat catalog with early-access partners. Incorporation follows real customer pull, not the other way around.",
   },
   {
-    q: "Why are you the right person to build this?",
-    a: "Two years of agent evaluation research at Berkeley directly above this problem. SkillsBench, sbti-cli, smolclaw &mdash; the prerequisites for SecureBench were already on my GitHub before Aegis had a name. The next problem after measuring how agents do their job is keeping them inside the lines while doing it.",
+    q: "Why are you the right team to build this?",
+    a: "Two years of agent evaluation research at Berkeley directly above this problem. SkillsBench, sbti-cli, smolclaw &mdash; the prerequisites for SecureBench were already on our GitHub before Aegis had a name. The next problem after measuring how agents do their job is keeping them inside the lines while doing it.",
   },
   {
-    q: "Solo founder. Risk?",
-    a: "Yes. Mitigation: hiring research-engineering partners (see below). The Berkeley advisor relationship gives me a research network to draw from. The deal with early-access partners is structurally co-development, not vendor-customer &mdash; the catalog grows by their contribution, not just mine.",
+    q: "Two-person team. Risk?",
+    a: "Yes &mdash; small team, large surface area. Mitigation: we&rsquo;re hiring research-engineering partners (see below), and the Berkeley advisor relationship gives us a research network to draw from. The deal with early-access partners is structurally co-development, not vendor-customer &mdash; the catalog grows by their contribution, not just ours.",
   },
   {
     q: "How is Aegis funded?",
@@ -105,17 +105,17 @@ export default function CompanyPage() {
         eyebrow="Company"
         title={
           <>
-            Solo-founded. Built openly.{" "}
+            Co-founded. Built openly.{" "}
             <span className="ag-text-amber italic">From Berkeley.</span>
           </>
         }
         lead={
           <>
             Aegis is an independent security-infrastructure project for AI
-            agents. Solo founder. Two years of agent evaluation research as
-            the prerequisite. We&rsquo;re building the trust layer we&rsquo;d
-            want running underneath our own agents &mdash; and shipping it
-            before the window closes.
+            agents. A two-person founding team. Two years of agent evaluation
+            research as the prerequisite. We&rsquo;re building the trust layer
+            we&rsquo;d want running underneath our own agents &mdash; and
+            shipping it before the window closes.
           </>
         }
         primary={{ href: "/aegis/waitlist", label: "Send us your incident" }}
@@ -126,7 +126,7 @@ export default function CompanyPage() {
         <div className="ag-container">
           <div className="grid gap-12 lg:grid-cols-[0.9fr_1.1fr]">
             <div>
-              <p className="ag-eyebrow">Founder</p>
+              <p className="ag-eyebrow">Founders</p>
               <h2
                 className="ag-display mt-5"
                 style={{
@@ -140,7 +140,7 @@ export default function CompanyPage() {
                 className="mt-3 ag-mono text-[11px] tracking-[0.28em]"
                 style={{ color: "var(--ag-fg-faint)" }}
               >
-                PHD CANDIDATE · UC BERKELEY · AGENT EVALUATION
+                CO-FOUNDER · PHD CANDIDATE · UC BERKELEY · AGENT EVALUATION
               </p>
               <div
                 className="mt-7 space-y-4 text-base leading-relaxed"
@@ -202,6 +202,49 @@ export default function CompanyPage() {
                   bingran.you@berkeley.edu
                 </a>
               </div>
+
+              <div
+                className="mt-10 rounded-xl border p-7"
+                style={{
+                  borderColor: "var(--ag-line)",
+                  background: "var(--ag-canvas)",
+                }}
+              >
+                <h3
+                  className="ag-display"
+                  style={{
+                    fontSize: "1.5rem",
+                    letterSpacing: "-0.018em",
+                  }}
+                >
+                  Serena Ke
+                </h3>
+                <p
+                  className="mt-2 ag-mono text-[11px] tracking-[0.28em]"
+                  style={{ color: "var(--ag-fg-faint)" }}
+                >
+                  CO-FOUNDER
+                </p>
+                <p
+                  className="mt-4 text-sm leading-relaxed"
+                  style={{ color: "var(--ag-fg-mute)" }}
+                >
+                  Co-founder. Building Aegis alongside Bingran out of Berkeley.
+                </p>
+                <div
+                  className="mt-5 flex flex-wrap gap-3 text-sm"
+                  style={{ color: "var(--ag-fg-mute)" }}
+                >
+                  <a
+                    href="https://github.com/serenakeyitan"
+                    className="ag-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    github.com/serenakeyitan
+                  </a>
+                </div>
+              </div>
             </div>
             <aside
               className="ag-card ag-card-amber p-10"
@@ -216,7 +259,7 @@ export default function CompanyPage() {
                   letterSpacing: "-0.012em",
                 }}
               >
-                Hiring research-engineering partner #1.
+                Hiring research-engineering partner #3.
               </p>
               <p
                 className="mt-4 text-sm leading-relaxed"
@@ -226,7 +269,8 @@ export default function CompanyPage() {
                 products, or red-team tooling &mdash; and you can hold a
                 strong opinion about what
                 &ldquo;verifiable&rdquo; means &mdash; we want to hear from
-                you. Co-founder energy welcome.
+                you. Joining a two-person founding team; founding-engineer
+                energy welcome.
               </p>
               <a
                 href="mailto:bingran.you@berkeley.edu?subject=Aegis%20%E2%80%94%20research-engineering"

--- a/personal-site/app/aegis/page.tsx
+++ b/personal-site/app/aegis/page.tsx
@@ -151,8 +151,8 @@ export default function AegisHome() {
               <span className="ag-pill-dot" />
               v0.1 research preview · Berkeley
             </span>
-            <span className="ag-pill">Founder: Bingran You</span>
-            <span className="ag-pill">Solo founder · hiring</span>
+            <span className="ag-pill">Founders: Bingran You + Serena Ke</span>
+            <span className="ag-pill">Two-person team · hiring</span>
           </div>
 
           <h1
@@ -567,7 +567,7 @@ export default function AegisHome() {
                 className="mt-3 ag-mono text-[11px] tracking-[0.28em]"
                 style={{ color: "var(--ag-fg-faint)" }}
               >
-                BINGRAN YOU · SOLO FOUNDER · PHD CANDIDATE, UC BERKELEY
+                BINGRAN YOU · CO-FOUNDER · PHD CANDIDATE, UC BERKELEY
               </p>
               <a
                 href="https://x.com/bingran_bry"
@@ -577,6 +577,21 @@ export default function AegisHome() {
               >
                 @bingran_bry on X
               </a>
+              <p
+                className="mt-5 text-xs leading-relaxed"
+                style={{ color: "var(--ag-fg-faint)" }}
+              >
+                Co-founded with{" "}
+                <a
+                  className="ag-link"
+                  href="https://github.com/serenakeyitan"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Serena Ke
+                </a>
+                .
+              </p>
             </div>
             <div className="space-y-5 text-base leading-relaxed" style={{ color: "var(--ag-fg-mute)" }}>
               <p>

--- a/personal-site/app/aegis/waitlist/page.tsx
+++ b/personal-site/app/aegis/waitlist/page.tsx
@@ -78,7 +78,7 @@ export default function WaitlistPage() {
                 className="mt-3 text-sm leading-relaxed"
                 style={{ color: "var(--ag-fg-mute)" }}
               >
-                Submitting opens an email draft addressed to the founder &mdash;
+                Submitting opens an email draft addressed to the founders &mdash;
                 no servers, no analytics, no wait. Edit it before you send.
               </p>
               <WaitlistForm />


### PR DESCRIPTION
## Summary

- Drop **solo founder** / **solo-founded** framing across the Aegis hero, footer, metadata, FAQs, and the homepage founder's note.
- Add **Serena Ke** ([github.com/serenakeyitan](https://github.com/serenakeyitan)) as co-founder on the Company page and reference her in the founder's note.
- Bump the open hiring slot to **research-engineering partner #3** and reword as joining a two-person founding team.
- Waitlist copy: email drafts now go to **the founders** (plural).

Files touched:

- \`personal-site/app/aegis/page.tsx\` — hero pills, founder's-note attribution, Serena callout
- \`personal-site/app/aegis/company/page.tsx\` — metadata, hero title/lead, Founders block (added Serena card), hiring aside, FAQs
- \`personal-site/app/aegis/_components/footer.tsx\` — \"About + founders\", \"Co-founded · Berkeley · v0.1\"
- \`personal-site/app/aegis/waitlist/page.tsx\` — \"the founders\"

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run build\` succeeds (all Aegis pages prerendered)
- [ ] Spot-check the rendered pages on Vercel preview after merge
- [ ] Confirm Serena's preferred display name + bio (currently using \"Serena Ke\" inferred from her GitHub handle)

> ⚠️ **Note for Bingran:** Serena's bio is a one-line placeholder. Send me her preferred display name, role/title, and a one-paragraph bio when ready and I'll follow up with a small PR.