### PR TITLE
personal-site: fix broken Haeffner Lab link

### DIFF
--- a/personal-site/app/(personal)/about/page.tsx
+++ b/personal-site/app/(personal)/about/page.tsx
@@ -23,7 +23,7 @@ const profilePageJsonLd = {
     affiliation: {
       "@type": "Organization",
       name: "Haeffner Lab, University of California, Berkeley",
-      url: "https://haeffnerlab.berkeley.edu/",
+      url: "https://ions.berkeley.edu/",
     },
     knowsAbout: [
       "Reliable AI Systems",
@@ -163,7 +163,7 @@ export default function AboutPage() {
             <span className="font-mono text-xs text-[var(--muted)]">Lab</span>
             <a
               className="underline underline-offset-4 decoration-[var(--border)] hover:decoration-foreground"
-              href="https://haeffnerlab.berkeley.edu/"
+              href="https://ions.berkeley.edu/"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/personal-site/app/llms-full.txt/route.ts
+++ b/personal-site/app/llms-full.txt/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
 
 - Name: Bingran You
 - Role: PhD Candidate, Applied Science & Technology, UC Berkeley
-- Lab: Haeffner Lab (https://haeffnerlab.berkeley.edu/)
+- Lab: Haeffner Lab (https://ions.berkeley.edu/)
 - Location: Berkeley, California, USA
 - Site: ${SITE}/
 - Email: me@bingranyou.com

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -18,7 +18,7 @@ I work on two tracks: reliable AI agent systems, and trapped-ion atomic, molecul
 
 - Name: Bingran You
 - Role: PhD Candidate, Applied Science & Technology, UC Berkeley
-- Lab: Haeffner Lab (https://haeffnerlab.berkeley.edu/)
+- Lab: Haeffner Lab (https://ions.berkeley.edu/)
 - Location: Berkeley, California, USA
 - Site: ${SITE}/
 - Email: me@bingranyou.com

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -70,7 +70,7 @@ export function personJsonLd() {
     affiliation: {
       "@type": "Organization",
       name: "Haeffner Lab, University of California, Berkeley",
-      url: "https://haeffnerlab.berkeley.edu/",
+      url: "https://ions.berkeley.edu/",
     },
     knowsAbout: [
       "Reliable AI Systems",


### PR DESCRIPTION
## Summary

- Old lab URL `https://haeffnerlab.berkeley.edu/` no longer resolves (`ECONNREFUSED`).
- Haeffner group's current public site is `https://ions.berkeley.edu/` (rebranded as "Berkeley Ions"; Hartmut Häffner still PI — confirmed via `ions.berkeley.edu/members/hartmut/`).
- Updates all 5 occurrences across the personal site:
  - `app/(personal)/about/page.tsx` — visible "Lab" link + JSON-LD `affiliation.url`
  - `lib/jsonld.ts` — `affiliation.url` in person schema
  - `app/llms.txt/route.ts` — identity block
  - `app/llms-full.txt/route.ts` — identity block
- Lab display name stays "Haeffner Lab"; only the URL changed.

## Test plan

- [ ] About page renders with the new link, anchor opens `https://ions.berkeley.edu/` in a new tab
- [ ] `/llms.txt` and `/llms-full.txt` routes serve the updated URL
- [ ] JSON-LD on `/about` validates

https://claude.ai/code/session_01D4935d8J42xpUM3aJYpEim

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4935d8J42xpUM3aJYpEim)_