### PR TITLE
personal-site: fix mobile responsive layout

### DIFF
--- a/personal-site/app/(personal)/layout.tsx
+++ b/personal-site/app/(personal)/layout.tsx
@@ -1,14 +1,6 @@
 import Link from "next/link";
+import { SiteNav } from "@/components/site-nav";
 import { SocialLinks } from "@/components/social-links";
-
-const nav = [
-  { href: "/", label: "Home" },
-  { href: "/projects", label: "Projects" },
-  { href: "/papers", label: "Papers" },
-  { href: "/skills", label: "Skills" },
-  { href: "/blog", label: "Blog" },
-  { href: "/about", label: "About" },
-];
 
 export default function PersonalLayout({
   children,
@@ -18,31 +10,21 @@ export default function PersonalLayout({
   return (
     <>
       <header className="sticky top-0 z-20 border-b border-[var(--border)] bg-[var(--background)]/85 backdrop-blur">
-        <div className="mx-auto max-w-4xl px-6 py-5 flex items-center justify-between">
+        <div className="mx-auto max-w-4xl px-4 py-4 sm:px-6 sm:py-5 flex items-center justify-between">
           <Link
             href="/"
             className="font-mono text-sm tracking-tight text-foreground hover:opacity-70 transition"
           >
             bingran.you
           </Link>
-          <nav className="flex items-center gap-6 text-sm">
-            {nav.slice(1).map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="text-[var(--muted)] hover:text-foreground transition"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
+          <SiteNav />
         </div>
       </header>
-      <main className="flex-1 mx-auto w-full max-w-4xl px-6 py-14 sm:py-16">
+      <main className="flex-1 mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 sm:py-16">
         {children}
       </main>
       <footer className="border-t border-[var(--border)]">
-        <div className="mx-auto max-w-4xl px-6 py-10 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 sm:py-10 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-[var(--muted)]">
             © {new Date().getFullYear()} Bingran You · Berkeley, CA
           </p>

--- a/personal-site/app/(personal)/page.tsx
+++ b/personal-site/app/(personal)/page.tsx
@@ -13,14 +13,14 @@ export default function Home() {
   const paperHighlights = papers.filter((p) => p.track === "ai").slice(0, 2);
 
   return (
-    <div className="space-y-24">
+    <div className="space-y-16 sm:space-y-24">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: jsonLdScriptContent(profilePageJsonLd("/")),
         }}
       />
-      <section className="grid gap-10 sm:grid-cols-[1fr_auto] sm:items-start">
+      <section className="grid gap-8 sm:gap-10 sm:grid-cols-[1fr_auto] sm:items-start">
         <div>
           <h1 className="font-display text-5xl leading-[1.02] tracking-[-0.035em] sm:text-6xl">
             Bingran You
@@ -46,13 +46,13 @@ export default function Home() {
           </ul>
         </div>
 
-        <div className="relative h-44 w-44 shrink-0 overflow-hidden rounded-full ring-1 ring-[var(--border)] sm:h-52 sm:w-52">
+        <div className="relative h-32 w-32 shrink-0 overflow-hidden rounded-full ring-1 ring-[var(--border)] sm:h-52 sm:w-52">
           <Image
             src="/images/profile/bingran-you-portrait.jpg"
             alt="Bingran You"
             fill
             priority
-            sizes="(max-width: 640px) 11rem, 13rem"
+            sizes="(max-width: 640px) 8rem, 13rem"
             className="object-cover object-[50%_28%]"
           />
         </div>

--- a/personal-site/app/(personal)/skills/[slug]/page.tsx
+++ b/personal-site/app/(personal)/skills/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function SkillDetailPage({
         </p>
       </header>
 
-      <aside className="grid gap-3 rounded-2xl border border-[var(--border)] p-5 sm:grid-cols-2">
+      <aside className="grid grid-cols-1 gap-3 rounded-2xl border border-[var(--border)] p-5 sm:grid-cols-2">
         <Meta label="Author">{skill.source.author}</Meta>
         <Meta label="Collection">{skill.source.collection}</Meta>
         <Meta label="License">

--- a/personal-site/app/(personal)/skills/_components/skills-browser.tsx
+++ b/personal-site/app/(personal)/skills/_components/skills-browser.tsx
@@ -62,7 +62,7 @@ export function SkillsBrowser({ skills, categories }: Props) {
           <SearchIcon className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--muted)]" />
         </div>
 
-        <div className="-mx-1 flex flex-wrap gap-1.5">
+        <div className="-mx-4 flex gap-1.5 overflow-x-auto px-4 pb-1 sm:-mx-1 sm:flex-wrap sm:overflow-visible sm:px-1 sm:pb-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <CategoryChip
             label={`All · ${skills.length}`}
             active={activeCategory === "All"}
@@ -117,7 +117,7 @@ export function SkillsBrowser({ skills, categories }: Props) {
                   {list.length}
                 </span>
               </div>
-              <ul className="grid gap-3 sm:grid-cols-2">
+              <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 {list.map((s) => (
                   <li key={s.slug}>
                     <SkillCard skill={s} />
@@ -177,7 +177,7 @@ function CategoryChip({
     <button
       type="button"
       onClick={onClick}
-      className={`rounded-full border px-3 py-1 text-xs transition ${
+      className={`shrink-0 whitespace-nowrap rounded-full border px-3 py-1 text-xs transition ${
         active
           ? "border-foreground bg-foreground text-[var(--background)]"
           : "border-[var(--border)] text-[var(--muted)] hover:border-foreground/30 hover:text-foreground"

--- a/personal-site/app/globals.css
+++ b/personal-site/app/globals.css
@@ -34,8 +34,14 @@
 }
 
 html {
-  scroll-behavior: smooth;
-  scrollbar-gutter: stable;
+  -webkit-text-size-adjust: 100%;
+}
+
+@media (min-width: 768px) and (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+    scrollbar-gutter: stable;
+  }
 }
 
 body {
@@ -45,6 +51,7 @@ body {
   font-feature-settings: "ss01", "ss02", "cv01", "cv11";
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  overflow-x: clip;
 }
 
 ::selection {

--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Newsreader } from "next/font/google";
 import "./globals.css";
 import {
@@ -62,6 +62,16 @@ export const metadata: Metadata = {
   verification: {
     google: "xWQd6sxfEf5jfU4AtrNcPv0jg71Ia8gQvXAcQmWKpyo",
   },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#faf8f4" },
+    { media: "(prefers-color-scheme: dark)", color: "#0c0e12" },
+  ],
 };
 
 export default function RootLayout({

--- a/personal-site/components/site-nav.tsx
+++ b/personal-site/components/site-nav.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const nav = [
+  { href: "/projects", label: "Projects" },
+  { href: "/papers", label: "Papers" },
+  { href: "/skills", label: "Skills" },
+  { href: "/blog", label: "Blog" },
+  { href: "/about", label: "About" },
+];
+
+export function SiteNav() {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const { body } = document;
+    const prev = body.style.overflow;
+    body.style.overflow = "hidden";
+    return () => {
+      body.style.overflow = prev;
+    };
+  }, [open]);
+
+  return (
+    <>
+      <nav className="hidden sm:flex items-center gap-6 text-sm">
+        {nav.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="text-[var(--muted)] hover:text-foreground transition"
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+
+      <button
+        type="button"
+        aria-label={open ? "Close menu" : "Open menu"}
+        aria-expanded={open}
+        aria-controls="mobile-nav-panel"
+        onClick={() => setOpen((v) => !v)}
+        className="sm:hidden -mr-2 p-2 text-foreground"
+      >
+        <span className="relative block h-4 w-5" aria-hidden>
+          <span
+            className={`absolute left-0 top-0 h-[1.5px] w-5 bg-current transition-transform duration-200 ${
+              open ? "translate-y-[7px] rotate-45" : ""
+            }`}
+          />
+          <span
+            className={`absolute left-0 top-[7px] h-[1.5px] w-5 bg-current transition-opacity duration-200 ${
+              open ? "opacity-0" : "opacity-100"
+            }`}
+          />
+          <span
+            className={`absolute left-0 top-[14px] h-[1.5px] w-5 bg-current transition-transform duration-200 ${
+              open ? "-translate-y-[7px] -rotate-45" : ""
+            }`}
+          />
+        </span>
+      </button>
+
+      <div
+        id="mobile-nav-panel"
+        className={`sm:hidden absolute left-0 right-0 top-full origin-top border-b border-[var(--border)] bg-[var(--background)]/95 backdrop-blur transition duration-200 ease-out ${
+          open
+            ? "translate-y-0 opacity-100 pointer-events-auto"
+            : "-translate-y-1 opacity-0 pointer-events-none"
+        }`}
+      >
+        <ul className="mx-auto max-w-4xl px-4 py-2">
+          {nav.map((item) => {
+            const active =
+              item.href === "/"
+                ? pathname === "/"
+                : pathname?.startsWith(item.href);
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  onClick={() => setOpen(false)}
+                  className={`block py-3 text-base transition ${
+                    active
+                      ? "text-foreground"
+                      : "text-[var(--muted)] hover:text-foreground"
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Mobile (sub-`sm`) on bingranyou.com had a buggy header (5 nav items + wordmark overflowing the bar with no hamburger), oversized portrait + section spacing, a 12px horizontal-overflow on `/skills`, and a global `scroll-behavior: smooth` that fights iOS momentum. All changes are scoped to sub-`sm` breakpoints; desktop visuals are unchanged (verified with screenshots at 1280px).

## Changes
- **Header**: new `components/site-nav.tsx` client component with `sm:hidden` hamburger + slide-down panel (Escape closes, body scroll lock, active-route highlight). Desktop nav kept as `hidden sm:flex` with original `gap-6`.
- **Container rhythm**: header/footer/main `px-4 sm:px-6`, main `py-10 sm:py-16`. Home `space-y-16 sm:space-y-24`, hero `gap-8 sm:gap-10`, portrait `h-32 w-32 sm:h-52 sm:w-52`.
- **Skills**: chip row scrolls horizontally on mobile (scrollbar hidden), `flex-wrap` on `sm+`. Added explicit `grid-cols-1 sm:grid-cols-2` on the cards grid and the `[slug]` aside — this was the root cause of the 12px overflow on iPhone SE (implicit auto track sized to max-content).
- **Globals**: scoped `scroll-behavior: smooth` and `scrollbar-gutter: stable` to `>=md + prefers-reduced-motion: no-preference`. Added `body { overflow-x: clip }` and `html { -webkit-text-size-adjust: 100% }`.
- **Viewport meta**: Next 16 `export const viewport` with `device-width`, `initialScale: 1`, `maximumScale: 5`, dual-scheme `themeColor`.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` passes (no type errors, all routes generated)
- [x] Playwright headless across 4 viewports (375 / 390 / 412 / 1280) × 6 routes (`/`, `/projects`, `/papers`, `/skills`, `/blog`, `/about`): 0 horizontal-overflow issues, mobile menu opens with all 5 links, skills chips scroll on a single line on mobile and wrap on desktop, desktop nav renders identically to before
- [ ] Verify post-deploy on production at iPhone SE / iPhone 14 / Pixel 7 widths