### PR TITLE
Register AI for Science post in postSlugs

### DIFF
--- a/personal-site/lib/posts.ts
+++ b/personal-site/lib/posts.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 export const postSlugs = [
   "a-curated-vetted-skills-catalog",
   "seo-and-geo-for-a-personal-site",
+  "trust-infrastructure-for-ai-in-expert-work",
   "welcome",
 ] as const;
 


### PR DESCRIPTION
## Summary
The blog post added in #133 (`personal-site/content/posts/trust-infrastructure-for-ai-in-expert-work.mdx`) was not appearing on `/blog`, in the sitemap, or in `llms.txt` because `personal-site/lib/posts.ts` exports a hardcoded `postSlugs` array that drives every post enumerator. The MDX file existed on disk but was invisible to the app.

This PR adds the slug to that array. One-line fix.

## Test plan
- [ ] Vercel preview: confirm the post appears at `/blog` and renders at `/blog/trust-infrastructure-for-ai-in-expert-work`
- [ ] Confirm `/sitemap.xml` includes the new URL
- [ ] Confirm `/llms.txt` and `/llms-full.txt` include the post