### PR TITLE
personal-site: warm Berkeley-dusk palette

### DIFF
--- a/personal-site/app/globals.css
+++ b/personal-site/app/globals.css
@@ -2,12 +2,13 @@
 @plugin "@tailwindcss/typography";
 
 :root {
-  --background: #faf8f4;
-  --foreground: #14161b;
-  --muted: #6b7280;
-  --border: rgba(20, 22, 27, 0.10);
-  --accent: #1f5f9f;
-  --accent-strong: #0f3154;
+  /* Berkeley dusk × lab notebook palette */
+  --background: #f4ead7;        /* aged lab-notebook paper */
+  --foreground: #1f1a14;        /* pine-soot ink */
+  --muted: #6b6055;             /* warm gray, AA on background */
+  --border: rgba(31, 26, 20, 0.12);
+  --accent: #a8431c;            /* Sather Tower terracotta */
+  --accent-strong: #7d2e10;     /* deeper terracotta for hover/emphasis */
 }
 
 @theme inline {
@@ -24,12 +25,12 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0c0e12;
-    --foreground: #ececef;
-    --muted: #8a93a1;
-    --border: rgba(232, 238, 249, 0.10);
-    --accent: #84b8ff;
-    --accent-strong: #c8defd;
+    --background: #1a1610;      /* warm desk-lamp ink */
+    --foreground: #ece4d4;      /* warm off-white */
+    --muted: #9a8d76;           /* warm gray */
+    --border: rgba(236, 228, 212, 0.12);
+    --accent: #e89968;          /* lit terracotta */
+    --accent-strong: #f0b687;   /* highlighted terracotta */
   }
 }
 
@@ -55,6 +56,43 @@ body {
 }
 
 ::selection {
-  background: var(--foreground);
+  background: var(--accent);
   color: var(--background);
+}
+
+/* Map Tailwind Typography to the Berkeley-dusk palette so prose pages
+   (blog posts, SKILL.md bodies) stay warm instead of cool zinc. */
+.prose {
+  --tw-prose-body: var(--foreground);
+  --tw-prose-headings: var(--foreground);
+  --tw-prose-lead: var(--foreground);
+  --tw-prose-links: var(--accent);
+  --tw-prose-bold: var(--foreground);
+  --tw-prose-counters: var(--muted);
+  --tw-prose-bullets: var(--border);
+  --tw-prose-hr: var(--border);
+  --tw-prose-quotes: var(--foreground);
+  --tw-prose-quote-borders: var(--accent);
+  --tw-prose-captions: var(--muted);
+  --tw-prose-code: var(--foreground);
+  --tw-prose-pre-code: var(--foreground);
+  --tw-prose-pre-bg: rgba(31, 26, 20, 0.04);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border);
+  --tw-prose-invert-body: var(--foreground);
+  --tw-prose-invert-headings: var(--foreground);
+  --tw-prose-invert-lead: var(--foreground);
+  --tw-prose-invert-links: var(--accent);
+  --tw-prose-invert-bold: var(--foreground);
+  --tw-prose-invert-counters: var(--muted);
+  --tw-prose-invert-bullets: var(--border);
+  --tw-prose-invert-hr: var(--border);
+  --tw-prose-invert-quotes: var(--foreground);
+  --tw-prose-invert-quote-borders: var(--accent);
+  --tw-prose-invert-captions: var(--muted);
+  --tw-prose-invert-code: var(--foreground);
+  --tw-prose-invert-pre-code: var(--foreground);
+  --tw-prose-invert-pre-bg: rgba(236, 228, 212, 0.04);
+  --tw-prose-invert-th-borders: var(--border);
+  --tw-prose-invert-td-borders: var(--border);
 }

--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -69,8 +69,8 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 5,
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#faf8f4" },
-    { media: "(prefers-color-scheme: dark)", color: "#0c0e12" },
+    { media: "(prefers-color-scheme: light)", color: "#f4ead7" },
+    { media: "(prefers-color-scheme: dark)", color: "#1a1610" },
   ],
 };
 

--- a/personal-site/lib/og.tsx
+++ b/personal-site/lib/og.tsx
@@ -22,8 +22,8 @@ export function renderOgImage({
           flexDirection: "column",
           justifyContent: "space-between",
           padding: "80px",
-          background: "#fafaf9",
-          color: "#0a0a0a",
+          background: "#f4ead7",
+          color: "#1f1a14",
           fontFamily: "Georgia, 'Times New Roman', serif",
         }}
       >
@@ -34,7 +34,7 @@ export function renderOgImage({
             fontFamily: "ui-monospace, Menlo, monospace",
             letterSpacing: "0.32em",
             textTransform: "uppercase",
-            color: "#737373",
+            color: "#a8431c",
           }}
         >
           {eyebrow ?? "bingran.you"}
@@ -63,7 +63,7 @@ export function renderOgImage({
               style={{
                 fontSize: 32,
                 lineHeight: 1.4,
-                color: "#525252",
+                color: "#3d352b",
                 maxWidth: 980,
                 fontFamily: "ui-sans-serif, system-ui, sans-serif",
               }}
@@ -79,7 +79,7 @@ export function renderOgImage({
             justifyContent: "space-between",
             alignItems: "center",
             fontSize: 22,
-            color: "#737373",
+            color: "#6b6055",
             fontFamily: "ui-sans-serif, system-ui, sans-serif",
           }}
         >


### PR DESCRIPTION
## Summary

Repaints the personal site from the academic-blue + cool-cream palette to a warm **Berkeley dusk × lab notebook** theme, designed to make a visitor feel "this is a person who lives in Berkeley, runs experiments, writes by hand, and doesn't shout."

**Light mode**

| token            | value                       | reads as                                |
| ---------------- | --------------------------- | --------------------------------------- |
| `--background`   | `#f4ead7`                   | aged lab-notebook paper                 |
| `--foreground`   | `#1f1a14`                   | pine-soot ink (warmed near-black)       |
| `--muted`        | `#6b6055`                   | warm gray, AA on background             |
| `--accent`       | `#a8431c`                   | Sather Tower terracotta — Berkeley dusk |
| `--accent-strong`| `#7d2e10`                   | deeper terracotta (hover/emphasis)      |

**Dark mode** — warm desk-lamp ink (`#1a1610`) + warm off-white (`#ece4d4`) + lit terracotta (`#e89968`). Cohesive with light mode, not a generic near-black.

## Why this palette

Driven from how Bingran actually shows up — a Berkeley experimental physicist + AI engineer who writes calmly, dislikes filler, and prefers things that "look clean." Concrete cues:

- **Terracotta** = Sather Tower / Berkeley golden hour — geographic color, not brand color.
- **Aged paper background + Newsreader serif** = lab notebooks and old physics books, matching the calm/factual writing voice.
- **Warmed near-black ink** instead of pure `#000` reads "handwritten" rather than "tech blog."
- **No cool blues** — deliberately splits from generic dev portfolios and from the prior `#1f5f9f` accent that read as "academic poster."

## Files changed

- `app/globals.css` — palette + `::selection` + Tailwind Typography prose variable mapping (so blog posts and `SKILL.md` bodies inherit the warm palette instead of the cool zinc/neutral defaults).
- `app/layout.tsx` — `themeColor` meta updated for both light and dark.
- `lib/og.tsx` — OG share-card backgrounds, eyebrow (now terracotta), subtitle, and footer text now match site palette.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run build` — clean, all 200+ static routes prerender.
- [x] Visual sweep across Home / About / Blog index / Blog post / Skills / Skill detail / Projects / Papers at desktop (1280×900) and mobile (390×844), in both light and dark — 32 screenshots checked.
- [x] Prose pages (blog post, SKILL.md detail) verified to use the new palette end-to-end.
- [x] Sticky header, mobile nav drawer, code blocks (Shiki), skill icon chips all read coherently against the new background in both schemes.