### PR TITLE
Fix Skills page on Vercel — generate skills.generated.json at build time

### DIFF
--- a/personal-site/app/(personal)/skills/page.tsx
+++ b/personal-site/app/(personal)/skills/page.tsx
@@ -30,9 +30,9 @@ export default function SkillsPage() {
           workspace can pick up at runtime.
         </p>
         <p className="mt-2 max-w-2xl text-sm text-[var(--muted)]">
-          This page rebuilds whenever{" "}
-          <code className="font-mono text-[12px]">.agents/skills/</code>{" "}
-          changes.
+          Generated from{" "}
+          <code className="font-mono text-[12px]">.agents/skills/</code> at
+          build time.
         </p>
       </header>
 

--- a/personal-site/lib/skills.generated.json
+++ b/personal-site/lib/skills.generated.json
@@ -1,0 +1,1806 @@
+[
+  {
+    "slug": "ab-test-setup",
+    "name": "ab-test-setup",
+    "description": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\" \"which version is better,\" \"test two versions,\" \"statistical significance,\" \"how long should I run this test,\" \"growth experiments,\" \"experiment velocity,\" \"experiment backlog,\" \"ICE score,\" \"experimentation program,\" or \"experiment playbook.\" Use this whenever someone is comparing two approaches and wants to measure which performs better, or when they want to build a systematic experimentation practice. For tracking implementation, see analytics-tracking. For page-level conversion optimization, see page-cro.",
+    "updatedAt": "2026-05-04T17:52:23.118Z"
+  },
+  {
+    "slug": "ad-creative",
+    "name": "ad-creative",
+    "description": "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see paid-ads. For landing page copy, see copywriting.",
+    "updatedAt": "2026-05-04T17:52:23.119Z"
+  },
+  {
+    "slug": "ai-seo",
+    "name": "ai-seo",
+    "description": "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup.",
+    "updatedAt": "2026-05-04T17:52:23.120Z"
+  },
+  {
+    "slug": "analytics-tracking",
+    "name": "analytics-tracking",
+    "description": "When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions \"set up tracking,\" \"GA4,\" \"Google Analytics,\" \"conversion tracking,\" \"event tracking,\" \"UTM parameters,\" \"tag manager,\" \"GTM,\" \"analytics implementation,\" \"tracking plan,\" \"how do I measure this,\" \"track conversions,\" \"attribution,\" \"Mixpanel,\" \"Segment,\" \"are my events firing,\" or \"analytics isn't working.\" Use this whenever someone asks how to know if something is working or wants to measure marketing results. For A/B test measurement, see ab-test-setup.",
+    "updatedAt": "2026-05-04T17:52:23.121Z"
+  },
+  {
+    "slug": "aso-audit",
+    "name": "aso-audit",
+    "description": "When the user wants to audit or optimize an App Store or Google Play listing. Also use when the user mentions 'ASO audit,' 'app store optimization,' 'optimize my app listing,' 'improve app visibility,' 'app store ranking,' 'audit my listing,' 'why aren't people downloading my app,' 'improve my app conversion,' 'keyword optimization for app,' or 'compare my app to competitors.' Use when the user shares an App Store or Google Play URL and wants to improve it.",
+    "updatedAt": "2026-05-04T17:52:23.122Z"
+  },
+  {
+    "slug": "audio-jingle",
+    "name": "audio-jingle",
+    "description": "Audio generation skill — jingles, beds, voiceover, and sound effects. Routes music requests to Suno V5 / Udio / Lyria, speech to MiniMax TTS / FishAudio / ElevenLabs V3, and SFX to ElevenLabs SFX or AudioCraft. Output is one MP3/WAV file saved to the project folder.",
+    "triggers": [
+      "music",
+      "jingle",
+      "bed",
+      "voiceover",
+      "tts",
+      "sound effect",
+      "音乐",
+      "配音",
+      "音效"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.351Z"
+  },
+  {
+    "slug": "autoplan",
+    "name": "autoplan",
+    "description": "Auto-review pipeline — reads the full CEO, design, eng, and DX review skills from disk and runs them sequentially with auto-decisions using 6 decision principles. Surfaces taste decisions (close approaches, borderline scope, codex disagreements) at a final approval gate. One command, fully reviewed plan out. Use when asked to \"auto review\", \"autoplan\", \"run all reviews\", \"review this plan automatically\", or \"make the decisions for me\". Proactively suggest when the user has a plan file and wants to run the full review gauntlet without answering 15-30 intermediate questions. (gstack) Voice triggers (speech-to-text aliases): \"auto plan\", \"automatic review\".",
+    "triggers": [
+      "run all reviews",
+      "automatic review pipeline",
+      "auto plan review"
+    ],
+    "updatedAt": "2026-05-04T17:52:22.960Z"
+  },
+  {
+    "slug": "benchmark",
+    "name": "benchmark",
+    "description": "Performance regression detection using the browse daemon. Establishes baselines for page load times, Core Web Vitals, and resource sizes. Compares before/after on every PR. Tracks performance trends over time. Use when: \"performance\", \"benchmark\", \"page speed\", \"lighthouse\", \"web vitals\", \"bundle size\", \"load time\". (gstack) Voice triggers (speech-to-text aliases): \"speed test\", \"check performance\".",
+    "triggers": [
+      "performance benchmark",
+      "check page speed",
+      "detect performance regression"
+    ],
+    "updatedAt": "2026-05-04T17:52:22.961Z"
+  },
+  {
+    "slug": "benchmark-models",
+    "name": "benchmark-models",
+    "description": "Cross-model benchmark for gstack skills. Runs the same prompt through Claude, GPT (via Codex CLI), and Gemini side-by-side — compares latency, tokens, cost, and optionally quality via LLM judge. Answers \"which model is actually best for this skill?\" with data instead of vibes. Separate from /benchmark, which measures web page performance. Use when: \"benchmark models\", \"compare models\", \"which model is best for X\", \"cross-model comparison\", \"model shootout\". (gstack) Voice triggers (speech-to-text aliases): \"compare models\", \"model shootout\", \"which model is best\".",
+    "triggers": [
+      "cross model benchmark",
+      "compare claude gpt gemini",
+      "benchmark skill across models",
+      "which model should I use"
+    ],
+    "updatedAt": "2026-05-04T17:52:22.961Z"
+  },
+  {
+    "slug": "blog-post",
+    "name": "blog-post",
+    "description": "A long-form article / blog post — masthead, hero image placeholder, article body with figures and pull quotes, author byline, related posts. Use when the brief asks for \"blog\", \"article\", \"post\", \"essay\", or \"case study\".",
+    "triggers": [
+      "blog",
+      "blog post",
+      "article",
+      "essay",
+      "case study",
+      "newsletter",
+      "博客",
+      "文章"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.351Z"
+  },
+  {
+    "slug": "browse",
+    "name": "browse",
+    "description": "Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with elements, verify page state, diff before/after actions, take annotated screenshots, check responsive layouts, test forms and uploads, handle dialogs, and assert element states. ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a user flow, or file a bug with evidence. Use when asked to \"open in browser\", \"test the site\", \"take a screenshot\", or \"dogfood this\". (gstack)",
+    "triggers": [
+      "browse a page",
+      "headless browser",
+      "take page screenshot"
+    ],
+    "updatedAt": "2026-05-04T17:52:22.968Z"
+  },
+  {
+    "slug": "canary",
+    "name": "canary",
+    "description": "Post-deploy canary monitoring. Watches the live app for console errors, performance regressions, and page failures using the browse daemon. Takes periodic screenshots, compares against pre-deploy baselines, and alerts on anomalies. Use when: \"monitor deploy\", \"canary\", \"post-deploy check\", \"watch production\", \"verify deploy\". (gstack)",
+    "triggers": [
+      "monitor after deploy",
+      "canary check",
+      "watch for errors post-deploy"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.025Z"
+  },
+  {
+    "slug": "careful",
+    "name": "careful",
+    "description": "Safety guardrails for destructive commands. Warns before rm -rf, DROP TABLE, force-push, git reset --hard, kubectl delete, and similar destructive operations. User can override each warning. Use when touching prod, debugging live systems, or working in a shared environment. Use when asked to \"be careful\", \"safety mode\", \"prod mode\", or \"careful mode\". (gstack)",
+    "triggers": [
+      "be careful",
+      "warn before destructive",
+      "safety mode"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.025Z"
+  },
+  {
+    "slug": "churn-prevention",
+    "name": "churn-prevention",
+    "description": "When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or implement retention strategies. Also use when the user mentions 'churn,' 'cancel flow,' 'offboarding,' 'save offer,' 'dunning,' 'failed payment recovery,' 'win-back,' 'retention,' 'exit survey,' 'pause subscription,' 'involuntary churn,' 'people keep canceling,' 'churn rate is too high,' 'how do I keep users,' or 'customers are leaving.' Use this whenever someone is losing subscribers or wants to build systems to prevent it. For post-cancel win-back email sequences, see email-sequence. For in-app upgrade paywalls, see paywall-upgrade-cro.",
+    "updatedAt": "2026-05-04T17:52:23.123Z"
+  },
+  {
+    "slug": "cli-creator",
+    "name": "cli-creator",
+    "description": "Build a composable CLI for Codex from API docs, an OpenAPI spec, existing curl examples, an SDK, a web app, an admin tool, or a local script. Use when the user wants Codex to create a command-line tool that can run from any repo, expose composable read/write commands, return stable JSON, manage auth, and pair with a companion skill.",
+    "updatedAt": "2026-05-04T17:52:15.890Z"
+  },
+  {
+    "slug": "codex",
+    "name": "codex",
+    "description": "OpenAI Codex CLI wrapper — three modes. Code review: independent diff review via codex review with pass/fail gate. Challenge: adversarial mode that tries to break your code. Consult: ask codex anything with session continuity for follow-ups. The \"200 IQ autistic developer\" second opinion. Use when asked to \"codex review\", \"codex challenge\", \"ask codex\", \"second opinion\", or \"consult codex\". (gstack) Voice triggers (speech-to-text aliases): \"code x\", \"code ex\", \"get another opinion\".",
+    "triggers": [
+      "codex review",
+      "second opinion",
+      "outside voice challenge"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.025Z"
+  },
+  {
+    "slug": "cold-email",
+    "name": "cold-email",
+    "description": "Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails, prospecting emails, cold email campaigns, sales development emails, or SDR emails. Also use when the user mentions \"cold outreach,\" \"prospecting email,\" \"outbound email,\" \"email to leads,\" \"reach out to prospects,\" \"sales email,\" \"follow-up email sequence,\" \"nobody's replying to my emails,\" or \"how do I write a cold email.\" Covers subject lines, opening lines, body copy, CTAs, personalization, and multi-touch follow-up sequences. For warm/lifecycle email sequences, see email-sequence. For sales collateral beyond emails, see sales-enablement.",
+    "updatedAt": "2026-05-04T17:52:23.123Z"
+  },
+  {
+    "slug": "community-marketing",
+    "name": "community-marketing",
+    "description": "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \"build a community,\" \"community strategy,\" \"Discord community,\" \"Slack community,\" \"community-led growth,\" \"brand advocates,\" \"user community,\" \"forum strategy,\" \"community engagement,\" \"grow our community,\" \"ambassador program,\" \"community flywheel.\"",
+    "updatedAt": "2026-05-04T17:52:23.124Z"
+  },
+  {
+    "slug": "competitor-alternatives",
+    "name": "competitor-alternatives",
+    "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement.",
+    "updatedAt": "2026-05-04T17:52:23.125Z"
+  },
+  {
+    "slug": "competitor-profiling",
+    "name": "competitor-profiling",
+    "description": "When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions 'competitor profile,' 'competitor research,' 'competitor analysis,' 'profile this competitor,' 'analyze competitor,' 'competitive intelligence,' 'competitor deep dive,' 'who are my competitors,' 'competitor landscape,' 'competitor dossier,' 'competitive audit,' or 'research these competitors.' Input is a list of competitor URLs. Output is structured competitor profile markdown files. For creating comparison/alternative pages from profiles, see competitor-alternatives. For sales-specific battle cards, see sales-enablement.",
+    "updatedAt": "2026-05-04T17:52:23.125Z"
+  },
+  {
+    "slug": "content-strategy",
+    "name": "content-strategy",
+    "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \"content strategy,\" \"what should I write about,\" \"content ideas,\" \"blog strategy,\" \"topic clusters,\" \"content planning,\" \"editorial calendar,\" \"content marketing,\" \"content roadmap,\" \"what content should I create,\" \"blog topics,\" \"content pillars,\" or \"I don't know what to write.\" Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social-content.",
+    "updatedAt": "2026-05-04T17:52:23.126Z"
+  },
+  {
+    "slug": "context-restore",
+    "name": "context-restore",
+    "description": "Restore working context saved earlier by /context-save. Loads the most recent saved state (across all branches by default) so you can pick up where you left off — even across Conductor workspace handoffs. Use when asked to \"resume\", \"restore context\", \"where was I\", or \"pick up where I left off\". Pair with /context-save. Formerly /checkpoint resume — renamed because Claude Code treats /checkpoint as a native rewind alias in current environments. (gstack)",
+    "triggers": [
+      "resume where i left off",
+      "restore context",
+      "where was i",
+      "pick up where i left off",
+      "context restore"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.026Z"
+  },
+  {
+    "slug": "context-save",
+    "name": "context-save",
+    "description": "Save working context. Captures git state, decisions made, and remaining work so any future session can pick up without losing a beat. Use when asked to \"save progress\", \"save state\", \"context save\", or \"save my work\". Pair with /context-restore to resume later. Formerly /checkpoint — renamed because Claude Code treats /checkpoint as a native rewind alias in current environments, which was shadowing this skill. (gstack)",
+    "triggers": [
+      "save progress",
+      "save state",
+      "save my work",
+      "context save"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.027Z"
+  },
+  {
+    "slug": "copy-editing",
+    "name": "copy-editing",
+    "description": "When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' 'copy sweep,' 'tighten this up,' 'this reads awkwardly,' 'clean up this text,' 'too wordy,' 'sharpen the messaging,' 'refresh this content,' 'update this page,' 'this content is outdated,' or 'content audit.' Use this when the user already has copy and wants it improved or refreshed rather than rewritten from scratch. For writing new copy, see copywriting.",
+    "updatedAt": "2026-05-04T17:52:23.127Z"
+  },
+  {
+    "slug": "copywriting",
+    "name": "copywriting",
+    "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \"write copy for,\" \"improve this copy,\" \"rewrite this page,\" \"marketing copy,\" \"headline help,\" \"CTA copy,\" \"value proposition,\" \"tagline,\" \"subheadline,\" \"hero section copy,\" \"above the fold,\" \"this copy is weak,\" \"make this more compelling,\" or \"help me describe my product.\" Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see email-sequence. For popup copy, see popup-cro. For editing existing copy, see copy-editing.",
+    "updatedAt": "2026-05-04T17:52:23.127Z"
+  },
+  {
+    "slug": "critique",
+    "name": "critique",
+    "description": "Run a 5-dimension expert design review on any HTML artifact in the project — Philosophy / Visual hierarchy / Detail / Functionality / Innovation, each scored 0–10. Outputs a single self-contained HTML report with a radar chart, evidence-backed scores, and three lists: Keep / Fix / Quick-wins. Use when the brief asks for a \"design review\", \"design critique\", \"5 维度评审\", \"design audit\", or \"what's wrong with my design\".",
+    "triggers": [
+      "critique",
+      "design review",
+      "design audit",
+      "5 维度评审",
+      "5-dim review",
+      "audit my design",
+      "review my deck",
+      "review my landing page",
+      "评审",
+      "复盘"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.351Z"
+  },
+  {
+    "slug": "cso",
+    "name": "cso",
+    "description": "Chief Security Officer mode. Infrastructure-first security audit: secrets archaeology, dependency supply chain, CI/CD pipeline security, LLM/AI security, skill supply chain scanning, plus OWASP Top 10, STRIDE threat modeling, and active verification. Two modes: daily (zero-noise, 8/10 confidence gate) and comprehensive (monthly deep scan, 2/10 bar). Trend tracking across audit runs. Use when: \"security audit\", \"threat model\", \"pentest review\", \"OWASP\", \"CSO review\". (gstack) Voice triggers (speech-to-text aliases): \"see-so\", \"see so\", \"security review\", \"security check\", \"vulnerability scan\", \"run security\".",
+    "triggers": [
+      "security audit",
+      "check for vulnerabilities",
+      "owasp review"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.028Z"
+  },
+  {
+    "slug": "customer-research",
+    "name": "customer-research",
+    "description": "When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions \"customer research,\" \"ICP research,\" \"talk to customers,\" \"analyze transcripts,\" \"customer interviews,\" \"survey analysis,\" \"support ticket analysis,\" \"voice of customer,\" \"VOC,\" \"build personas,\" \"customer personas,\" \"jobs to be done,\" \"JTBD,\" \"what do customers say,\" \"what are customers struggling with,\" \"Reddit mining,\" \"G2 reviews,\" \"review mining,\" \"digital watering holes,\" \"community research,\" \"forum research,\" \"competitor reviews,\" \"customer sentiment,\" or \"find out why customers churn/convert/buy.\" Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see page-cro.",
+    "updatedAt": "2026-05-04T17:52:23.129Z"
+  },
+  {
+    "slug": "dashboard",
+    "name": "dashboard",
+    "description": "Admin / analytics dashboard in a single HTML file. Fixed left sidebar, top bar with user/search, main grid of KPI cards and one or two charts. Use when the brief asks for a \"dashboard\", \"admin\", \"analytics\", or \"control panel\" screen.",
+    "triggers": [
+      "dashboard",
+      "admin panel",
+      "analytics",
+      "control panel",
+      "后台",
+      "管理后台"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.351Z"
+  },
+  {
+    "slug": "dating-web",
+    "name": "dating-web",
+    "description": "A consumer-feeling dating / matchmaking dashboard — left rail navigation, ticker bar of community signals, headline KPIs, a 30-day mutual-matches bar chart, and a match-rate trend block. Editorial typography, restrained accent. Use when the brief asks for a \"dating site\", \"matchmaking\", \"community dashboard\", \"social network dashboard\", or any consumer product where the data is the story.",
+    "triggers": [
+      "dating app",
+      "dating site",
+      "matchmaking",
+      "social dashboard",
+      "community dashboard",
+      "consumer dashboard",
+      "约会应用",
+      "婚恋"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.352Z"
+  },
+  {
+    "slug": "design-brief",
+    "name": "design-brief",
+    "description": "Parse a structured design brief written in I-Lang protocol format into a concrete design spec. Eliminates ambiguity from vague requests like \"make it professional\" by requiring explicit dimensions: palette, typography, layout, mood, density, and constraints. Trigger keywords: \"design brief\", \"create a design brief\", \"ilang brief\", \"structured brief\".",
+    "triggers": [
+      "design brief",
+      "create a design brief",
+      "ilang brief",
+      "structured brief"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.352Z"
+  },
+  {
+    "slug": "design-consultation",
+    "name": "design-consultation",
+    "description": "Design consultation: understands your product, researches the landscape, proposes a complete design system (aesthetic, typography, color, layout, spacing, motion), and generates font+color preview pages. Creates DESIGN.md as your project's design source of truth. For existing sites, use /plan-design-review to infer the system instead. Use when asked to \"design system\", \"brand guidelines\", or \"create DESIGN.md\". Proactively suggest when starting a new project's UI with no existing design system or DESIGN.md. (gstack)",
+    "triggers": [
+      "design system",
+      "create a brand",
+      "design from scratch"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.028Z"
+  },
+  {
+    "slug": "design-html",
+    "name": "design-html",
+    "description": "Design finalization: generates production-quality Pretext-native HTML/CSS. Works with approved mockups from /design-shotgun, CEO plans from /plan-ceo-review, design review context from /plan-design-review, or from scratch with a user description. Text actually reflows, heights are computed, layouts are dynamic. 30KB overhead, zero deps. Smart API routing: picks the right Pretext patterns for each design type. Use when: \"finalize this design\", \"turn this into HTML\", \"build me a page\", \"implement this design\", or after any planning skill. Proactively suggest when user has approved a design or has a plan ready. (gstack) Voice triggers (speech-to-text aliases): \"build the design\", \"code the mockup\", \"make it real\".",
+    "triggers": [
+      "build the design",
+      "code the mockup",
+      "make design real"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.029Z"
+  },
+  {
+    "slug": "design-review",
+    "name": "design-review",
+    "description": "Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them. Iteratively fixes issues in source code, committing each fix atomically and re-verifying with before/after screenshots. For plan-mode design review (before implementation), use /plan-design-review. Use when asked to \"audit the design\", \"visual QA\", \"check if it looks good\", or \"design polish\". Proactively suggest when the user mentions visual inconsistencies or wants to polish the look of a live site. (gstack)",
+    "triggers": [
+      "visual design audit",
+      "design qa",
+      "fix design issues"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.029Z"
+  },
+  {
+    "slug": "design-shotgun",
+    "name": "design-shotgun",
+    "description": "Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate. Standalone design exploration you can run anytime. Use when: \"explore designs\", \"show me options\", \"design variants\", \"visual brainstorm\", or \"I don't like how this looks\". Proactively suggest when the user describes a UI feature but hasn't seen what it could look like. (gstack)",
+    "triggers": [
+      "explore design variants",
+      "show me design options",
+      "visual design brainstorm"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.029Z"
+  },
+  {
+    "slug": "devex-review",
+    "name": "devex-review",
+    "description": "Live developer experience audit. Uses the browse tool to actually TEST the developer experience: navigates docs, tries the getting started flow, times TTHW, screenshots error messages, evaluates CLI help text. Produces a DX scorecard with evidence. Compares against /plan-devex-review scores if they exist (the boomerang: plan said 3 minutes, reality says 8). Use when asked to \"test the DX\", \"DX audit\", \"developer experience test\", or \"try the onboarding\". Proactively suggest after shipping a developer-facing feature. (gstack) Voice triggers (speech-to-text aliases): \"dx audit\", \"test the developer experience\", \"try the onboarding\", \"developer experience test\".",
+    "triggers": [
+      "live dx audit",
+      "test developer experience",
+      "measure onboarding time"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.032Z"
+  },
+  {
+    "slug": "digital-eguide",
+    "name": "digital-eguide",
+    "description": "A two-spread digital e-guide preview — page 1 is a cover (display title, author, \"What's inside\" stats, table of contents teaser); page 2 is a spread (lesson body with pull-quote and a step list). Lifestyle / creator brand tone. Use when the brief asks for an \"e-guide\", \"digital guide\", \"lookbook\", \"lead magnet\", \"creator guide\", \"playbook\", \"PDF guide\", or \"电子指南\".",
+    "triggers": [
+      "e-guide",
+      "digital guide",
+      "lead magnet",
+      "lookbook",
+      "creator guide",
+      "playbook",
+      "pdf guide",
+      "ebook",
+      "电子指南",
+      "电子书"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.352Z"
+  },
+  {
+    "slug": "directory-submissions",
+    "name": "directory-submissions",
+    "description": "When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for backlinks, domain rating, and discovery. Also use when the user mentions \"directory submissions,\" \"submit to directories,\" \"backlinks from directories,\" \"list my product,\" \"submit to Product Hunt,\" \"BetaList,\" \"TAAFT,\" \"Futurepedia,\" \"G2 listing,\" \"Capterra listing,\" \"AlternativeTo,\" \"SaaSHub,\" \"AI directories,\" \"MCP registry,\" \"agent directory,\" \"dofollow backlinks,\" \"launch directories,\" or \"directory tracker.\" Use this whenever someone is planning the directory layer of a product launch or an ongoing backlink campaign. For the broader launch moment, see launch-strategy. For programmatic SEO pages that should live behind these backlinks, see programmatic-seo. For AI citation optimization, see ai-seo.",
+    "updatedAt": "2026-05-04T17:52:23.130Z"
+  },
+  {
+    "slug": "docs-page",
+    "name": "docs-page",
+    "description": "A documentation page — left nav, scrollable article body, right-rail table of contents. Use when the brief mentions \"docs\", \"documentation\", \"guide\", \"API reference\", or \"tutorial\".",
+    "triggers": [
+      "docs",
+      "documentation",
+      "guide",
+      "tutorial",
+      "api reference",
+      "文档"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.353Z"
+  },
+  {
+    "slug": "document-release",
+    "name": "document-release",
+    "description": "Post-ship documentation update. Reads all project docs, cross-references the diff, updates README/ARCHITECTURE/CONTRIBUTING/CLAUDE.md to match what shipped, polishes CHANGELOG voice, cleans up TODOS, and optionally bumps VERSION. Use when asked to \"update the docs\", \"sync documentation\", or \"post-ship docs\". Proactively suggest after a PR is merged or code is shipped. (gstack)",
+    "triggers": [
+      "update docs after ship",
+      "document what changed",
+      "post-ship docs"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.037Z"
+  },
+  {
+    "slug": "docx",
+    "name": "docx",
+    "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
+    "updatedAt": "2026-05-04T17:52:15.891Z"
+  },
+  {
+    "slug": "email-marketing",
+    "name": "email-marketing",
+    "description": "A brand product-launch email — masthead with wordmark, hero image block, headline lockup with skewed-italic accent, body copy, primary CTA, and a specifications grid. Pure HTML email layout (centered single column, table fallback). Use when the brief asks for an \"email\", \"newsletter blast\", \"MJML\", \"product launch email\", or \"email template\".",
+    "triggers": [
+      "email",
+      "email template",
+      "newsletter",
+      "email blast",
+      "product launch email",
+      "mjml",
+      "邮件营销",
+      "邮件模板"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.353Z"
+  },
+  {
+    "slug": "email-sequence",
+    "name": "email-sequence",
+    "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" \"lifecycle emails,\" \"trigger-based emails,\" \"email funnel,\" \"email workflow,\" \"what emails should I send,\" \"welcome series,\" or \"email cadence.\" Use this for any multi-email automated flow. For cold outreach emails, see cold-email. For in-app onboarding, see onboarding-cro.",
+    "updatedAt": "2026-05-04T17:52:23.131Z"
+  },
+  {
+    "slug": "eng-runbook",
+    "name": "eng-runbook",
+    "description": "An engineering runbook — service overview, alerts table, dashboards links, common procedures with copy-pasteable commands, on-call rotation, and an incident-response checklist. Use when the brief mentions \"runbook\", \"ops doc\", \"on-call guide\", \"SRE doc\", or \"运维手册\".",
+    "triggers": [
+      "runbook",
+      "ops doc",
+      "on-call",
+      "sre doc",
+      "service runbook",
+      "运维手册"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.353Z"
+  },
+  {
+    "slug": "finance-report",
+    "name": "finance-report",
+    "description": "Quarterly / monthly financial report — masthead with KPIs, revenue and burn charts, P&L summary table, top-line highlights, and an outlook paragraph. Use when the brief mentions \"financial report\", \"Q3 report\", \"MRR review\", \"P&L\", or \"财报\".",
+    "triggers": [
+      "financial report",
+      "finance report",
+      "quarterly report",
+      "p&l",
+      "mrr review",
+      "财报",
+      "财务报告"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.354Z"
+  },
+  {
+    "slug": "form-cro",
+    "name": "form-cro",
+    "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" \"contact form,\" \"nobody fills out our form,\" \"form abandonment,\" \"too many fields,\" \"demo request form,\" or \"lead form isn't converting.\" Use this for any non-signup form that captures information. For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
+    "updatedAt": "2026-05-04T17:52:23.131Z"
+  },
+  {
+    "slug": "free-tool-strategy",
+    "name": "free-tool-strategy",
+    "description": "When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions \"engineering as marketing,\" \"free tool,\" \"marketing tool,\" \"calculator,\" \"generator,\" \"interactive tool,\" \"lead gen tool,\" \"build a tool for leads,\" \"free resource,\" \"ROI calculator,\" \"grader tool,\" \"audit tool,\" \"should I build a free tool,\" or \"tools for lead gen.\" Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.",
+    "updatedAt": "2026-05-04T17:52:23.132Z"
+  },
+  {
+    "slug": "freeze",
+    "name": "freeze",
+    "description": "Restrict file edits to a specific directory for the session. Blocks Edit and Write outside the allowed path. Use when debugging to prevent accidentally \"fixing\" unrelated code, or when you want to scope changes to one module. Use when asked to \"freeze\", \"restrict edits\", \"only edit this folder\", or \"lock down edits\". (gstack)",
+    "triggers": [
+      "freeze edits to directory",
+      "lock editing scope",
+      "restrict file changes"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.039Z"
+  },
+  {
+    "slug": "frontend-design",
+    "name": "frontend-design",
+    "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+    "updatedAt": "2026-05-04T17:52:15.909Z"
+  },
+  {
+    "slug": "frontend-slides",
+    "name": "frontend-slides",
+    "description": "Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.",
+    "updatedAt": "2026-05-04T17:52:15.910Z"
+  },
+  {
+    "slug": "gamified-app",
+    "name": "gamified-app",
+    "description": "A multi-frame gamified mobile-app prototype — three phone frames on a dark showcase stage. Frame 1: cover / poster, Frame 2: today's quests with XP ribbons and a level bar, Frame 3: quest detail. Vivid quest tiles, level ribbon, bottom tab bar. Use when the brief asks for a \"gamified app\", \"habit tracker\", \"RPG-style life app\", \"level-up app\", \"daily quests\", \"XP / streak app\", or \"ELI5-style explainer app\".",
+    "triggers": [
+      "gamified app",
+      "habit tracker",
+      "rpg app",
+      "level up app",
+      "daily quests",
+      "xp app",
+      "streak app",
+      "life management app",
+      "游戏化",
+      "习惯打卡"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.354Z"
+  },
+  {
+    "slug": "gh-address-comments",
+    "name": "gh-address-comments",
+    "description": "Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and prompt the user to authenticate if not logged in.",
+    "updatedAt": "2026-05-04T17:52:15.915Z"
+  },
+  {
+    "slug": "gh-fix-ci",
+    "name": "gh-fix-ci",
+    "description": "Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and logs, summarize failure context, draft a fix plan, and implement only after explicit approval. Treat external providers (for example Buildkite) as out of scope and report only the details URL.",
+    "updatedAt": "2026-05-04T17:52:15.916Z"
+  },
+  {
+    "slug": "gstack",
+    "name": "gstack",
+    "description": "Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with elements, verify state, diff before/after, take annotated screenshots, test responsive layouts, forms, uploads, dialogs, and capture bug evidence. Use when asked to open or test a site, verify a deployment, dogfood a user flow, or file a bug with screenshots. (gstack)",
+    "triggers": [
+      "browse this page",
+      "take a screenshot",
+      "navigate to url",
+      "inspect the page"
+    ],
+    "updatedAt": "2026-05-04T17:52:22.959Z"
+  },
+  {
+    "slug": "gstack-openclaw-ceo-review",
+    "name": "gstack-openclaw-ceo-review",
+    "description": "Use when asked to review a plan, challenge a proposal, run a CEO review, poke holes in an approach, think bigger about scope, or decide whether to expand or reduce the plan.",
+    "updatedAt": "2026-05-04T17:52:23.048Z"
+  },
+  {
+    "slug": "gstack-openclaw-investigate",
+    "name": "gstack-openclaw-investigate",
+    "description": "Use when asked to debug, fix a bug, investigate an error, or do root cause analysis, and when users report errors, stack traces, unexpected behavior, or say something stopped working.",
+    "updatedAt": "2026-05-04T17:52:23.048Z"
+  },
+  {
+    "slug": "gstack-openclaw-office-hours",
+    "name": "gstack-openclaw-office-hours",
+    "description": "Use when asked to brainstorm, evaluate whether an idea is worth building, run office hours, or think through a new product idea or design direction before any code is written.",
+    "updatedAt": "2026-05-04T17:52:23.049Z"
+  },
+  {
+    "slug": "gstack-openclaw-retro",
+    "name": "gstack-openclaw-retro",
+    "description": "Weekly engineering retrospective. Analyzes commit history, work patterns, and code quality metrics with persistent history and trend tracking. Team-aware with per-person contributions, praise, and growth areas. Use when asked for weekly retro, what shipped this week, or engineering retrospective.",
+    "updatedAt": "2026-05-04T17:52:23.049Z"
+  },
+  {
+    "slug": "gstack-upgrade",
+    "name": "gstack-upgrade",
+    "description": "Upgrade gstack to the latest version. Detects global vs vendored install, runs the upgrade, and shows what's new. Use when asked to \"upgrade gstack\", \"update gstack\", or \"get latest version\". Voice triggers (speech-to-text aliases): \"upgrade the tools\", \"update the tools\", \"gee stack upgrade\", \"g stack upgrade\".",
+    "triggers": [
+      "upgrade gstack",
+      "update gstack version",
+      "get latest gstack"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.040Z"
+  },
+  {
+    "slug": "guard",
+    "name": "guard",
+    "description": "Full safety mode: destructive command warnings + directory-scoped edits. Combines /careful (warns before rm -rf, DROP TABLE, force-push, etc.) with /freeze (blocks edits outside a specified directory). Use for maximum safety when touching prod or debugging live systems. Use when asked to \"guard mode\", \"full safety\", \"lock it down\", or \"maximum safety\". (gstack)",
+    "triggers": [
+      "full safety mode",
+      "guard against mistakes",
+      "maximum safety"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.041Z"
+  },
+  {
+    "slug": "hackernews-frontpage",
+    "name": "hackernews-frontpage",
+    "description": "Scrape the Hacker News front page (titles, points, comment counts).",
+    "triggers": [
+      "scrape hacker news frontpage",
+      "scrape hn frontpage",
+      "get hn top stories",
+      "latest hacker news stories"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.024Z"
+  },
+  {
+    "slug": "hatch-pet",
+    "name": "hatch-pet",
+    "description": "Create, repair, validate, preview, and package Codex-compatible animated pet spritesheets from character art, screenshots, generated images, or visual references. Use when a user wants to hatch a Codex pet, create a custom animated pet, or build a built-in pet asset with an 8x9 atlas, transparent unused cells, row-by-row animation prompts, QA contact sheets, preview videos, and pet.json packaging. This skill composes the installed $imagegen system skill for visual generation and uses bundled scripts for deterministic spritesheet assembly.",
+    "triggers": [
+      "hatch a pet",
+      "hatch pet",
+      "codex pet",
+      "spritesheet pet",
+      "animated pet",
+      "孵化宠物",
+      "电子宠物"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.356Z"
+  },
+  {
+    "slug": "health",
+    "name": "health",
+    "description": "Code quality dashboard. Wraps existing project tools (type checker, linter, test runner, dead code detector, shell linter), computes a weighted composite 0-10 score, and tracks trends over time. Use when: \"health check\", \"code quality\", \"how healthy is the codebase\", \"run all checks\", \"quality score\". (gstack)",
+    "triggers": [
+      "code health check",
+      "quality dashboard",
+      "how healthy is codebase"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.041Z"
+  },
+  {
+    "slug": "hr-onboarding",
+    "name": "hr-onboarding",
+    "description": "A new-hire onboarding plan as a single page — first week schedule, buddy + manager intro, learning track, equipment checklist, and \"you're set when…\" outcomes. Use when the brief mentions \"onboarding\", \"new hire\", \"first week plan\", or \"入职\".",
+    "triggers": [
+      "onboarding",
+      "new hire",
+      "first week",
+      "入职",
+      "新员工"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.359Z"
+  },
+  {
+    "slug": "html-ppt",
+    "name": "html-ppt",
+    "description": "HTML PPT Studio — author professional static HTML presentations in many styles, layouts, and animations, all driven by templates. Use when the user asks for a presentation, PPT, slides, keynote, deck, slideshow, \"幻灯片\", \"演讲稿\", \"做一份 PPT\", \"做一份 slides\", a reveal-style HTML deck, a 小红书 图文, or any kind of multi-slide pitch/report/sharing document that should look tasteful and be usable with keyboard navigation. Triggers include keywords like \"presentation\", \"ppt\", \"slides\", \"deck\", \"keynote\", \"reveal\", \"slideshow\", \"幻灯片\", \"演讲稿\", \"分享稿\", \"小红书图文\", \"talk slides\", \"pitch deck\", \"tech sharing\", \"technical presentation\".",
+    "triggers": [
+      "ppt",
+      "deck",
+      "slides",
+      "presentation",
+      "keynote",
+      "reveal",
+      "slideshow",
+      "幻灯片",
+      "演讲稿",
+      "分享稿",
+      "talk slides",
+      "pitch deck",
+      "tech sharing",
+      "technical presentation"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.366Z"
+  },
+  {
+    "slug": "html-ppt-course-module",
+    "name": "html-ppt-course-module",
+    "description": "Online-course / workshop module deck — warm paper background + Playfair serif, persistent left sidebar of learning objectives, MCQ self-check page. Use for teaching modules, training materials, workshop slides.",
+    "triggers": [
+      "course module",
+      "course slides",
+      "workshop",
+      "training deck",
+      "lesson",
+      "教学",
+      "课件"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.360Z"
+  },
+  {
+    "slug": "html-ppt-dir-key-nav-minimal",
+    "name": "html-ppt-dir-key-nav-minimal",
+    "description": "8 页极简方向键 keynote — 每页一个独立单色背景（靛 / 奶 / 绛 / 翠 / 灰 / 紫 / 白 / 炭），各自配色，160px display 标题 + 4px 短粗 accent 线分隔、箭头 → 前缀的 Mono 列表、左下 ← → kbd 提示 + 右下页码、巨大呼吸留白。适合\"有话要说但没什么可看\"的 keynote、launch、公开演讲。",
+    "triggers": [
+      "minimal keynote",
+      "极简",
+      "mono color",
+      "one idea per slide",
+      "public talk",
+      "launch keynote"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.360Z"
+  },
+  {
+    "slug": "html-ppt-graphify-dark-graph",
+    "name": "html-ppt-graphify-dark-graph",
+    "description": "暗底知识图谱 deck —",
+    "triggers": [
+      "知识图谱",
+      "graph deck",
+      "dark graph",
+      "dev tool launch",
+      "cli launch",
+      "data viz launch"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.360Z"
+  },
+  {
+    "slug": "html-ppt-hermes-cyber-terminal",
+    "name": "html-ppt-hermes-cyber-terminal",
+    "description": "暗终端 honest-review deck —",
+    "triggers": [
+      "terminal review",
+      "cli review",
+      "agent review",
+      "honest review",
+      "dev tool review",
+      "测评"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.361Z"
+  },
+  {
+    "slug": "html-ppt-knowledge-arch-blueprint",
+    "name": "html-ppt-knowledge-arch-blueprint",
+    "description": "奶油蓝图架构 deck — 奶油纸",
+    "triggers": [
+      "architecture",
+      "blueprint",
+      "system design",
+      "架构图",
+      "data flow",
+      "engineering whitepaper"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.361Z"
+  },
+  {
+    "slug": "html-ppt-obsidian-claude-gradient",
+    "name": "html-ppt-obsidian-claude-gradient",
+    "description": "GitHub 暗紫渐变 deck — GitHub-dark",
+    "triggers": [
+      "github dark",
+      "developer tutorial",
+      "mcp tutorial",
+      "agent tutorial",
+      "dev workflow",
+      "changelog deck"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.361Z"
+  },
+  {
+    "slug": "html-ppt-pitch-deck",
+    "name": "html-ppt-pitch-deck",
+    "description": "Investor-ready 10-slide HTML pitch deck — white + blue→purple gradient hero, big numbers, traction bar chart, $4.5M-style ask page. Use when the user wants a fundraising deck, seed-round pitch, or VC meeting slides.",
+    "triggers": [
+      "pitch deck",
+      "pitch",
+      "fundraising",
+      "seed round",
+      "investor deck",
+      "vc deck",
+      "pitch slides"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.362Z"
+  },
+  {
+    "slug": "html-ppt-presenter-mode-reveal",
+    "name": "html-ppt-presenter-mode",
+    "description": "演讲者模式专用 deck — tokyo-night 默认主题，5 套主题 T 键切换，每页带 150-300 字逐字稿示例（<aside class=\"notes\">），按 S 打开 popup（CURRENT / NEXT / SCRIPT / TIMER 四张磁吸卡片）。用于技术分享、公开演讲、课程讲解，怕忘词或要提词器的场景。",
+    "triggers": [
+      "presenter mode",
+      "演讲者模式",
+      "逐字稿",
+      "speaker notes",
+      "提词器",
+      "presenter view",
+      "演讲"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.362Z"
+  },
+  {
+    "slug": "html-ppt-product-launch",
+    "name": "html-ppt-product-launch",
+    "description": "Launch keynote deck — dark hero + light content, warm orange→peach accent, feature cards, pricing tiers, CTA. Use when announcing a product, launching a feature, or doing a keynote-style reveal.",
+    "triggers": [
+      "product launch",
+      "keynote",
+      "launch deck",
+      "feature reveal",
+      "launch slides",
+      "发布会"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.362Z"
+  },
+  {
+    "slug": "html-ppt-taste-brutalist",
+    "name": "html-ppt-taste-brutalist",
+    "description": "16:9 HTML deck in tactical-telemetry / CRT-terminal taste. Deactivated-CRT charcoal slides, white-phosphor monospace, hazard-red accent, scanline overlay, ASCII syntax, density over decoration. Distilled from Leonxlnx/taste-skill `brutalist-skill` (Tactical Telemetry mode).",
+    "updatedAt": "2026-05-04T17:52:23.363Z"
+  },
+  {
+    "slug": "html-ppt-taste-editorial",
+    "name": "html-ppt-taste-editorial",
+    "description": "16:9 HTML deck in editorial-minimalist taste. Warm cream slides, serif display + grotesque body, hairline rules, monospace meta, generous macro-whitespace, one accent. Distilled from Leonxlnx/taste-skill `minimalist-skill`.",
+    "updatedAt": "2026-05-04T17:52:23.363Z"
+  },
+  {
+    "slug": "html-ppt-tech-sharing",
+    "name": "html-ppt-tech-sharing",
+    "description": "Conference / internal tech-talk deck — GitHub-dark, JetBrains Mono, terminal code blocks, agenda + Q&A pages. Use for engineering presentations, internal sharing sessions, conference talks, and code-heavy walkthroughs.",
+    "triggers": [
+      "tech sharing",
+      "tech talk",
+      "技术分享",
+      "engineering talk",
+      "conference talk",
+      "dev talk"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.363Z"
+  },
+  {
+    "slug": "html-ppt-testing-safety-alert",
+    "name": "html-ppt-testing-safety-alert",
+    "description": "红琥珀警示 deck — 顶/底 45° 红黑 hazard 条纹、红色删除线否定标题、L1/L2/L3 绿/琥珀/红 tier 卡片、圆点状态 alert box、policy-yaml 代码块（红左边框 + bad 关键词高亮）、红绿 checklist、Q1 事故堆叠柱状图。适合安全 / 风险 / 事故复盘 / 红队 / 上线前 AI 评审 / policy-as-code。",
+    "triggers": [
+      "safety alert",
+      "incident",
+      "red team",
+      "risk review",
+      "事故复盘",
+      "安全评审",
+      "policy as code"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.364Z"
+  },
+  {
+    "slug": "html-ppt-weekly-report",
+    "name": "html-ppt-weekly-report",
+    "description": "Team weekly / status-update deck — corporate clarity, 8-cell KPI grid, shipped list, 8-week bar chart, next-week table. Use for 周报, business reviews, team status updates, and exec dashboards.",
+    "triggers": [
+      "weekly report",
+      "周报",
+      "status update",
+      "team report",
+      "business review",
+      "wbr"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.364Z"
+  },
+  {
+    "slug": "html-ppt-xhs-pastel-card",
+    "name": "html-ppt-xhs-pastel-card",
+    "description": "柔和马卡龙慢生活 deck — 奶油",
+    "triggers": [
+      "pastel",
+      "macaron",
+      "lifestyle",
+      "slow living",
+      "慢生活",
+      "生活方式",
+      "个人成长"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.364Z"
+  },
+  {
+    "slug": "html-ppt-xhs-post",
+    "name": "html-ppt-xhs-post",
+    "description": "小红书 / Instagram 风 9 页 3:4 竖版图文（810×1080）— 暖色 pastel、虚线 sticker 卡片、底部页码点点。用于发小红书图文、Instagram carousel、品牌种草内容。",
+    "triggers": [
+      "小红书",
+      "xhs",
+      "xhs post",
+      "xiaohongshu",
+      "图文",
+      "instagram carousel",
+      "种草"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.364Z"
+  },
+  {
+    "slug": "html-ppt-xhs-white-editorial",
+    "name": "html-ppt-xhs-white-editorial",
+    "description": "白底杂志风 deck — 纯白背景 + 顶部 10 色彩虹 bar、80-110px display 标题、紫→蓝→绿→橙→粉渐变文字、马卡龙软卡片组（粉/紫/蓝/绿/橙）、黑底白字 .focus pill、引用大块。同时适合发小红书图文 + 横版 PPT 双用。",
+    "triggers": [
+      "白底杂志",
+      "杂志风",
+      "xhs editorial",
+      "white editorial",
+      "小红书白底",
+      "editorial deck"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.365Z"
+  },
+  {
+    "slug": "hyperframes",
+    "name": "hyperframes",
+    "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For CLI commands (init, lint, preview, render, transcribe, tts) see the hyperframes-cli skill.",
+    "triggers": [
+      "hyperframes",
+      "html video",
+      "video composition",
+      "interactive video",
+      "captions",
+      "tts video",
+      "kinetic typography"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.412Z"
+  },
+  {
+    "slug": "image",
+    "name": "image",
+    "description": "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video.",
+    "updatedAt": "2026-05-04T17:52:23.132Z"
+  },
+  {
+    "slug": "image-poster",
+    "name": "image-poster",
+    "description": "Single-image generation skill for posters, key art, and editorial illustrations. Defaults to gpt-image-2 but is provider-agnostic — the same workflow drives Flux, Imagen, or Midjourney via the active upstream tooling. Output is one or more PNG/JPEG files saved to the project folder.",
+    "triggers": [
+      "poster",
+      "key art",
+      "illustration",
+      "image",
+      "cover art",
+      "海报",
+      "插画"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.416Z"
+  },
+  {
+    "slug": "investigate",
+    "name": "investigate",
+    "description": "Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to \"debug this\", \"fix this bug\", \"why is this broken\", \"investigate this error\", or \"root cause analysis\". Proactively invoke this skill (do NOT debug directly) when the user reports errors, 500 errors, stack traces, unexpected behavior, \"it was working yesterday\", or is troubleshooting why something stopped working. (gstack)",
+    "triggers": [
+      "debug this",
+      "fix this bug",
+      "why is this broken",
+      "root cause analysis",
+      "investigate this error"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.042Z"
+  },
+  {
+    "slug": "invoice",
+    "name": "invoice",
+    "description": "A printable invoice page — sender + recipient block, line items table, tax breakdown, totals, and payment instructions. Use when the brief mentions \"invoice\", \"bill\", \"billing statement\", or \"发票\".",
+    "triggers": [
+      "invoice",
+      "bill",
+      "billing statement",
+      "发票",
+      "账单"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.416Z"
+  },
+  {
+    "slug": "jupyter-notebook",
+    "name": "jupyter-notebook",
+    "description": "Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`) for experiments, explorations, or tutorials; prefer the bundled templates and run the helper script `new_notebook.py` to generate a clean starting notebook.",
+    "updatedAt": "2026-05-04T17:52:15.918Z"
+  },
+  {
+    "slug": "kanban-board",
+    "name": "kanban-board",
+    "description": "Kanban / task board with columns (To do / In progress / In review / Done), draggable-looking cards, assignee avatars, swimlanes, and a top filter bar. Use when the brief mentions \"kanban\", \"task board\", \"sprint board\", \"trello\", \"看板\".",
+    "triggers": [
+      "kanban",
+      "task board",
+      "sprint board",
+      "trello",
+      "jira board",
+      "看板"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.417Z"
+  },
+  {
+    "slug": "land-and-deploy",
+    "name": "land-and-deploy",
+    "description": "Land and deploy workflow. Merges the PR, waits for CI and deploy, verifies production health via canary checks. Takes over after /ship creates the PR. Use when: \"merge\", \"land\", \"deploy\", \"merge and verify\", \"land it\", \"ship it to production\". (gstack)",
+    "triggers": [
+      "merge and deploy",
+      "land the pr",
+      "ship to production"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.043Z"
+  },
+  {
+    "slug": "landing-report",
+    "name": "landing-report",
+    "description": "Read-only queue dashboard for workspace-aware ship. Shows which VERSION slots are currently claimed by open PRs, which sibling Conductor workspaces have WIP work likely to ship soon, and what slot /ship would pick next. No mutations — just a snapshot. Use when asked to \"landing report\", \"what's in the queue\", \"show me open PRs\", or \"which version do I claim next\". (gstack)",
+    "triggers": [
+      "landing report",
+      "version queue",
+      "ship queue",
+      "what version comes next",
+      "show open PR versions"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.043Z"
+  },
+  {
+    "slug": "launch-strategy",
+    "name": "launch-strategy",
+    "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas.",
+    "updatedAt": "2026-05-04T17:52:23.133Z"
+  },
+  {
+    "slug": "lead-magnets",
+    "name": "lead-magnets",
+    "description": "When the user wants to create, plan, or optimize a lead magnet for email capture or lead generation. Also use when the user mentions \"lead magnet,\" \"gated content,\" \"content upgrade,\" \"downloadable,\" \"ebook,\" \"cheat sheet,\" \"checklist,\" \"template download,\" \"opt-in,\" \"freebie,\" \"PDF download,\" \"resource library,\" \"content offer,\" \"email capture content,\" \"Notion template,\" \"spreadsheet template,\" or \"what should I give away for emails.\" Use this for planning what to create and how to distribute it. For interactive tools as lead magnets, see free-tool-strategy. For writing the actual content, see copywriting. For the email sequence after capture, see email-sequence.",
+    "updatedAt": "2026-05-04T17:52:23.133Z"
+  },
+  {
+    "slug": "learn",
+    "name": "learn",
+    "description": "Manage project learnings. Review, search, prune, and export what gstack has learned across sessions. Use when asked to \"what have we learned\", \"show learnings\", \"prune stale learnings\", or \"export learnings\". Proactively suggest when the user asks about past patterns or wonders \"didn't we fix this before?\"",
+    "triggers": [
+      "show learnings",
+      "what have we learned",
+      "manage project learnings"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.043Z"
+  },
+  {
+    "slug": "magazine-poster",
+    "name": "magazine-poster",
+    "description": "An editorial-style poster — newsprint paper, dateline, oversized serif headline with a struck-through word and italic accent, a 2-column body block, and 6 numbered sections with annotated pull-quote captions. Reads like a Sunday-paper full-page essay or a thoughtful launch poster. Use when the brief asks for \"magazine poster\", \"editorial poster\", \"newsprint\", \"essay layout\", or \"manifesto\".",
+    "triggers": [
+      "magazine poster",
+      "editorial poster",
+      "newsprint",
+      "newspaper layout",
+      "essay",
+      "manifesto",
+      "long-form poster",
+      "杂志海报",
+      "报纸版式"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.417Z"
+  },
+  {
+    "slug": "guizang-ppt",
+    "name": "magazine-web-ppt",
+    "description": "生成\"电子杂志 × 电子墨水\"风格的横向翻页网页 PPT（单 HTML 文件），含 WebGL 流体背景、衬线标题 + 非衬线正文、章节幕封、数据大字报、图片网格等模板。当用户需要制作分享 / 演讲 / 发布会风格的网页 PPT，或提到\"杂志风 PPT\"、\"horizontal swipe deck\"、\"editorial magazine\"、\"e-ink presentation\"时使用。",
+    "triggers": [
+      "ppt",
+      "deck",
+      "slides",
+      "presentation",
+      "magazine",
+      "杂志",
+      "杂志风 PPT",
+      "horizontal swipe",
+      "horizontal swipe deck",
+      "editorial magazine",
+      "e-ink presentation",
+      "网页 PPT",
+      "发布会",
+      "分享 PPT"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.355Z"
+  },
+  {
+    "slug": "make-pdf",
+    "name": "make-pdf",
+    "description": "Turn any markdown file into a publication-quality PDF. Proper 1in margins, intelligent page breaks, page numbers, cover pages, running headers, curly quotes and em dashes, clickable TOC, diagonal DRAFT watermark. Not a draft artifact — a finished artifact. Use when asked to \"make a PDF\", \"export to PDF\", \"turn this markdown into a PDF\", or \"generate a document\". (gstack) Voice triggers (speech-to-text aliases): \"make this a pdf\", \"make it a pdf\", \"export to pdf\", \"turn this into a pdf\", \"turn this markdown into a pdf\", \"generate a pdf\", \"make a pdf from\", \"pdf this markdown\".",
+    "triggers": [
+      "markdown to pdf",
+      "generate pdf",
+      "make pdf",
+      "export pdf"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.044Z"
+  },
+  {
+    "slug": "marketing-ideas",
+    "name": "marketing-ideas",
+    "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (paid-ads, social-content, email-sequence, etc.).",
+    "updatedAt": "2026-05-04T17:52:23.134Z"
+  },
+  {
+    "slug": "marketing-psychology",
+    "name": "marketing-psychology",
+    "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' 'consumer behavior,' 'anchoring,' 'social proof,' 'scarcity,' 'loss aversion,' 'framing,' or 'nudge.' Use this whenever someone wants to understand or leverage how people think and make decisions in a marketing context.",
+    "updatedAt": "2026-05-04T17:52:23.134Z"
+  },
+  {
+    "slug": "mcp-builder",
+    "name": "mcp-builder",
+    "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+    "updatedAt": "2026-05-04T17:52:15.920Z"
+  },
+  {
+    "slug": "meeting-notes",
+    "name": "meeting-notes",
+    "description": "Meeting notes page — title bar with attendees, agenda checklist, decisions block, action items table with owners + dates, and a \"next meeting\" footer. Use when the brief mentions \"meeting notes\", \"minutes\", \"1:1 notes\", \"all-hands recap\", or \"会议纪要\".",
+    "triggers": [
+      "meeting notes",
+      "minutes",
+      "1:1 notes",
+      "all-hands recap",
+      "会议纪要"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.417Z"
+  },
+  {
+    "slug": "mobile-app",
+    "name": "mobile-app",
+    "description": "A mobile-app screen rendered inside a pixel-accurate iPhone 15 Pro frame on the page. Built by copying the seed `assets/template.html` and pasting one screen archetype from `references/layouts.md`. Use when the brief asks for \"mobile app\", \"iOS app\", \"Android app\", \"phone screen\", or \"app UI\".",
+    "triggers": [
+      "mobile app",
+      "ios app",
+      "android app",
+      "phone screen",
+      "app ui",
+      "app mockup",
+      "移动端",
+      "手机 app"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.418Z"
+  },
+  {
+    "slug": "mobile-onboarding",
+    "name": "mobile-onboarding",
+    "description": "A multi-screen mobile onboarding flow rendered as three phone frames side by side — splash, value-prop, sign-in. Status bar, swipe dots, primary CTA. Use when the brief mentions \"mobile onboarding\", \"iOS onboarding\", \"phone signup\", or \"移动端引导\".",
+    "triggers": [
+      "mobile onboarding",
+      "ios onboarding",
+      "android onboarding",
+      "phone signup",
+      "app onboarding",
+      "移动端引导"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.418Z"
+  },
+  {
+    "slug": "motion-frames",
+    "name": "motion-frames",
+    "description": "A single-frame motion-design composition with looping CSS animations — rotating type ring, animated globe, ticking timer, parallax labels. Renders as a hero video poster you can hand straight to HyperFrames or any keyframe-based exporter. Use when the brief asks for \"motion design\", \"animated hero\", \"loop\", \"video poster\", \"title card\", or pairs Open Claude Design with HyperFrames for a kinetic export.",
+    "triggers": [
+      "motion design",
+      "motion graphic",
+      "animated hero",
+      "loop animation",
+      "video poster",
+      "title card",
+      "hyperframes",
+      "kinetic typography",
+      "动态设计",
+      "动效"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.419Z"
+  },
+  {
+    "slug": "office-hours",
+    "name": "office-hours",
+    "description": "YC Office Hours — two modes. Startup mode: six forcing questions that expose demand reality, status quo, desperate specificity, narrowest wedge, observation, and future-fit. Builder mode: design thinking brainstorming for side projects, hackathons, learning, and open source. Saves a design doc. Use when asked to \"brainstorm this\", \"I have an idea\", \"help me think through this\", \"office hours\", or \"is this worth building\". Proactively invoke this skill (do NOT answer directly) when the user describes a new product idea, asks whether something is worth building, wants to think through design decisions for something that doesn't exist yet, or is exploring a concept before any code is written. Use before /plan-ceo-review or /plan-eng-review. (gstack)",
+    "triggers": [
+      "brainstorm this",
+      "is this worth building",
+      "help me think through",
+      "office hours"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.047Z"
+  },
+  {
+    "slug": "onboarding-cro",
+    "name": "onboarding-cro",
+    "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" \"new user experience,\" \"users aren't activating,\" \"nobody completes setup,\" \"low activation rate,\" \"users sign up but don't use the product,\" \"time to value,\" or \"first session experience.\" Use this whenever users are signing up but not sticking around. For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.",
+    "updatedAt": "2026-05-04T17:52:23.135Z"
+  },
+  {
+    "slug": "connect-chrome",
+    "name": "open-gstack-browser",
+    "description": "Launch GStack Browser — AI-controlled Chromium with the sidebar extension baked in. Opens a visible browser window where you can watch every action in real time. The sidebar shows a live activity feed and chat. Anti-bot stealth built in. Use when asked to \"open gstack browser\", \"launch browser\", \"connect chrome\", \"open chrome\", \"real browser\", \"launch chrome\", \"side panel\", or \"control my browser\". Voice triggers (speech-to-text aliases): \"show me the browser\".",
+    "triggers": [
+      "open gstack browser",
+      "launch chromium",
+      "show me the browser"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.047Z"
+  },
+  {
+    "slug": "open-gstack-browser",
+    "name": "open-gstack-browser",
+    "description": "Launch GStack Browser — AI-controlled Chromium with the sidebar extension baked in. Opens a visible browser window where you can watch every action in real time. The sidebar shows a live activity feed and chat. Anti-bot stealth built in. Use when asked to \"open gstack browser\", \"launch browser\", \"connect chrome\", \"open chrome\", \"real browser\", \"launch chrome\", \"side panel\", or \"control my browser\". Voice triggers (speech-to-text aliases): \"show me the browser\".",
+    "triggers": [
+      "open gstack browser",
+      "launch chromium",
+      "show me the browser"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.047Z"
+  },
+  {
+    "slug": "page-cro",
+    "name": "page-cro",
+    "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" \"why isn't this page working,\" \"my landing page sucks,\" \"nobody's converting,\" \"low conversion rate,\" \"bounce rate is too high,\" \"people leave without signing up,\" or \"this page needs work.\" Use this even if the user just shares a URL and asks for feedback — they probably want conversion help. For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
+    "updatedAt": "2026-05-04T17:52:23.135Z"
+  },
+  {
+    "slug": "paid-ads",
+    "name": "paid-ads",
+    "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see page-cro.",
+    "updatedAt": "2026-05-04T17:52:23.136Z"
+  },
+  {
+    "slug": "pair-agent",
+    "name": "pair-agent",
+    "description": "Pair a remote AI agent with your browser. One command generates a setup key and prints instructions the other agent can follow to connect. Works with OpenClaw, Hermes, Codex, Cursor, or any agent that can make HTTP requests. The remote agent gets its own tab with scoped access (read+write by default, admin on request). Use when asked to \"pair agent\", \"connect agent\", \"share browser\", \"remote browser\", \"let another agent use my browser\", or \"give browser access\". (gstack) Voice triggers (speech-to-text aliases): \"pair agent\", \"connect agent\", \"share my browser\", \"remote browser access\".",
+    "triggers": [
+      "pair with agent",
+      "connect remote agent",
+      "share my browser"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.049Z"
+  },
+  {
+    "slug": "paywall-upgrade-cro",
+    "name": "paywall-upgrade-cro",
+    "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" \"in-app pricing,\" \"free users won't upgrade,\" \"trial to paid conversion,\" or \"how do I get users to pay.\" Use this for any in-product moment where you're asking users to upgrade. Distinct from public pricing pages (see page-cro) — this focuses on in-product upgrade moments where the user has already experienced value. For pricing decisions, see pricing-strategy.",
+    "updatedAt": "2026-05-04T17:52:23.137Z"
+  },
+  {
+    "slug": "pdf",
+    "name": "pdf",
+    "description": "Use when tasks involve reading, creating, or reviewing PDF files where rendering and layout matter; prefer visual checks by rendering pages (Poppler) and use Python tools such as `reportlab`, `pdfplumber`, and `pypdf` for generation and extraction.",
+    "updatedAt": "2026-05-04T17:52:15.924Z"
+  },
+  {
+    "slug": "plan-ceo-review",
+    "name": "plan-ceo-review",
+    "description": "CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick expansions), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to \"think bigger\", \"expand scope\", \"strategy review\", \"rethink this\", or \"is this ambitious enough\". Proactively suggest when the user is questioning scope or ambition of a plan, or when the plan feels like it could be thinking bigger. (gstack)",
+    "triggers": [
+      "think bigger",
+      "expand scope",
+      "strategy review",
+      "rethink this plan"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.049Z"
+  },
+  {
+    "slug": "plan-design-review",
+    "name": "plan-design-review",
+    "description": "Designer's eye plan review — interactive, like CEO and Eng review. Rates each design dimension 0-10, explains what would make it a 10, then fixes the plan to get there. Works in plan mode. For live site visual audits, use /design-review. Use when asked to \"review the design plan\" or \"design critique\". Proactively suggest when the user has a plan with UI/UX components that should be reviewed before implementation. (gstack)",
+    "triggers": [
+      "design plan review",
+      "review ux plan",
+      "check design decisions"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.050Z"
+  },
+  {
+    "slug": "plan-devex-review",
+    "name": "plan-devex-review",
+    "description": "Interactive developer experience plan review. Explores developer personas, benchmarks against competitors, designs magical moments, and traces friction points before scoring. Three modes: DX EXPANSION (competitive advantage), DX POLISH (bulletproof every touchpoint), DX TRIAGE (critical gaps only). Use when asked to \"DX review\", \"developer experience audit\", \"devex review\", or \"API design review\". Proactively suggest when the user has a plan for developer-facing products (APIs, CLIs, SDKs, libraries, platforms, docs). (gstack) Voice triggers (speech-to-text aliases): \"dx review\", \"developer experience review\", \"devex review\", \"devex audit\", \"API design review\", \"onboarding review\".",
+    "triggers": [
+      "developer experience review",
+      "dx plan review",
+      "check developer onboarding"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.050Z"
+  },
+  {
+    "slug": "plan-eng-review",
+    "name": "plan-eng-review",
+    "description": "Eng manager-mode plan review. Lock in the execution plan — architecture, data flow, diagrams, edge cases, test coverage, performance. Walks through issues interactively with opinionated recommendations. Use when asked to \"review the architecture\", \"engineering review\", or \"lock in the plan\". Proactively suggest when the user has a plan or design doc and is about to start coding — to catch architecture issues before implementation. (gstack) Voice triggers (speech-to-text aliases): \"tech review\", \"technical review\", \"plan engineering review\".",
+    "triggers": [
+      "review architecture",
+      "eng plan review",
+      "check the implementation plan"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.050Z"
+  },
+  {
+    "slug": "plan-tune",
+    "name": "plan-tune",
+    "description": "Self-tuning question sensitivity + developer psychographic for gstack (v1: observational). Review which AskUserQuestion prompts fire across gstack skills, set per-question preferences (never-ask / always-ask / ask-only-for-one-way), inspect the dual-track profile (what you declared vs what your behavior suggests), and enable/disable question tuning. Conversational interface — no CLI syntax required. Use when asked to \"tune questions\", \"stop asking me that\", \"too many questions\", \"show my profile\", \"what questions have I been asked\", \"show my vibe\", \"developer profile\", or \"turn off question tuning\". (gstack) Proactively suggest when the user says the same gstack question has come up before, or when they explicitly override a recommendation for the Nth time.",
+    "triggers": [
+      "tune questions",
+      "stop asking me that",
+      "too many questions",
+      "show my profile",
+      "show my vibe",
+      "developer profile",
+      "turn off question tuning"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.051Z"
+  },
+  {
+    "slug": "playwright",
+    "name": "playwright",
+    "description": "Use when the task requires automating a real browser from the terminal (navigation, form filling, snapshots, screenshots, data extraction, UI-flow debugging) via `playwright-cli` or the bundled wrapper script.",
+    "updatedAt": "2026-05-04T17:52:15.927Z"
+  },
+  {
+    "slug": "playwright-interactive",
+    "name": "playwright-interactive",
+    "description": "Persistent browser and Electron interaction through `js_repl` for fast iterative UI debugging.",
+    "updatedAt": "2026-05-04T17:52:15.925Z"
+  },
+  {
+    "slug": "plugin-creator",
+    "name": "plugin-creator",
+    "description": "Create and scaffold plugin directories for Codex with a required `.codex-plugin/plugin.json`, optional plugin folders/files, and baseline placeholders you can edit before publishing or testing. Use when Codex needs to create a new local plugin, add optional plugin structure, or generate or update repo-root `.agents/plugins/marketplace.json` entries for plugin ordering and availability metadata.",
+    "updatedAt": "2026-05-04T17:52:15.928Z"
+  },
+  {
+    "slug": "pm-spec",
+    "name": "pm-spec",
+    "description": "Product spec / PRD as a single page — problem, success metrics, scope, user stories, design notes, rollout plan, open questions. Use when the brief mentions \"PRD\", \"spec\", \"product spec\", \"feature brief\", or \"需求文档\".",
+    "triggers": [
+      "prd",
+      "spec",
+      "product spec",
+      "feature brief",
+      "feature doc",
+      "需求文档"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.419Z"
+  },
+  {
+    "slug": "popup-cro",
+    "name": "popup-cro",
+    "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" \"overlay,\" \"collect emails with a popup,\" \"exit popup,\" \"scroll trigger,\" \"sticky bar,\" or \"notification bar.\" Use this for any overlay or interrupt-style conversion element. For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.",
+    "updatedAt": "2026-05-04T17:52:23.137Z"
+  },
+  {
+    "slug": "pptx",
+    "name": "pptx",
+    "description": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \"deck,\" \"slides,\" \"presentation,\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
+    "updatedAt": "2026-05-04T17:52:15.929Z"
+  },
+  {
+    "slug": "pptx-html-fidelity-audit",
+    "name": "pptx-html-fidelity-audit",
+    "description": "Audit a python-pptx export against its source HTML deck, identify layout/content drift (footer overflow, cropped content, missing italic/em, lost styling, off-rhythm spacing), and re-export with strict footer-rail + cursor-flow layout discipline. Use this skill whenever the user has a .pptx that was generated from an HTML slide deck and asks to compare/audit/verify/fix the export — including phrases like \"compare ppt with html\", \"fidelity audit\", \"fix the pptx\", \"ppt is cut off\", \"footer overlap\", \"italic missing in pptx\", \"re-export the deck\", \"pptx-html-fidelity-audit\", or any case where a python-pptx → HTML round-trip needs verification or repair. Also trigger when the user shows you a deck.html and a deck.pptx side by side and is debugging visual differences.",
+    "triggers": [
+      "pptx fidelity",
+      "pptx audit",
+      "ppt 跑掉",
+      "字型不對",
+      "footer overlap",
+      "verify pptx",
+      "html to pptx"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.419Z"
+  },
+  {
+    "slug": "pricing-page",
+    "name": "pricing-page",
+    "description": "A standalone pricing page — header, plan tiers, feature comparison table, and an FAQ. Use when the brief asks for \"pricing\", \"plans\", \"subscription tiers\", or a \"compare plans\" page.",
+    "triggers": [
+      "pricing",
+      "pricing page",
+      "plans",
+      "subscription",
+      "compare plans",
+      "定价",
+      "套餐"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.420Z"
+  },
+  {
+    "slug": "pricing-strategy",
+    "name": "pricing-strategy",
+    "description": "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' or 'should I offer a free plan.' Use this whenever someone is figuring out what to charge or how to structure their plans. For in-app upgrade screens, see paywall-upgrade-cro.",
+    "updatedAt": "2026-05-04T17:52:23.138Z"
+  },
+  {
+    "slug": "product-marketing-context",
+    "name": "product-marketing-context",
+    "description": "When the user wants to create or update their product marketing context document. Also use when the user mentions 'product context,' 'marketing context,' 'set up context,' 'positioning,' 'who is my target audience,' 'describe my product,' 'ICP,' 'ideal customer profile,' or wants to avoid repeating foundational information across marketing tasks. Use this at the start of any new project before using other marketing skills — it creates `.agents/product-marketing-context.md` that all other skills reference for product, audience, and positioning context.",
+    "updatedAt": "2026-05-04T17:52:23.138Z"
+  },
+  {
+    "slug": "programmatic-seo",
+    "name": "programmatic-seo",
+    "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" \"building many pages for SEO,\" \"pSEO,\" \"generate 100 pages,\" \"data-driven pages,\" or \"templated landing pages.\" Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.",
+    "updatedAt": "2026-05-04T17:52:23.139Z"
+  },
+  {
+    "slug": "qa",
+    "name": "qa",
+    "description": "Systematically QA test a web application and fix bugs found. Runs QA testing, then iteratively fixes bugs in source code, committing each fix atomically and re-verifying. Use when asked to \"qa\", \"QA\", \"test this site\", \"find bugs\", \"test and fix\", or \"fix what's broken\". Proactively suggest when the user says a feature is ready for testing or asks \"does this work?\". Three tiers: Quick (critical/high only), Standard (+ medium), Exhaustive (+ cosmetic). Produces before/after health scores, fix evidence, and a ship-readiness summary. For report-only mode, use /qa-only. (gstack) Voice triggers (speech-to-text aliases): \"quality check\", \"test the app\", \"run QA\".",
+    "triggers": [
+      "qa test this",
+      "find bugs on site",
+      "test the site"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.051Z"
+  },
+  {
+    "slug": "qa-only",
+    "name": "qa-only",
+    "description": "Report-only QA testing. Systematically tests a web application and produces a structured report with health score, screenshots, and repro steps — but never fixes anything. Use when asked to \"just report bugs\", \"qa report only\", or \"test but don't fix\". For the full test-fix-verify loop, use /qa instead. Proactively suggest when the user wants a bug report without any code changes. (gstack) Voice triggers (speech-to-text aliases): \"bug report\", \"just check for bugs\".",
+    "triggers": [
+      "qa report only",
+      "just report bugs",
+      "test but dont fix"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.051Z"
+  },
+  {
+    "slug": "referral-program",
+    "name": "referral-program",
+    "description": "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch-strategy.",
+    "updatedAt": "2026-05-04T17:52:23.139Z"
+  },
+  {
+    "slug": "replit-deck",
+    "name": "replit-deck",
+    "description": "Single-file horizontal-swipe HTML deck in the style of Replit Slides's landing-page template gallery. Eight distinct themes (helix, holm, vance, bevel, world-dark, world-mint, atlas, bluehouse) — each a complete visual system (palette + type + accent) captured from replit.com/slides. Pick one theme, do not mix. For pitch decks, board reports, brand memos, campaign reveals — when the user explicitly wants \"Replit Slides style\".",
+    "triggers": [
+      "replit deck",
+      "replit slides",
+      "replit 风格 ppt",
+      "replit style deck",
+      "helix deck",
+      "holm memo",
+      "atlas chapter",
+      "bluehouse",
+      "bevel campaign"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.421Z"
+  },
+  {
+    "slug": "retro",
+    "name": "retro",
+    "description": "Weekly engineering retrospective. Analyzes commit history, work patterns, and code quality metrics with persistent history and trend tracking. Team-aware: breaks down per-person contributions with praise and growth areas. Use when asked to \"weekly retro\", \"what did we ship\", or \"engineering retrospective\". Proactively suggest at the end of a work week or sprint. (gstack)",
+    "triggers": [
+      "weekly retro",
+      "what did we ship",
+      "engineering retrospective"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.052Z"
+  },
+  {
+    "slug": "review",
+    "name": "review",
+    "description": "Pre-landing PR review. Analyzes diff against the base branch for SQL safety, LLM trust boundary violations, conditional side effects, and other structural issues. Use when asked to \"review this PR\", \"code review\", \"pre-landing review\", or \"check my diff\". Proactively suggest when the user is about to merge or land code changes. (gstack)",
+    "triggers": [
+      "review this pr",
+      "code review",
+      "check my diff",
+      "pre-landing review"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.052Z"
+  },
+  {
+    "slug": "revops",
+    "name": "revops",
+    "description": "When the user wants help with revenue operations, lead lifecycle management, or marketing-to-sales handoff processes. Also use when the user mentions 'RevOps,' 'revenue operations,' 'lead scoring,' 'lead routing,' 'MQL,' 'SQL,' 'pipeline stages,' 'deal desk,' 'CRM automation,' 'marketing-to-sales handoff,' 'data hygiene,' 'leads aren't getting to sales,' 'pipeline management,' 'lead qualification,' or 'when should marketing hand off to sales.' Use this for anything involving the systems and processes that connect marketing to revenue. For cold outreach emails, see cold-email. For email drip campaigns, see email-sequence. For pricing decisions, see pricing-strategy.",
+    "updatedAt": "2026-05-04T17:52:23.140Z"
+  },
+  {
+    "slug": "saas-landing",
+    "name": "saas-landing",
+    "description": "Single-page SaaS landing with hero, features, social proof, pricing, and CTA. Respects the active DESIGN.md color/typography/layout tokens. Trigger keywords: \"saas landing\", \"marketing page\", \"product landing\".",
+    "triggers": [
+      "saas landing",
+      "marketing page",
+      "product landing"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.422Z"
+  },
+  {
+    "slug": "sales-enablement",
+    "name": "sales-enablement",
+    "description": "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitor-alternatives. For marketing website copy, see copywriting. For cold outreach emails, see cold-email.",
+    "updatedAt": "2026-05-04T17:52:23.141Z"
+  },
+  {
+    "slug": "schema-markup",
+    "name": "schema-markup",
+    "description": "When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user mentions \"schema markup,\" \"structured data,\" \"JSON-LD,\" \"rich snippets,\" \"schema.org,\" \"FAQ schema,\" \"product schema,\" \"review schema,\" \"breadcrumb schema,\" \"Google rich results,\" \"knowledge panel,\" \"star ratings in search,\" or \"add structured data.\" Use this whenever someone wants their pages to show enhanced results in Google. For broader SEO issues, see seo-audit. For AI search optimization, see ai-seo.",
+    "updatedAt": "2026-05-04T17:52:23.142Z"
+  },
+  {
+    "slug": "scrape",
+    "name": "scrape",
+    "description": "Pull data from a web page. First call on a new intent prototypes the flow via $B primitives and returns JSON. Subsequent calls on a matching intent route to a codified browser-skill and return in ~200ms. Read-only — for mutating flows (form fills, clicks, submissions), use /automate. Use when asked to \"scrape\", \"get data from\", \"pull\", \"extract from\", or \"what's on\" a page. (gstack)",
+    "triggers": [
+      "scrape this page",
+      "get data from",
+      "pull from",
+      "extract from",
+      "what is on"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.054Z"
+  },
+  {
+    "slug": "screenshot",
+    "name": "screenshot",
+    "description": "Use when the user explicitly asks for a desktop or system screenshot (full screen, specific app or window, or a pixel region), or when tool-specific capture capabilities are unavailable and an OS-level capture is needed.",
+    "updatedAt": "2026-05-04T17:52:15.942Z"
+  },
+  {
+    "slug": "security-best-practices",
+    "name": "security-best-practices",
+    "description": "Perform language and framework specific security best-practice reviews and suggest improvements. Trigger only when the user explicitly requests security best practices guidance, a security review/report, or secure-by-default coding help. Trigger only for supported languages (python, javascript/typescript, go). Do not trigger for general code review, debugging, or non-security tasks.",
+    "updatedAt": "2026-05-04T17:52:15.944Z"
+  },
+  {
+    "slug": "security-ownership-map",
+    "name": "security-ownership-map",
+    "description": "Analyze git repositories to build a security ownership topology (people-to-file), compute bus factor and sensitive-code ownership, and export CSV/JSON for graph databases and visualization. Trigger only when the user explicitly wants a security-oriented ownership or bus-factor analysis grounded in git history (for example: orphaned sensitive code, security maintainers, CODEOWNERS reality checks for risk, sensitive hotspots, or ownership clusters). Do not trigger for general maintainer lists or non-security ownership questions.",
+    "updatedAt": "2026-05-04T17:52:15.948Z"
+  },
+  {
+    "slug": "security-threat-model",
+    "name": "security-threat-model",
+    "description": "Repository-grounded threat modeling that enumerates trust boundaries, assets, attacker capabilities, abuse paths, and mitigations, and writes a concise Markdown threat model. Trigger only when the user explicitly asks to threat model a codebase or path, enumerate threats/abuse paths, or perform AppSec threat modeling. Do not trigger for general architecture summaries, code review, or non-security design work.",
+    "updatedAt": "2026-05-04T17:52:15.951Z"
+  },
+  {
+    "slug": "seo-audit",
+    "name": "seo-audit",
+    "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" \"SEO health check,\" \"my traffic dropped,\" \"lost rankings,\" \"not showing up in Google,\" \"site isn't ranking,\" \"Google update hit me,\" \"page speed,\" \"core web vitals,\" \"crawl errors,\" or \"indexing issues.\" Use this even if the user just says something vague like \"my SEO is bad\" or \"help with SEO\" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.",
+    "updatedAt": "2026-05-04T17:52:23.143Z"
+  },
+  {
+    "slug": "setup-browser-cookies",
+    "name": "setup-browser-cookies",
+    "description": "Import cookies from your real Chromium browser into the headless browse session. Opens an interactive picker UI where you select which cookie domains to import. Use before QA testing authenticated pages. Use when asked to \"import cookies\", \"login to the site\", or \"authenticate the browser\". (gstack)",
+    "triggers": [
+      "import browser cookies",
+      "login to test site",
+      "setup authenticated session"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.066Z"
+  },
+  {
+    "slug": "setup-deploy",
+    "name": "setup-deploy",
+    "description": "Configure deployment settings for /land-and-deploy. Detects your deploy platform (Fly.io, Render, Vercel, Netlify, Heroku, GitHub Actions, custom), production URL, health check endpoints, and deploy status commands. Writes the configuration to CLAUDE.md so all future deploys are automatic. Use when: \"setup deploy\", \"configure deployment\", \"set up land-and-deploy\", \"how do I deploy with gstack\", \"add deploy config\".",
+    "triggers": [
+      "configure deploy",
+      "setup deployment",
+      "set deploy platform"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.066Z"
+  },
+  {
+    "slug": "setup-gbrain",
+    "name": "setup-gbrain",
+    "description": "Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy. One command from zero to \"gbrain is running, and this agent can call it.\" Use when: \"setup gbrain\", \"connect gbrain\", \"start gbrain\", \"install gbrain\", \"configure gbrain for this machine\". (gstack)",
+    "triggers": [
+      "setup gbrain",
+      "install gbrain",
+      "connect gbrain",
+      "start gbrain",
+      "configure gbrain"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.066Z"
+  },
+  {
+    "slug": "ship",
+    "name": "ship",
+    "description": "Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. Use when asked to \"ship\", \"deploy\", \"push to main\", \"create a PR\", \"merge and push\", or \"get it deployed\". Proactively invoke this skill (do NOT push/PR directly) when the user says code is ready, asks about deploying, wants to push code up, or asks to create a PR. (gstack)",
+    "triggers": [
+      "ship it",
+      "create a pr",
+      "push to main",
+      "deploy this"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.067Z"
+  },
+  {
+    "slug": "signup-flow-cro",
+    "name": "signup-flow-cro",
+    "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" \"account creation flow,\" \"people aren't signing up,\" \"signup abandonment,\" \"trial conversion rate,\" \"nobody completes registration,\" \"too many steps to sign up,\" or \"simplify our signup.\" Use this whenever the user has a signup or registration flow that isn't performing. For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.",
+    "updatedAt": "2026-05-04T17:52:23.144Z"
+  },
+  {
+    "slug": "simple-deck",
+    "name": "simple-deck",
+    "description": "Single-file horizontal-swipe HTML deck. Built by copying the seed `assets/template.html` (which carries the proven 5-rule iframe nav script) and pasting slide layouts from `references/layouts.md`. Pitch decks, product overviews, study material — when you don't need the magazine aesthetic of `magazine-web-ppt`.",
+    "triggers": [
+      "deck",
+      "slides",
+      "ppt",
+      "presentation",
+      "幻灯",
+      "ppt 模板"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.422Z"
+  },
+  {
+    "slug": "site-architecture",
+    "name": "site-architecture",
+    "description": "When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal linking. Also use when the user mentions \"sitemap,\" \"site map,\" \"visual sitemap,\" \"site structure,\" \"page hierarchy,\" \"information architecture,\" \"IA,\" \"navigation design,\" \"URL structure,\" \"breadcrumbs,\" \"internal linking strategy,\" \"website planning,\" \"what pages do I need,\" \"how should I organize my site,\" or \"site navigation.\" Use this whenever someone is planning what pages a website should have and how they connect. NOT for XML sitemaps (that's technical SEO — see seo-audit). For SEO audits, see seo-audit. For structured data, see schema-markup.",
+    "updatedAt": "2026-05-04T17:52:23.144Z"
+  },
+  {
+    "slug": "skill-creator",
+    "name": "skill-creator",
+    "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
+    "updatedAt": "2026-05-04T17:52:15.952Z"
+  },
+  {
+    "slug": "skill-installer",
+    "name": "skill-installer",
+    "description": "Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos).",
+    "updatedAt": "2026-05-04T17:52:15.955Z"
+  },
+  {
+    "slug": "skillify",
+    "name": "skillify",
+    "description": "Codify the most recent successful /scrape flow into a permanent browser-skill on disk. Future /scrape calls with the same intent run the codified script in ~200ms instead of re-driving the page. Walks back through the conversation, synthesizes script.ts + script.test.ts + fixture, runs the test in a temp dir, and asks before committing. Use when asked to \"skillify\", \"codify\", \"save this scrape\", or \"make this permanent\". (gstack)",
+    "triggers": [
+      "skillify",
+      "codify this scrape",
+      "save this scrape",
+      "make this permanent"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.067Z"
+  },
+  {
+    "slug": "social-carousel",
+    "name": "social-carousel",
+    "description": "A three-card social-media carousel laid out as 1080×1080 squares — three cinematic, on-brand panels with display headlines that connect across the series (\"onwards.\" → \"to the next one.\" → \"looking ahead.\"). Each card has a brand mark, a number / total, a caption, and a \"loop\" affordance. Use when the brief asks for a \"carousel post\", \"social carousel\", \"Instagram carousel\", \"LinkedIn series\", \"X thread cards\", or \"三连发\".",
+    "triggers": [
+      "social carousel",
+      "carousel post",
+      "instagram carousel",
+      "linkedin carousel",
+      "x thread cards",
+      "social series",
+      "三连发",
+      "轮播图"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.423Z"
+  },
+  {
+    "slug": "social-content",
+    "name": "social-content",
+    "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative.",
+    "updatedAt": "2026-05-04T17:52:23.145Z"
+  },
+  {
+    "slug": "sprite-animation",
+    "name": "sprite-animation",
+    "description": "A pixel / sprite-style animated explainer slide — full-bleed cream stage, bold display year, animated pixel-art mascot (e.g. Hanafuda card, mushroom, or 8-bit console), kinetic Japanese display type, ticking timeline ribbon. Reads like a single frame of an educational motion video — looping CSS keyframes, no JS, ready to be screen-recorded into a vertical video. Use when the brief asks for a \"sprite animation\", \"pixel-art video\", \"8-bit explainer\", \"history of X explainer\", \"kinetic typography history\", \"Nintendo-style\", \"精灵图动画\", \"像素动画\", or \"复古动画\".",
+    "triggers": [
+      "sprite animation",
+      "pixel art animation",
+      "8-bit explainer",
+      "retro animation",
+      "kinetic typography",
+      "history explainer",
+      "nintendo style",
+      "精灵图",
+      "像素动画",
+      "复古动画"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.423Z"
+  },
+  {
+    "slug": "team-okrs",
+    "name": "team-okrs",
+    "description": "OKR tracker page — quarter banner, three objectives with their key results as progress bars, owner avatars, status pills, and a \"this quarter at a glance\" sidebar. Use when the brief mentions \"OKRs\", \"key results\", \"objectives\", or \"目标\".",
+    "triggers": [
+      "okr",
+      "okrs",
+      "key results",
+      "objectives",
+      "目标"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.424Z"
+  },
+  {
+    "slug": "theme-factory",
+    "name": "theme-factory",
+    "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.",
+    "updatedAt": "2026-05-04T17:52:15.956Z"
+  },
+  {
+    "slug": "tweaks",
+    "name": "tweaks",
+    "description": "Wrap any HTML artifact with a side panel of live, parameterized controls — accent color, type scale, density, motion, theme — that rewrite CSS custom properties in real time and persist to localStorage. Lets the user explore variants of a design without re-prompting the agent. Use when the brief asks for \"variants\", \"side-by-side options\", \"tweak this\", \"let me adjust\", \"live knobs\", or \"实时调参\".",
+    "triggers": [
+      "tweaks",
+      "variants",
+      "tweak panel",
+      "live controls",
+      "adjust on the fly",
+      "实时调参",
+      "可调参数面板",
+      "side panel",
+      "knobs"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.424Z"
+  },
+  {
+    "slug": "unfreeze",
+    "name": "unfreeze",
+    "description": "Clear the freeze boundary set by /freeze, allowing edits to all directories again. Use when you want to widen edit scope without ending the session. Use when asked to \"unfreeze\", \"unlock edits\", \"remove freeze\", or \"allow all edits\". (gstack)",
+    "triggers": [
+      "unfreeze edits",
+      "unlock all directories",
+      "remove edit restrictions"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.090Z"
+  },
+  {
+    "slug": "vercel-deploy",
+    "name": "vercel-deploy",
+    "description": "Deploy applications and websites to Vercel. Use when the user requests deployment actions like \"deploy my app\", \"deploy and give me the link\", \"push this live\", or \"create a preview deployment\".",
+    "updatedAt": "2026-05-04T17:52:15.962Z"
+  },
+  {
+    "slug": "video",
+    "name": "video",
+    "description": "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social-content. For paid video ad creative, see ad-creative.",
+    "updatedAt": "2026-05-04T17:52:23.146Z"
+  },
+  {
+    "slug": "video-shortform",
+    "name": "video-shortform",
+    "description": "Short-form video generation skill — 3-10 second clips for product reveals, motion teasers, ambient loops. Defaults to Seedance 2 but works the same with Kling 3 / 4, Veo 3 or Sora 2. Output is one MP4 saved to the project folder. When the workspace also ships an interactive-video / hyperframes skill, prefer composing several short shots into a single timeline rather than one long monolithic clip.",
+    "triggers": [
+      "video",
+      "clip",
+      "shortform",
+      "reel",
+      "短视频",
+      "动效"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.424Z"
+  },
+  {
+    "slug": "web-artifacts-builder",
+    "name": "web-artifacts-builder",
+    "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.",
+    "updatedAt": "2026-05-04T17:52:15.964Z"
+  },
+  {
+    "slug": "web-prototype",
+    "name": "web-prototype",
+    "description": "General-purpose desktop web prototype. Single self-contained HTML file built by copying the seed `assets/template.html` and pasting section layouts from `references/layouts.md`. Default for any landing / marketing / docs / SaaS page when no more specific skill matches.",
+    "triggers": [
+      "prototype",
+      "mockup",
+      "landing",
+      "single page",
+      "marketing page",
+      "homepage"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.425Z"
+  },
+  {
+    "slug": "web-prototype-taste-brutalist",
+    "name": "web-prototype-taste-brutalist",
+    "description": "Swiss industrial-print web prototype. Newsprint canvas, monolithic black grotesque, viewport-bleeding numerals, hairline grid dividers, hazard-red accent, ASCII syntax decoration. Distilled from Leonxlnx/taste-skill `brutalist-skill` (Swiss Industrial Print mode).",
+    "updatedAt": "2026-05-04T17:52:23.425Z"
+  },
+  {
+    "slug": "web-prototype-taste-editorial",
+    "name": "web-prototype-taste-editorial",
+    "description": "Editorial-minimalist web prototype. Warm monochrome canvas, serif display + grotesque body, 1px hairline borders, muted pastel chips, generous macro-whitespace, ambient micro-motion. Distilled from Leonxlnx/taste-skill `minimalist-skill`.",
+    "updatedAt": "2026-05-04T17:52:23.425Z"
+  },
+  {
+    "slug": "web-prototype-taste-soft",
+    "name": "web-prototype-taste-soft",
+    "description": "Apple-tier soft web prototype. Silver/cream canvas, double-bezel cards, button-in-button CTAs, generous squircle radii, spring motion, ambient mesh. Distilled from Leonxlnx/taste-skill `soft-skill` + sections 4–8 of `taste-skill`.",
+    "updatedAt": "2026-05-04T17:52:23.425Z"
+  },
+  {
+    "slug": "webapp-testing",
+    "name": "webapp-testing",
+    "description": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
+    "updatedAt": "2026-05-04T17:52:15.965Z"
+  },
+  {
+    "slug": "weekly-update",
+    "name": "weekly-update",
+    "description": "Single-file horizontal-swipe slide deck for a weekly team update — shipped, in flight, blocked, metrics, asks. 6–8 slides. Use when the brief mentions \"weekly update\", \"team update slides\", \"weekly status\", \"周报演示\".",
+    "triggers": [
+      "weekly update",
+      "team update slides",
+      "weekly status",
+      "weekly review",
+      "周报演示"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.426Z"
+  },
+  {
+    "slug": "wireframe-sketch",
+    "name": "wireframe-sketch",
+    "description": "A hand-drawn wireframe exploration — graph-paper background, marker / pencil tone, multiple tab labels for variants, sticky-note annotations, scribbled chart placeholders, hatched fills. Reads like a designer's whiteboard before any pixels are committed. Use when the brief asks for \"wireframe\", \"sketch wireframe\", \"hand-drawn\", \"lo-fi\", \"whiteboard\", \"草稿\", or \"手绘原型\".",
+    "triggers": [
+      "wireframe",
+      "sketch wireframe",
+      "lo-fi mockup",
+      "hand drawn",
+      "whiteboard sketch",
+      "low fidelity",
+      "手绘原型",
+      "草图",
+      "线框图"
+    ],
+    "updatedAt": "2026-05-04T17:52:23.426Z"
+  },
+  {
+    "slug": "xiaohongshu-knowledge",
+    "name": "xiaohongshu-knowledge",
+    "description": "Use when writing, planning, analyzing, or editing Xiaohongshu (小红书) content — posts, titles, covers, hashtags, captions, account positioning, growth strategy. Provides on-demand access to a 139-skill knowledge base covering content creation, account ops, interaction, analytics, e-commerce, platform rules, tooling, marketing, and growth. Read this index first to locate the relevant sub-skill, then read that sub-skill's SKILL.md before producing output.",
+    "updatedAt": "2026-05-04T17:52:15.966Z"
+  },
+  {
+    "slug": "xlsx",
+    "name": "xlsx",
+    "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
+    "updatedAt": "2026-05-04T17:52:16.033Z"
+  }
+]

--- a/personal-site/lib/skills.ts
+++ b/personal-site/lib/skills.ts
@@ -1,15 +1,14 @@
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import path from "node:path";
-import matter from "gray-matter";
+import skillsData from "./skills.generated.json";
 
-export type Skill = {
+type RawSkill = {
   slug: string;
   name: string;
   description: string;
-  category: SkillCategory;
   triggers?: string[];
   updatedAt: string;
 };
+
+export type Skill = RawSkill & { category: SkillCategory };
 
 export const SKILL_CATEGORIES = [
   "Marketing & Growth",
@@ -26,13 +25,6 @@ export const SKILL_CATEGORIES = [
 ] as const;
 
 export type SkillCategory = (typeof SKILL_CATEGORIES)[number];
-
-const SKILLS_DIR = path.join(
-  process.cwd(),
-  "..",
-  ".agents",
-  "skills",
-);
 
 function inferCategory(slug: string): SkillCategory {
   if (
@@ -121,81 +113,15 @@ function inferCategory(slug: string): SkillCategory {
   return "Other";
 }
 
-function normalizeDescription(raw: unknown): string {
-  if (typeof raw !== "string") return "";
-  return raw.replace(/\s+/g, " ").trim();
-}
-
-function normalizeTriggers(raw: unknown): string[] | undefined {
-  if (!Array.isArray(raw)) return undefined;
-  const list = raw
-    .map((item) => (typeof item === "string" ? item.trim() : ""))
-    .filter((item) => item.length > 0);
-  return list.length > 0 ? list : undefined;
-}
-
 let cached: Skill[] | null = null;
 
 export function getAllSkills(): Skill[] {
   if (cached) return cached;
-
-  let entries: string[] = [];
-  try {
-    entries = readdirSync(SKILLS_DIR);
-  } catch {
-    cached = [];
-    return cached;
-  }
-
-  const skills: Skill[] = [];
-
-  for (const slug of entries) {
-    if (slug.startsWith(".")) continue;
-    const skillPath = path.join(SKILLS_DIR, slug);
-    let skillStat;
-    try {
-      skillStat = statSync(skillPath);
-    } catch {
-      continue;
-    }
-    if (!skillStat.isDirectory()) continue;
-
-    const skillFile = path.join(skillPath, "SKILL.md");
-    let raw: string;
-    let mtime: Date;
-    try {
-      raw = readFileSync(skillFile, "utf8");
-      mtime = statSync(skillFile).mtime;
-    } catch {
-      continue;
-    }
-
-    let parsed;
-    try {
-      parsed = matter(raw);
-    } catch {
-      continue;
-    }
-
-    const data = parsed.data ?? {};
-    const name =
-      typeof data.name === "string" && data.name.trim().length > 0
-        ? data.name.trim()
-        : slug;
-    const description = normalizeDescription(data.description);
-    if (!description) continue;
-    const triggers = normalizeTriggers(data.triggers);
-
-    skills.push({
-      slug,
-      name,
-      description,
-      category: inferCategory(slug),
-      triggers,
-      updatedAt: mtime.toISOString(),
-    });
-  }
-
+  const raw = skillsData as RawSkill[];
+  const skills: Skill[] = raw.map((s) => ({
+    ...s,
+    category: inferCategory(s.slug),
+  }));
   skills.sort((a, b) => a.name.localeCompare(b.name));
   cached = skills;
   return cached;

--- a/personal-site/package.json
+++ b/personal-site/package.json
@@ -3,10 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "node scripts/generate-skills-data.mjs && next dev",
+    "prebuild": "node scripts/generate-skills-data.mjs",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "skills:generate": "node scripts/generate-skills-data.mjs"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",

--- a/personal-site/scripts/generate-skills-data.mjs
+++ b/personal-site/scripts/generate-skills-data.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const SKILLS_DIR = path.join(__dirname, "..", "..", ".agents", "skills");
+const OUT_PATH = path.join(__dirname, "..", "lib", "skills.generated.json");
+
+function normalizeDescription(raw) {
+  if (typeof raw !== "string") return "";
+  return raw.replace(/\s+/g, " ").trim();
+}
+
+function normalizeTriggers(raw) {
+  if (!Array.isArray(raw)) return undefined;
+  const list = raw
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter((item) => item.length > 0);
+  return list.length > 0 ? list : undefined;
+}
+
+let entries;
+try {
+  entries = readdirSync(SKILLS_DIR);
+} catch (err) {
+  console.error(
+    `[generate-skills-data] Cannot read ${SKILLS_DIR}: ${err.message}`,
+  );
+  console.error(
+    "  This script must run inside the bingran-you repo so it can see ../.agents/skills/.",
+  );
+  process.exit(1);
+}
+
+const skills = [];
+
+for (const slug of entries) {
+  if (slug.startsWith(".")) continue;
+  const skillDir = path.join(SKILLS_DIR, slug);
+  let dirStat;
+  try {
+    dirStat = statSync(skillDir);
+  } catch {
+    continue;
+  }
+  if (!dirStat.isDirectory()) continue;
+
+  const skillFile = path.join(skillDir, "SKILL.md");
+  let raw;
+  let mtime;
+  try {
+    raw = readFileSync(skillFile, "utf8");
+    mtime = statSync(skillFile).mtime;
+  } catch {
+    continue;
+  }
+
+  let parsed;
+  try {
+    parsed = matter(raw);
+  } catch {
+    continue;
+  }
+
+  const data = parsed.data ?? {};
+  const name =
+    typeof data.name === "string" && data.name.trim().length > 0
+      ? data.name.trim()
+      : slug;
+  const description = normalizeDescription(data.description);
+  if (!description) continue;
+  const triggers = normalizeTriggers(data.triggers);
+
+  skills.push({
+    slug,
+    name,
+    description,
+    triggers,
+    updatedAt: mtime.toISOString(),
+  });
+}
+
+skills.sort((a, b) => a.name.localeCompare(b.name));
+
+writeFileSync(OUT_PATH, JSON.stringify(skills, null, 2) + "\n");
+console.log(
+  `[generate-skills-data] Wrote ${skills.length} skills to ${path.relative(process.cwd(), OUT_PATH)}`,
+);

--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../.agents/skills"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
 }


### PR DESCRIPTION
## Summary
- Production was rendering "0 skills" because Vercel's Root Directory is \`personal-site/\` and \`../.agents/skills/\` isn't in the build container.
- Fix: \`npm run prebuild\` (also wired into \`dev\` and \`npm run skills:generate\`) walks \`../.agents/skills/*/SKILL.md\` and writes \`personal-site/lib/skills.generated.json\`.
- The page imports the JSON instead of scanning the filesystem, so the data ships inside \`personal-site/\`.

## Tradeoff
- Loses the "auto-rebuild when \`.agents/skills/\` changes" behavior. To refresh after running \`scripts/sync_skills.sh\`, run \`npm run skills:generate\` inside \`personal-site/\` and commit the JSON.
- \`vercel.json\` \`ignoreCommand\` reverts to watching only \`personal-site/\`.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run build\` — 175 detail pages prerendered
- [x] Generated JSON shows 175 entries
- [ ] Vercel preview deploy renders the cards
- [ ] Production \`/skills\` shows 175 cards after merge