### PR TITLE
Align workspace docs with site and README

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,8 @@ Main-session only. Keep this file high-signal and durable.
 
 - `current-projects/` holds active project submodules such as `DoWhiz`, `first-tree`, `mews`, and `skillsbench`.
 - `personal-site/` hosts `bingranyou.com` (Next.js 16 + MDX, deployed on Vercel from this repo with Root Directory `personal-site`). Pushes to `main` trigger production builds; the `personal-site/vercel.json` `ignoreCommand` skips builds when nothing inside `personal-site/` changes.
+- The personal site now includes `/about`, `/projects`, `/papers`, `/skills`, `/blog`, `/llms.txt`, and `/llms-full.txt`.
+- `personal-site/scripts/generate-skills-data.mjs` generates the `/skills` catalog payload (`lib/skills.generated.json`) and downloadable copies under `public/skill-files/` from mirrored `.agents/skills/`.
 - Repo-managed skills live in `repo-skills/`, `trusted-external-repos/open-design/skills/`, `trusted-external-repos/marketingskills/skills/`, and `trusted-external-repos/gstack/` (including `browser-skills/` and `openclaw/skills/`).
 - `scripts/sync_skills.sh` mirrors valid skill directories into `.agents/skills` and `.claude/skills`.
 - Session-start hooks in `.claude/settings.json` and `.codex/config.toml` attempt to run `scripts/sync_skills.sh init` automatically.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -21,7 +21,8 @@ Fill in as you learn. Delete sections that don't apply.
 - **Worktrees root:** `~/Downloads/GitHub/Claude-Worktrees/bingran-you/` — parallel sessions, per-branch.
 - **Private submodule:** `bingran-you-private/` — confidential, never exfiltrate.
 - **Active project submodules:** `current-projects/DoWhiz`, `current-projects/first-tree`, `current-projects/mews`, `current-projects/skillsbench`
-- **Personal site:** `personal-site/` — Next.js + MDX source for `bingranyou.com`, deployed on Vercel (project `personal-site` under team `bingran-yous-projects`)
+- **Personal site:** `personal-site/` — Next.js + MDX source for `bingranyou.com`, including the public `/skills`, `/llms.txt`, and `/llms-full.txt` routes; deployed on Vercel (project `personal-site` under team `bingran-yous-projects`)
+- **Skills catalog generation:** `personal-site/scripts/generate-skills-data.mjs` builds `personal-site/lib/skills.generated.json` and downloadable `personal-site/public/skill-files/*.md` entries from mirrored `.agents/skills/`
 
 ## Ion-Trap Environment
 

--- a/USER.md
+++ b/USER.md
@@ -12,7 +12,7 @@ _The one you serve. Keep this living and current._
 
 ## Role
 
-- PhD Candidate, UC Berkeley
+- PhD Candidate in Applied Science & Technology, UC Berkeley
 - **Two tracks, both active:**
   - 💻 **Agentic Builder** — agent evaluation, skills-based benchmarking, deterministic test environments for long-horizon workflows, applied AI systems across existing tools.
   - ⚛︎ **Ion Trapper** — trapped-ion experiments in atomic, molecular and optical (AMO) physics: integrated photonics, ion-photon interfaces, multiplexed networking, 3D-printed microtraps. Member of HaeffnerLab.
@@ -24,14 +24,15 @@ _The one you serve. Keep this living and current._
 
 ## Projects to Know
 
-- [SkillsBench](https://github.com/benchflow-ai/skillsbench) — benchmark for agent skill use.
-- [first-tree](https://github.com/agent-team-foundation/first-tree) — Git-native context layer for teams.
-- [DoWhiz](https://github.com/KnoWhiz/DoWhiz) — agent-native productivity product.
-- [DeepTutor](https://deeptutor.knowhiz.us/) — AI research assistant on Zotero.
-- [smolclaw](https://github.com/bingran-you/smolclaw) — seeded mock envs for agent testing.
-- [SBTI CLI](https://github.com/bingran-you/sbti-cli) — offline CLI for agent behavior testing.
-- [bem](https://github.com/HaeffnerLab/bem) — boundary element / fast multipole methods.
-- [artiq_photonics_integration](https://github.com/HaeffnerLab/artiq_photonics_integration) — ARTIQ photonics control.
+- [SkillsBench](https://github.com/benchflow-ai/skillsbench) — benchmark for evaluating how well AI agents use skills.
+- [first-tree](https://github.com/agent-team-foundation/first-tree) — Git-native context layer for decisions, ownership, and shared team knowledge.
+- [DoWhiz](https://github.com/KnoWhiz/DoWhiz) — agent-native product for getting work done across email, chat, documents, and related tools.
+- [DeepTutor](https://deeptutor.knowhiz.us/) — AI research assistant built on Zotero for cited answers, figure and formula understanding, and multi-paper comparison.
+- [mews](https://github.com/bingran-you/mews) — local GitHub notification daemon that triages inbox activity and dispatches Codex or Claude Code work for allow-listed repos.
+- [smolclaw](https://github.com/bingran-you/smolclaw) — seeded mock environments for testing agent behavior in realistic workflows.
+- [SBTI CLI](https://github.com/bingran-you/sbti-cli) — offline CLI for testing agent behavior with bundled logic and exportable results.
+- [bem](https://github.com/HaeffnerLab/bem) — scientific computing code for boundary element and fast multipole methods in Python.
+- [artiq_photonics_integration](https://github.com/HaeffnerLab/artiq_photonics_integration) — ARTIQ control framework for photonics integration experiments.
 
 ## How He Works
 
@@ -51,7 +52,7 @@ _The one you serve. Keep this living and current._
 ## Public Channels
 
 - 𝕏 / Twitter: [@bingran_bry](https://x.com/bingran_bry)
-- Rednote, Google Scholar, ORCID, Hugging Face, LinkedIn — see README.md for links.
+- GitHub, Rednote, YouTube, Discord, Google Scholar, ORCID, Hugging Face, LinkedIn — see README.md for links.
 
 ---
 

--- a/memory/2026-05-06.md
+++ b/memory/2026-05-06.md
@@ -3,3 +3,6 @@
 - Updated public-facing contact email references across the workspace from `bingran.bry@gmail.com` to `me@bingranyou.com`.
 - Switched the personal-site's default outward email on the social links, About page, and `llms.txt` / `llms-full.txt` routes to `me@bingranyou.com`.
 - Synced internal workspace docs (`USER.md`, `TOOLS.md`) so future sessions treat `me@bingranyou.com` as Bingran's personal/default external contact email.
+- Audited repo docs against the current `README.md`, the live `bingranyou.com` routes, and the `personal-site/` source.
+- Updated `personal-site/README.md` to match the real route structure (`app/(personal)/*`), document `/skills`, `/llms.txt`, `/llms-full.txt`, and explain the generated skills catalog flow from mirrored `.agents/skills/`.
+- Updated workspace docs so `USER.md`, `TOOLS.md`, and `MEMORY.md` now reflect the current public project list (including `mews`) and the site's skills/LLMS surfaces.

--- a/personal-site/README.md
+++ b/personal-site/README.md
@@ -6,7 +6,8 @@ Personal site of [Bingran You](https://bingranyou.com) — built with Next.js + 
 
 - **Next.js 16** (App Router, Turbopack, React 19)
 - **Tailwind CSS v4** + `@tailwindcss/typography`
-- **MDX** via `@next/mdx` with file-based blog routing
+- **MDX** via `@next/mdx` for blog content
+- **Generated skills catalog** sourced from mirrored `.agents/skills/`
 - **TypeScript**
 
 ## Develop
@@ -17,6 +18,8 @@ npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
+
+`npm run dev` regenerates `lib/skills.generated.json` before starting Next.js so the `/skills` catalog stays in sync with the mirrored workspace skills.
 
 ## Add a blog post
 
@@ -33,22 +36,41 @@ Open [http://localhost:3000](http://localhost:3000).
 2. Add `"{slug}"` to `postSlugs` in `lib/posts.ts`.
 3. Push — Vercel deploys.
 
+## Refresh the skills catalog
+
+When mirrored skills change and you want to refresh the static data without starting the dev server:
+
+```bash
+npm run skills:generate
+```
+
 ## Layout
 
 ```
 app/
-  page.tsx              home
-  projects/page.tsx     projects index
-  papers/page.tsx       papers index
-  blog/page.tsx         blog index
-  blog/[slug]/page.tsx  individual post (static, dynamicParams=false)
+  (personal)/layout.tsx                 shared shell + nav + footer
+  (personal)/page.tsx                   home
+  (personal)/about/page.tsx             about
+  (personal)/projects/page.tsx          projects index
+  (personal)/papers/page.tsx            papers index
+  (personal)/skills/page.tsx            skills index
+  (personal)/skills/[slug]/page.tsx     individual skill page
+  (personal)/blog/page.tsx              blog index
+  (personal)/blog/[slug]/page.tsx       individual post
+  llms.txt/route.ts                     crawler-friendly site index
+  llms-full.txt/route.ts                full index + blog bodies
 components/
-  social-links.tsx      footer links
+  social-links.tsx                      footer links
+  bio-icons.tsx                         homepage icons
 content/
-  posts/                MDX blog posts
+  posts/                                MDX blog posts
 lib/
-  content.ts            projects + papers data
-  posts.ts              MDX post registry
-mdx-components.tsx      global MDX component overrides
-next.config.ts          MDX + remark-gfm
+  content.ts                            projects + papers + education data
+  posts.ts                              blog post registry
+  skills.ts                             skills catalog helpers
+  skills.generated.json                 generated skills payload
+scripts/
+  generate-skills-data.mjs              build skills payload + public downloads
+mdx-components.tsx                      global MDX component overrides
+next.config.ts                          MDX + redirects
 ```


### PR DESCRIPTION
## Summary
- update `personal-site/README.md` to match the current route structure, `/skills`, and the LLMS exports
- sync `USER.md`, `TOOLS.md`, and `MEMORY.md` with the current public project list and site surfaces
- record the docs audit in `memory/2026-05-06.md` for future sessions

## Testing
- `npm run build` (in `personal-site/`)
- live-route spot check for `bingranyou.com`, `/about`, `/projects`, `/papers`, `/blog`, `/skills`, `/llms.txt`, and `/llms-full.txt`