### PR TITLE
Skills page: fix confusing empty state when category filter hides matches

### DIFF
--- a/personal-site/app/(personal)/skills/_components/skills-browser.tsx
+++ b/personal-site/app/(personal)/skills/_components/skills-browser.tsx
@@ -16,20 +16,26 @@ export function SkillsBrowser({ skills, categories }: Props) {
   );
   const deferredQuery = useDeferredValue(query);
 
-  const filtered = useMemo(() => {
-    const q = deferredQuery.trim().toLowerCase();
-    return skills.filter((s) => {
-      if (activeCategory !== "All" && s.category !== activeCategory)
-        return false;
-      if (!q) return true;
-      return (
+  const q = deferredQuery.trim().toLowerCase();
+
+  const queryMatches = useMemo(() => {
+    if (!q) return skills;
+    return skills.filter(
+      (s) =>
         s.name.toLowerCase().includes(q) ||
         s.slug.toLowerCase().includes(q) ||
         s.description.toLowerCase().includes(q) ||
-        (s.triggers?.some((t) => t.toLowerCase().includes(q)) ?? false)
-      );
-    });
-  }, [skills, deferredQuery, activeCategory]);
+        (s.triggers?.some((t) => t.toLowerCase().includes(q)) ?? false),
+    );
+  }, [skills, q]);
+
+  const filtered = useMemo(() => {
+    if (activeCategory === "All") return queryMatches;
+    return queryMatches.filter((s) => s.category === activeCategory);
+  }, [queryMatches, activeCategory]);
+
+  const queryMatchesAcrossCategories =
+    q && activeCategory !== "All" ? queryMatches.length : 0;
 
   const grouped = useMemo(() => {
     const map = new Map<SkillCategory, Skill[]>();
@@ -77,10 +83,28 @@ export function SkillsBrowser({ skills, categories }: Props) {
       </div>
 
       {filtered.length === 0 ? (
-        <p className="py-16 text-center text-sm text-[var(--muted)]">
-          No skills match{" "}
-          <span className="font-mono">&ldquo;{deferredQuery}&rdquo;</span>.
-        </p>
+        <div className="py-16 text-center text-sm text-[var(--muted)]">
+          <p>
+            No skills match{" "}
+            <span className="font-mono">&ldquo;{deferredQuery}&rdquo;</span>
+            {activeCategory !== "All" ? (
+              <>
+                {" "}
+                in <span className="font-medium">{activeCategory}</span>
+              </>
+            ) : null}
+            .
+          </p>
+          {queryMatchesAcrossCategories > 0 ? (
+            <button
+              type="button"
+              onClick={() => setActiveCategory("All")}
+              className="mt-3 rounded-full border border-[var(--border)] px-3 py-1 text-xs text-foreground transition hover:border-foreground/30"
+            >
+              Search all categories ({queryMatchesAcrossCategories})
+            </button>
+          ) : null}
+        </div>
       ) : (
         <div className="space-y-12">
           {grouped.map(([cat, list]) => (


### PR DESCRIPTION
## Summary
- Repros the reported bug: with a category chip active (e.g. Documents), searching common terms like `office` or `ppt` returned `No skills match …` even though matches exist in other categories. Substring matching itself was correct; the empty state just never surfaced the active category constraint.
- Empty state now names the active category (`No skills match "office" in Documents.`) and offers a `Search all categories (N)` button that clears the chip when matches exist elsewhere.
- No change to the search/filter algorithm.

## Test plan
- [x] Repro on prod: select `Documents` → type `office` → 0 results, no hint.
- [x] Verified on local dev: same flow now shows the new empty state with `Search all categories (3)` and clicking it reveals the 3 matches grouped by their actual categories (Reviews & Plans / Security).
- [x] `All` + empty query path unchanged.