### PR TITLE
Skills detail: make code blocks readable on cream background

### DIFF
--- a/personal-site/app/(personal)/skills/[slug]/page.tsx
+++ b/personal-site/app/(personal)/skills/[slug]/page.tsx
@@ -128,7 +128,7 @@ export default async function SkillDetailPage({
             SKILL.md
           </h2>
           <div
-            className="prose prose-neutral max-w-none dark:prose-invert prose-headings:tracking-tight prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg prose-pre:bg-[var(--background)] prose-pre:border prose-pre:border-[var(--border)] prose-code:font-mono prose-code:text-[13px] prose-a:text-[var(--accent)] prose-a:underline-offset-4"
+            className="prose prose-neutral max-w-none dark:prose-invert prose-headings:tracking-tight prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg prose-pre:bg-foreground/[0.04] prose-pre:text-foreground prose-pre:border prose-pre:border-[var(--border)] prose-code:font-mono prose-code:text-[13px] prose-code:text-foreground prose-code:bg-foreground/[0.06] prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:before:content-none prose-code:after:content-none prose-a:text-[var(--accent)] prose-a:underline-offset-4"
             dangerouslySetInnerHTML={{ __html: skill.bodyHtml }}
           />
         </section>


### PR DESCRIPTION
## Summary
Tailwind Typography ships near-white \`pre\` text by default (assumes a dark background). My earlier override forced \`prose-pre:bg-[var(--background)]\` to match the cream page surface, which left the body of every code block near-invisible — most painful on long ASCII-art mockups (Cancel Flow patterns, Health Score formula, etc.).

This PR explicitly sets foreground text on \`pre\` and inline \`code\`, gives them a faint \`foreground/4%\` wash, and strips the default backtick wrappers prose adds around inline \`code\`.

## Test plan
- [x] \`npm run build\` clean
- [x] Local browser: \`/skills/churn-prevention\` ASCII-art code blocks now have dark legible text
- [ ] Vercel preview confirms the fix