### PR TITLE
Derive blog post slugs from content/posts at build time

### DIFF
--- a/personal-site/app/(personal)/blog/[slug]/opengraph-image.tsx
+++ b/personal-site/app/(personal)/blog/[slug]/opengraph-image.tsx
@@ -1,13 +1,14 @@
 import { notFound } from "next/navigation";
-import { postSlugs, type PostSlug } from "@/lib/posts";
+import { getPostSlugs } from "@/lib/posts";
 import { ogContentType, ogSize, renderOgImage } from "@/lib/og";
 
 export const alt = "Blog post — Bingran You";
 export const size = ogSize;
 export const contentType = ogContentType;
 
-export function generateStaticParams() {
-  return postSlugs.map((slug) => ({ slug }));
+export async function generateStaticParams() {
+  const slugs = await getPostSlugs();
+  return slugs.map((slug) => ({ slug }));
 }
 
 export default async function Image({
@@ -16,7 +17,8 @@ export default async function Image({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  if (!postSlugs.includes(slug as PostSlug)) notFound();
+  const slugs = await getPostSlugs();
+  if (!slugs.includes(slug)) notFound();
   const mod = await import(`@/content/posts/${slug}.mdx`);
   return renderOgImage({
     eyebrow: "Blog",

--- a/personal-site/app/(personal)/blog/[slug]/page.tsx
+++ b/personal-site/app/(personal)/blog/[slug]/page.tsx
@@ -4,8 +4,7 @@ import Link from "next/link";
 import {
   getPostLastModified,
   getPostMetadata,
-  postSlugs,
-  type PostSlug,
+  getPostSlugs,
 } from "@/lib/posts";
 import {
   blogPostingJsonLd,
@@ -18,8 +17,9 @@ import {
 
 export const dynamicParams = false;
 
-export function generateStaticParams() {
-  return postSlugs.map((slug) => ({ slug }));
+export async function generateStaticParams() {
+  const slugs = await getPostSlugs();
+  return slugs.map((slug) => ({ slug }));
 }
 
 type Params = Promise<{ slug: string }>;
@@ -30,10 +30,10 @@ export async function generateMetadata({
   params: Params;
 }): Promise<Metadata> {
   const { slug } = await params;
-  if (!postSlugs.includes(slug as PostSlug)) return {};
-  const postSlug = slug as PostSlug;
-  const metadata = await getPostMetadata(postSlug);
-  const modifiedTime = (await getPostLastModified(postSlug)).toISOString();
+  const slugs = await getPostSlugs();
+  if (!slugs.includes(slug)) return {};
+  const metadata = await getPostMetadata(slug);
+  const modifiedTime = (await getPostLastModified(slug)).toISOString();
   const description = metadata.description ?? SITE_DESCRIPTION;
 
   return {
@@ -62,12 +62,12 @@ export async function generateMetadata({
 
 export default async function PostPage({ params }: { params: Params }) {
   const { slug } = await params;
-  if (!postSlugs.includes(slug as PostSlug)) notFound();
-  const postSlug = slug as PostSlug;
+  const slugs = await getPostSlugs();
+  if (!slugs.includes(slug)) notFound();
   const { default: Post, metadata } = await import(
     `@/content/posts/${slug}.mdx`
   );
-  const modifiedTime = (await getPostLastModified(postSlug)).toISOString();
+  const modifiedTime = (await getPostLastModified(slug)).toISOString();
   const jsonLd = jsonLdScriptContent(
     blogPostingJsonLd({
       slug,

--- a/personal-site/lib/posts.ts
+++ b/personal-site/lib/posts.ts
@@ -1,14 +1,7 @@
-import { stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
-export const postSlugs = [
-  "a-curated-vetted-skills-catalog",
-  "seo-and-geo-for-a-personal-site",
-  "trust-infrastructure-for-ai-in-expert-work",
-  "welcome",
-] as const;
-
-export type PostSlug = (typeof postSlugs)[number];
+const POSTS_DIR = path.join(process.cwd(), "content", "posts");
 
 export type PostMetadata = {
   title: string;
@@ -16,18 +9,25 @@ export type PostMetadata = {
   date: string;
 };
 
-export async function getPostMetadata(
-  slug: PostSlug,
-): Promise<PostMetadata> {
+export async function getPostSlugs(): Promise<string[]> {
+  const entries = await readdir(POSTS_DIR);
+  return entries
+    .filter((f) => f.endsWith(".mdx"))
+    .map((f) => f.replace(/\.mdx$/, ""))
+    .sort();
+}
+
+export async function getPostMetadata(slug: string): Promise<PostMetadata> {
   const mod = await import(`@/content/posts/${slug}.mdx`);
   return mod.metadata as PostMetadata;
 }
 
 export async function getAllPostsMetadata(): Promise<
-  Array<PostMetadata & { slug: PostSlug }>
+  Array<PostMetadata & { slug: string }>
 > {
+  const slugs = await getPostSlugs();
   const all = await Promise.all(
-    postSlugs.map(async (slug) => ({
+    slugs.map(async (slug) => ({
       slug,
       ...(await getPostMetadata(slug)),
     })),
@@ -35,8 +35,8 @@ export async function getAllPostsMetadata(): Promise<
   return all.sort((a, b) => (a.date < b.date ? 1 : -1));
 }
 
-export async function getPostLastModified(slug: PostSlug) {
-  const filePath = path.join(process.cwd(), "content", "posts", `${slug}.mdx`);
+export async function getPostLastModified(slug: string) {
+  const filePath = path.join(POSTS_DIR, `${slug}.mdx`);
   const { mtime } = await stat(filePath);
   return mtime;
 }


### PR DESCRIPTION
## Summary
Replaces the hardcoded `postSlugs` array in `personal-site/lib/posts.ts` with an async `getPostSlugs()` that scans `content/posts/*.mdx` via `node:fs/promises` `readdir`. Adding an MDX file to `content/posts/` is now enough to make the post appear on `/blog`, in the sitemap, in `llms.txt` / `llms-full.txt`, and through the `[slug]` route — no separate registration step.

This is a follow-up to #135, which fixed the same class of problem manually. Goal: stop the bug from being possible.

### Changes
- `personal-site/lib/posts.ts` — drop the `postSlugs as const` array and the `PostSlug` literal-union type; add `getPostSlugs()`.
- `personal-site/app/(personal)/blog/[slug]/page.tsx` — `generateStaticParams`, `generateMetadata`, and the page itself now await `getPostSlugs()`.
- `personal-site/app/(personal)/blog/[slug]/opengraph-image.tsx` — same pattern for the OG image route.

`sitemap.ts` and `llms.txt` / `llms-full.txt` consume `getAllPostsMetadata()` and don't need changes.

### Why filesystem scan instead of a generated JSON
The skills system uses a generate-then-commit pattern (`scripts/generate-skills-data.mjs` → `lib/skills.generated.json`) because skill content lives across multiple external repos and needs cross-source merging. Posts live in one local directory next to the code; a direct `readdir` is simpler and removes the registration step entirely.

## Test plan
- [ ] Vercel preview build succeeds
- [ ] Preview `/blog` lists all four current posts
- [ ] Preview `/blog/trust-infrastructure-for-ai-in-expert-work` renders
- [ ] Preview `/sitemap.xml` includes all four post URLs
- [ ] Preview `/llms.txt` and `/llms-full.txt` include all four posts
- [ ] Preview OG image route works for at least one slug