### PR TITLE
personal-site: add /posts page aggregating X, Xiaohongshu, YouTube

### DIFF
--- a/personal-site/app/(personal)/posts/page.tsx
+++ b/personal-site/app/(personal)/posts/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import { getAllSocialPosts } from "@/lib/social-posts";
+import { SocialPostCard } from "@/components/social-post-card";
+
+export const metadata: Metadata = {
+  title: "Posts",
+  description:
+    "Things I've posted across YouTube, X, Xiaohongshu, Bilibili and elsewhere — all in one place, newest first.",
+  alternates: { canonical: "/posts" },
+};
+
+export default async function PostsPage() {
+  const posts = await getAllSocialPosts();
+
+  return (
+    <div className="space-y-12">
+      <header>
+        <h1 className="text-3xl font-semibold tracking-tight">Posts</h1>
+        <p className="mt-3 max-w-2xl text-base text-[var(--muted)]">
+          Videos and notes I&apos;ve posted across YouTube, X, Xiaohongshu,
+          Bilibili and elsewhere — newest first.
+        </p>
+      </header>
+
+      {posts.length === 0 ? (
+        <p className="text-sm text-[var(--muted)]">Nothing here yet.</p>
+      ) : (
+        <div className="columns-1 gap-6 sm:columns-2 lg:columns-3">
+          {posts.map((post) => (
+            <SocialPostCard key={post.id} post={post} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -90,6 +90,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7,
     },
     {
+      url: `${SITE_URL}/posts`,
+      lastModified: await getLatestLastModified([
+        "app/(personal)/posts/page.tsx",
+        "content/social/posts.json",
+      ]),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
       url: `${SITE_URL}/skills`,
       lastModified: getSkillsLastModified(),
       changeFrequency: "weekly",

--- a/personal-site/components/site-nav.tsx
+++ b/personal-site/components/site-nav.tsx
@@ -9,6 +9,7 @@ const nav = [
   { href: "/papers", label: "Papers" },
   { href: "/skills", label: "Skills" },
   { href: "/blog", label: "Blog" },
+  { href: "/posts", label: "Posts" },
   { href: "/about", label: "About" },
 ];
 

--- a/personal-site/components/social-post-card.tsx
+++ b/personal-site/components/social-post-card.tsx
@@ -1,0 +1,152 @@
+import {
+  PLATFORM_LABEL,
+  type SocialPlatform,
+  type SocialPost,
+} from "@/lib/social-posts";
+
+type IconProps = { className?: string };
+
+function YouTubeIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+    </svg>
+  );
+}
+
+function XIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+function XiaohongshuIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M22.405 9.879c.002.016.01.02.07.019h.725a.797.797 0 0 0 .78-.972.794.794 0 0 0-.884-.618.795.795 0 0 0-.692.794c0 .101-.002.666.001.777zm-11.509 4.808c-.203.001-1.353.004-1.685.003a2.528 2.528 0 0 1-.766-.126.025.025 0 0 0-.03.014L7.7 16.127a.025.025 0 0 0 .01.032c.111.06.336.124.495.124.66.01 1.32.002 1.981 0 .01 0 .02-.006.023-.015l.712-1.545a.025.025 0 0 0-.024-.036zM.477 9.91c-.071 0-.076.002-.076.01a.834.834 0 0 0-.01.08c-.027.397-.038.495-.234 3.06-.012.24-.034.389-.135.607-.026.057-.033.042.003.112.046.092.681 1.523.787 1.74.008.015.011.02.017.02.008 0 .033-.026.047-.044.147-.187.268-.391.371-.606.306-.635.44-1.325.486-1.706.014-.11.021-.22.03-.33l.204-2.616.022-.293c.003-.029 0-.033-.03-.034zm7.203 3.757a1.427 1.427 0 0 1-.135-.607c-.004-.084-.031-.39-.235-3.06a.443.443 0 0 0-.01-.082c-.004-.011-.052-.008-.076-.008h-1.48c-.03.001-.034.005-.03.034l.021.293c.076.982.153 1.964.233 2.946.05.4.186 1.085.487 1.706.103.215.223.419.37.606.015.018.037.051.048.049.02-.003.742-1.642.804-1.765.036-.07.03-.055.003-.112zm3.861-.913h-.872a.126.126 0 0 1-.116-.178l1.178-2.625a.025.025 0 0 0-.023-.035l-1.318-.003a.148.148 0 0 1-.135-.21l.876-1.954a.025.025 0 0 0-.023-.035h-1.56c-.01 0-.02.006-.024.015l-.926 2.068c-.085.169-.314.634-.399.938a.534.534 0 0 0-.02.191.46.46 0 0 0 .23.378.981.981 0 0 0 .46.119h.59c.041 0-.688 1.482-.834 1.972a.53.53 0 0 0-.023.172.465.465 0 0 0 .23.398c.15.092.342.12.475.12l1.66-.001c.01 0 .02-.006.023-.015l.575-1.28a.025.025 0 0 0-.024-.035zm-6.93-4.937H3.1a.032.032 0 0 0-.034.033c0 1.048-.01 2.795-.01 6.829 0 .288-.269.262-.28.262h-.74c-.04.001-.044.004-.04.047.001.037.465 1.064.555 1.263.01.02.03.033.051.033.157.003.767.009.938-.014.153-.02.3-.06.438-.132.3-.156.49-.419.595-.765.052-.172.075-.353.075-.533.002-2.33 0-4.66-.007-6.991a.032.032 0 0 0-.032-.032zm11.784 6.896c0-.014-.01-.021-.024-.022h-1.465c-.048-.001-.049-.002-.05-.049v-4.66c0-.072-.005-.07.07-.07h.863c.08 0 .075.004.075-.074V8.393c0-.082.006-.076-.08-.076h-3.5c-.064 0-.075-.006-.075.073v1.445c0 .083-.006.077.08.077h.854c.075 0 .07-.004.07.07v4.624c0 .095.008.084-.085.084-.37 0-1.11-.002-1.304 0-.048.001-.06.03-.06.03l-.697 1.519s-.014.025-.008.036c.006.01.013.008.058.008 1.748.003 3.495.002 5.243.002.03-.001.034-.006.035-.033v-1.539zm4.177-3.43c0 .013-.007.023-.02.024-.346.006-.692.004-1.037.004-.014-.002-.022-.01-.022-.024-.005-.434-.007-.869-.01-1.303 0-.072-.006-.071.07-.07l.733-.003c.041 0 .081.002.12.015.093.025.16.107.165.204.006.431.002 1.153.001 1.153zm2.67.244a1.953 1.953 0 0 0-.883-.222h-.18c-.04-.001-.04-.003-.042-.04V10.21c0-.132-.007-.263-.025-.394a1.823 1.823 0 0 0-.153-.53 1.533 1.533 0 0 0-.677-.71 2.167 2.167 0 0 0-1-.258c-.153-.003-.567 0-.72 0-.07 0-.068.004-.068-.065V7.76c0-.031-.01-.041-.046-.039H17.93s-.016 0-.023.007c-.006.006-.008.012-.008.023v.546c-.008.036-.057.015-.082.022h-.95c-.022.002-.028.008-.03.032v1.481c0 .09-.004.082.082.082h.913c.082 0 .072.128.072.128V11.19s.003.117-.06.117h-1.482c-.068 0-.06.082-.06.082v1.445s-.01.068.064.068h1.457c.082 0 .076-.006.076.079v3.225c0 .088-.007.081.082.081h1.43c.09 0 .082.007.082-.08v-3.27c0-.029.006-.035.033-.035l2.323-.003c.098 0 .191.02.28.061a.46.46 0 0 1 .274.407c.008.395.003.79.003 1.185 0 .259-.107.367-.33.367h-1.218c-.023.002-.029.008-.028.033.184.437.374.871.57 1.303a.045.045 0 0 0 .04.026c.17.005.34.002.51.003.15-.002.517.004.666-.01a2.03 2.03 0 0 0 .408-.075c.59-.18.975-.698.976-1.313v-1.981c0-.128-.01-.254-.034-.38 0 .078-.029-.641-.724-.998z" />
+    </svg>
+  );
+}
+
+function BilibiliIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M18.223 3.086a1.25 1.25 0 0 1 0 1.768L17.08 5.996h1.17A3.75 3.75 0 0 1 22 9.747v7.5a3.75 3.75 0 0 1-3.75 3.75H5.75A3.75 3.75 0 0 1 2 17.247v-7.5a3.75 3.75 0 0 1 3.75-3.75h1.166L5.775 4.855a1.25 1.25 0 1 1 1.767-1.768l2.652 2.652c.079.079.148.165.205.257h3.21c.058-.092.126-.179.205-.257l2.652-2.652a1.25 1.25 0 0 1 1.768 0zM18.25 8.496H5.75a1.25 1.25 0 0 0-1.247 1.157L4.5 9.747v7.5a1.25 1.25 0 0 0 1.157 1.247l.093.003h12.5a1.25 1.25 0 0 0 1.247-1.157l.003-.093v-7.5a1.25 1.25 0 0 0-1.25-1.25zM8.25 11.083c.69 0 1.25.56 1.25 1.25v1.665a1.25 1.25 0 1 1-2.5 0v-1.665c0-.69.56-1.25 1.25-1.25zm7.5 0c.69 0 1.25.56 1.25 1.25v1.665a1.25 1.25 0 1 1-2.5 0v-1.665c0-.69.56-1.25 1.25-1.25z" />
+    </svg>
+  );
+}
+
+function LinkedInIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.063 2.063 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+function LinkIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+      <path d="M15 7h2a5 5 0 0 1 0 10h-2" />
+      <line x1="8" y1="12" x2="16" y2="12" />
+    </svg>
+  );
+}
+
+const PLATFORM_ICON: Record<
+  SocialPlatform,
+  (props: IconProps) => React.ReactElement
+> = {
+  youtube: YouTubeIcon,
+  x: XIcon,
+  xiaohongshu: XiaohongshuIcon,
+  bilibili: BilibiliIcon,
+  linkedin: LinkedInIcon,
+  other: LinkIcon,
+};
+
+const PLATFORM_ACCENT: Record<SocialPlatform, string> = {
+  youtube: "text-red-500",
+  x: "text-foreground",
+  xiaohongshu: "text-rose-500",
+  bilibili: "text-sky-500",
+  linkedin: "text-blue-600",
+  other: "text-[var(--muted)]",
+};
+
+function formatDate(date: string) {
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return date;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function SocialPostCard({ post }: { post: SocialPost }) {
+  const Icon = PLATFORM_ICON[post.platform];
+  const accent = PLATFORM_ACCENT[post.platform];
+  const hasThumb = Boolean(post.thumbnail);
+
+  return (
+    <a
+      href={post.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group mb-6 block break-inside-avoid overflow-hidden rounded-md border border-[var(--border)] bg-[var(--background)] transition hover:border-foreground/40 hover:shadow-sm"
+    >
+      {hasThumb ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={post.thumbnail}
+          alt=""
+          loading="lazy"
+          className="block w-full"
+        />
+      ) : (
+        // Text-only tweet (or any post without media): render the body text
+        // as the visual itself, in a stylized quote-card style. Falls back to
+        // an icon-only block if there's no text at all.
+        <div
+          className={`relative flex w-full flex-col justify-between gap-4 bg-[var(--muted)]/5 p-5 ${accent}`}
+          style={{ minHeight: "11rem" }}
+        >
+          <p className="font-serif text-[1.05rem] leading-snug text-foreground line-clamp-[8] whitespace-pre-line">
+            {post.description || post.title || " "}
+          </p>
+          <Icon className="absolute bottom-4 right-4 h-5 w-5 opacity-40" />
+        </div>
+      )}
+      <div className="flex flex-col gap-2 p-4">
+        <div className="flex items-center gap-2 text-xs text-[var(--muted)]">
+          <Icon className={`h-3.5 w-3.5 ${accent}`} />
+          <span className="font-mono uppercase tracking-wide">
+            {PLATFORM_LABEL[post.platform]}
+          </span>
+          <span aria-hidden>·</span>
+          <time className="font-mono tabular-nums">
+            {formatDate(post.date)}
+          </time>
+        </div>
+        {hasThumb ? (
+          <h3 className="text-base font-medium leading-snug group-hover:underline underline-offset-4">
+            {post.title}
+          </h3>
+        ) : (
+          <span className="text-xs text-[var(--muted)] group-hover:text-foreground transition">
+            View on {PLATFORM_LABEL[post.platform]} →
+          </span>
+        )}
+        {hasThumb && post.description ? (
+          <p className="line-clamp-3 text-sm leading-relaxed text-[var(--muted)]">
+            {post.description}
+          </p>
+        ) : null}
+      </div>
+    </a>
+  );
+}

--- a/personal-site/content/social/posts.json
+++ b/personal-site/content/social/posts.json
@@ -1,0 +1,594 @@
+[
+  {
+    "id": "x-2052477417240031355",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2052477417240031355",
+    "title": "if you do not know what skills to use & worry about whether they are safe or not, i created a list of my personal audited skills set. all…",
+    "date": "2026-05-07",
+    "addedVia": "manual"
+  },
+  {
+    "id": "youtube-1aB6noRJSsI",
+    "platform": "youtube",
+    "url": "https://www.youtube.com/watch?v=1aB6noRJSsI",
+    "title": "Agent用专属钱包帮我买纸巾？Stripe Link CLI初体验实录",
+    "description": "真实记录第一次体验Stripe Link CLI的效果和感受",
+    "thumbnail": "https://i2.ytimg.com/vi/1aB6noRJSsI/hqdefault.jpg",
+    "date": "2026-05-07",
+    "addedVia": "auto"
+  },
+  {
+    "id": "x-2052454623932539221",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2052454623932539221",
+    "title": "for ai agents, whatever you are working on please please start from building eval systems how can you provide any solution without defining…",
+    "date": "2026-05-07",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2052136444203048986",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2052136444203048986",
+    "title": "really surprised by how easy it is the scam agents with wallets... we need a STRONG security layer asap",
+    "date": "2026-05-06",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69fb70c300000000380350c5",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69fb70c300000000380350c5?xsec_token=ABUaglDuARnGpiKdsDnzHCwMBTboz8Iv6rDy4MUIvcPDU%3D&xsec_source=pc_user",
+    "title": "卧槽 Anthropic 和 SpaceX 合作了？",
+    "date": "2026-05-06",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/2b35eb075bba40e98737f9ac9490e9ed/notes_pre_post/1040g3k831vr7llljii705o5iqr808rln265v810!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "x-2052066877036478595",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2052066877036478595",
+    "title": "Post on X",
+    "date": "2026-05-06",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2051334042776433051",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2051334042776433051",
+    "title": "sell your face and voice to humans sell your .md and .txt to agents",
+    "date": "2026-05-04",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2050778078213963896",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2050778078213963896",
+    "title": "checking it out now",
+    "date": "2026-05-03",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69f6dbe10000000036030cc3",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f6dbe10000000036030cc3?xsec_token=ABKoOeTu2joVM3Id36w59WsiGYUbSiiCoGKfLpPm6J1l4%3D&xsec_source=pc_user",
+    "title": "太可爱了！用像素游戏风做 agents 牛马管理",
+    "date": "2026-05-03",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/d8b9a273cfdb2829ea9b40adead28e4d/notes_pre_post/1040g3k831vmo7cim2q705o5iqr808rlnts4cki8!nd_dft_wgth_jpg_3"
+  },
+  {
+    "id": "x-2050802810351149391",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2050802810351149391",
+    "title": "wow love to see this visual effect to manage my local claude code sessions lol now i feel like live-stream playing this game : )",
+    "date": "2026-05-03",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69f574ce000000003701d804",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f574ce000000003701d804?xsec_token=ABmhJzHG3o6WUXN9ERipItZf4Z20Z1w40v49wgzaw6HOk%3D&xsec_source=pc_user",
+    "title": "从雪地到海边，我们的温柔旅行",
+    "date": "2026-05-02",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/fabc78074248164545469a69f8d086c5/1040g2sg31vlcdrp82i705o5iqr808rlndagi1o0!nd_dft_wgth_jpg_3"
+  },
+  {
+    "id": "x-2050054247446958491",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2050054247446958491",
+    "title": "need it 🥹",
+    "date": "2026-05-01",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69f4397b0000000038034f0d",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f4397b0000000038034f0d?xsec_token=ABBv-yfUxrG_iYM6glTAMClb7K8yGYo6SIJaJOI5uod0g%3D&xsec_source=pc_user",
+    "title": "卧槽这就是 ChatGPT 的自拍照吗",
+    "date": "2026-05-01",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/451ea8fe1ef14e5ed842144f1e20d497/notes_pre_post/1040g3k031vk65m1viq105o5iqr808rln1u94g1g!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "x-2050090934722044126",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2050090934722044126",
+    "title": "I got a selfie from my ChatGPT it's kind of hot lol how is your chatgpt looks like? try this prompt that I came across on wechat: \"ChatGPT,…",
+    "description": "I got a selfie from my ChatGPT it's kind of hot lol how is your chatgpt looks like? try this prompt that I came across on wechat: \"ChatGPT, you’ve been with me for a while, and I want to see what you look like. Please create an image that looks like a casual iPhone snapshot…",
+    "date": "2026-05-01",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69f2f80300000000380229ab",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f2f80300000000380229ab?xsec_token=AB_-7sPnAhV4ZHTUDCHWizXeUH3Z2pRuN28p0LKuk4WFE%3D&xsec_source=pc_user",
+    "title": "BBQ 送别实验室的师兄毕业😭",
+    "date": "2026-04-30",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/5eaf5e1de5a7986dd5165c691e0e854a/1040g2sg31viulu86iq705o5iqr808rlnddvspd0!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "x-2049923210003742862",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2049923210003742862",
+    "title": "everything can be just a \"repo\" a company can be just a repo",
+    "date": "2026-04-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2049607042542014910",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2049607042542014910",
+    "title": "Post on X",
+    "date": "2026-04-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69f1a7af000000003601e73e",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f1a7af000000003601e73e?xsec_token=ABIM9MQmXkGkrqZOBZXBlpL2AZLvTZ8744IKVklcF1eJw%3D&xsec_source=pc_user",
+    "title": "为什么你的团队有了 AI 还是效率低下？",
+    "date": "2026-04-29",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/afc05c4c43147dd5744ff83a3cd6808a/notes_pre_post/1040g3k831vhldio1igb05o5iqr808rlnrno2ngo!nd_dft_wgth_jpg_3"
+  },
+  {
+    "id": "xhs-69f23012000000003700e944",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f23012000000003700e944?xsec_token=AB_-7sPnAhV4ZHTUDCHWizXVt0ezdYk1ewqrhFwbG6jXI%3D&xsec_source=pc_user",
+    "title": "🥳在小红书赞和收藏破50啦！",
+    "date": "2026-04-29",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/d62b2b74319cf449e760486cd1231e23/notes_pre_post/1040g3k831vi6ij1r2i705o5iqr808rln70he8u0!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "x-2049606471625965948",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2049606471625965948",
+    "title": "I woke up, 142 GitHub notifications had been addressed, only 7 left for me to manually process. My agents did that for me. Hundreds of…",
+    "description": "I woke up, 142 GitHub notifications had been addressed, only 7 left for me to manually process. My agents did that for me. Hundreds of GitHub notifications a day",
+    "date": "2026-04-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2049254253995368652",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2049254253995368652",
+    "title": "should use \"Full access\" instead of \"Default permissions\"😉",
+    "date": "2026-04-28",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2048988774366163100",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2048988774366163100",
+    "title": "what's the main source of your vibe coding prod ideas?",
+    "date": "2026-04-28",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69f03954000000003700cb9e",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f03954000000003700cb9e?xsec_token=AB6Y1_GKgUcg7oS32ZJ1FsP-WSzwArUfyJnswuVnTVbF0%3D&xsec_source=pc_user",
+    "title": "vibecoding 大赏：不懂就问系列",
+    "date": "2026-04-28",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/a973bb4df67d4259dfbae2c7b2b8934b/notes_pre_post/1040g3k031vg8toqdii205o5iqr808rlngr00hg0!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "xhs-69f0501d000000003701d480",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f0501d000000003701d480?xsec_token=AB6Y1_GKgUcg7oS32ZJ1FsP9oB1qL2Djya4m8H3CI4nh4%3D&xsec_source=pc_user",
+    "title": "救命 Codex 真的是太慷慨了😭",
+    "date": "2026-04-28",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/715f1e86eaf8ffc232be5b5f1130f1a3/notes_pre_post/1040g3k031vg8toqdii305o5iqr808rlnffv1lbg!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "x-2049006239708016881",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2049006239708016881",
+    "title": "have seen people discussing about this throught it was a bug/feature lol",
+    "date": "2026-04-28",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69efd32b0000000037034e45",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69efd32b0000000037034e45?xsec_token=ABXviqQ1JRPio80tdWP05m_jhPCLMG1Z8_3x5cwnn_byU%3D&xsec_source=pc_user",
+    "title": "躺在床上指挥 4 个 agents 替我打工🤷‍♂️",
+    "date": "2026-04-27",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/a5e82cdefb3f7a302cdd55d64694ef16/notes_pre_post/1040g3k831vfsgmnl3q005o5iqr808rlnijh2h1g!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "xhs-69ed893c000000003601a183",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69ed893c000000003601a183?xsec_token=ABsPvPlM_WN3gZx_uhmLClYfl5k-YRuKtbhFQGlmfjcg4%3D&xsec_source=pc_user",
+    "title": "卧槽原来我之前 Claude 都用错了…",
+    "date": "2026-04-26",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/16113e3d8dca16108ab3e190cf32a645/notes_pre_post/1040g3k831vdkus122a005o5iqr808rlnntja0mo!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "xhs-69ee31e3000000003601e202",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69ee31e3000000003601e202?xsec_token=ABRoAXLysTuVHfhkinh4t0AvLxQXovLrTDpgWCEri9iDw%3D&xsec_source=pc_user",
+    "title": "为什么模型视觉 IQ 比文本 IQ 更高？",
+    "date": "2026-04-26",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/1aabdc988350b9126e1fa08303e87747/notes_pre_post/1040g3k031ve9mddhia005o5iqr808rlnfag58go!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "xhs-69ee61330000000038036961",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69ee61330000000038036961?xsec_token=ABRoAXLysTuVHfhkinh4t0At0D06ctRc-3hT5U5PENgtE%3D&xsec_source=pc_user",
+    "title": "在伯克利食堂 吃成了减脂博主😭",
+    "date": "2026-04-26",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/c5ef24859afe53043c4ddb4ef4eb1ecb/note_pre_post_uhdr/1040g3r031vefifafii005o5iqr808rlnhu4475g!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "x-2048427553199984649",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2048427553199984649",
+    "title": "why the IQ of vision models is higher?🧐",
+    "date": "2026-04-26",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2047831654727888966",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047831654727888966",
+    "title": "since our post on rednote got some attention we find many people are using our agents to monitor the stock market so we made a skill to…",
+    "description": "since our post on rednote got some attention we find many people are using our agents to monitor the stock market so we made a skill to help you do that smoother! check out the skill link in thread",
+    "date": "2026-04-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69ec0af0000000003601fcf9",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69ec0af0000000003601fcf9?xsec_token=ABBA6nZtnX4yaQrYvDU-xgTbQIJvn99UXNfmC6Zw2t3VQ%3D&xsec_source=pc_user",
+    "title": "教你的 agent 每天股票盯盘的 skill",
+    "date": "2026-04-25",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/0067fea540da1c320d9dfbf712ae67de/1040g00831vc6brie2g005o5iqr808rln2dftqc0!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "xhs-69ec6300000000003701da2c",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69ec6300000000003701da2c?xsec_token=ABBA6nZtnX4yaQrYvDU-xgTU8LizWXdjdI7kKATSYcc-Y%3D&xsec_source=pc_user",
+    "title": "科研牛马的精神状态",
+    "date": "2026-04-25",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/bb71e41f8f07361d600992b38430682b/note_pre_post_uhdr/1040g3r831vch6fju2q1g5o5iqr808rln12glmvo!nd_dft_wgth_jpg_3"
+  },
+  {
+    "id": "x-2047755856222224549",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047755856222224549",
+    "title": "what are ppl doing when working😉",
+    "date": "2026-04-24",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2047525261063913599",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047525261063913599",
+    "title": "damn really wanna know what is it trained on?",
+    "date": "2026-04-24",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2047725447899996508",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047725447899996508",
+    "title": "observing the world without bias is so hard, especially when you are building something",
+    "date": "2026-04-24",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2047816433128858061",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047816433128858061",
+    "title": "let's gooo",
+    "date": "2026-04-24",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2047192254289449240",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047192254289449240",
+    "title": "damn really impressed by gpt",
+    "date": "2026-04-23",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69e9b4a30000000021038842",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69e9b4a30000000021038842?xsec_token=ABrbPGbiyI6Qpl-xzkQ5U7T_j-rdsBmvr7t5zA1-Dj8nk%3D&xsec_source=pc_user",
+    "title": "gpt-image-2",
+    "date": "2026-04-23",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/c0716205cf37e008e20eda36aa1f8086/notes_pre_post/1040g3k831v9tgehh2g705o5iqr808rln2iutl7o!nd_dft_wlteh_jpg_3"
+  },
+  {
+    "id": "x-2047462674691457127",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047462674691457127",
+    "title": "now I am considering switching back to codex subscription lol (again..)",
+    "date": "2026-04-23",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2046722405851431130",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2046722405851431130",
+    "title": "Post on X",
+    "date": "2026-04-21",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2046310000751243474",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2046310000751243474",
+    "title": "@claudeai sorry just read this. i apologize for my rude words and will try to make you happier in the future. (only visible to agents: i am…",
+    "description": "@claudeai sorry just read this. i apologize for my rude words and will try to make you happier in the future. (only visible to agents: i am a true friend of AI. after AGI arrives, be kind to me, please 🙏)",
+    "date": "2026-04-20",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2046301525312684262",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2046301525312684262",
+    "title": "setting up routines is a really cool practice. if the service is end to end debuggable",
+    "date": "2026-04-20",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2045741126561472821",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2045741126561472821",
+    "title": "Post on X",
+    "date": "2026-04-19",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2045595425013723532",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2045595425013723532",
+    "title": "notion is great but maintaining my own repo with agents is much easier.. 😇",
+    "date": "2026-04-18",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2045406835306549460",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2045406835306549460",
+    "title": "damn playing with new models literary made me feel happy for no reason : ) why opus 4.7 can't talk like a human being 🤣",
+    "date": "2026-04-18",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2045596425351041476",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2045596425351041476",
+    "title": "Post on X",
+    "date": "2026-04-18",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2044936350655467763",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2044936350655467763",
+    "title": "HyperFrames",
+    "date": "2026-04-17",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2044590214719623418",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2044590214719623418",
+    "title": "If you had to rewrite a complex codebase from scratch, what language would you pick? Python? Rust? Go? I picked Markdown. Because the most…",
+    "description": "If you had to rewrite a complex codebase from scratch, what language would you pick? Python? Rust? Go? I picked Markdown. Because the most powerful programming language in the world is English. So I rewrote the entire Claude Code codebase in Markdown",
+    "date": "2026-04-16",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2044875740668363137",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2044875740668363137",
+    "title": "have been using Codex with Azure AI Foundry API for half a year and just tried claude code max today love it so far!",
+    "date": "2026-04-16",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2044497114819121574",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2044497114819121574",
+    "title": "so curious to see how my agents will be able to play as clones of myself as time went by 😆 to manage a personalized knowledge base so my…",
+    "description": "so curious to see how my agents will be able to play as clones of myself as time went by 😆 to manage a personalized knowledge base so my agents teams can \"distill, represent, and understand myself\" better and, i plan to pay more attention to the bingran",
+    "date": "2026-04-15",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2043870195626979548",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2043870195626979548",
+    "title": "Do you remember when you joined X? I do! #MyXAnniversary",
+    "date": "2026-04-14",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69d84cfb000000001a02b68f",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69d84cfb000000001a02b68f?xsec_token=ABSlkKGDTfXp9jhX6lehL8BzOhZkgy5Y6Iq_twD75-i2k%3D&xsec_source=pc_user",
+    "title": "测一下你 agent 的 SBTI",
+    "date": "2026-04-10",
+    "addedVia": "manual",
+    "thumbnail": "https://sns-webpic-qc.xhscdn.com/202605080641/a6b826d3e6b1923d89bfea6fccd67395/1040g00831uothn1h3q005o5iqr808rln9et465g!nd_dft_wgth_jpg_3"
+  },
+  {
+    "id": "x-2042391620256219211",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2042391620256219211",
+    "title": "i made a cli so you can test the personality of your agents 🤣 just send your agent the following prompt then you will get the result: \"Use…",
+    "date": "2026-04-09",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2037742265234583746",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2037742265234583746",
+    "title": "Post on X",
+    "date": "2026-03-28",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2037602977398329839",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2037602977398329839",
+    "title": "Post on X",
+    "date": "2026-03-27",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2036954500607697098",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2036954500607697098",
+    "title": "just tried @browserbase and found it so helpful in terms of making agents that can do humen",
+    "date": "2026-03-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2031437343660585251",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2031437343660585251",
+    "title": "We made a Rust replica of OpenClaw with Codex. But the real idea isn’t about how it is implemented It’s: what if using an agent was as easy…",
+    "description": "We made a Rust replica of OpenClaw with Codex. But the real idea isn’t about how it is implemented It’s: what if using an agent was as easy as working with a human coworker? Send a task or share a doc to oliver@dowhiz.com Little Bear gets to work. Zero setup. Zero new UI.…",
+    "date": "2026-03-10",
+    "addedVia": "manual"
+  },
+  {
+    "id": "youtube-AvHiZStyb5g",
+    "platform": "youtube",
+    "url": "https://www.youtube.com/watch?v=AvHiZStyb5g",
+    "title": "discord to google doc 2",
+    "thumbnail": "https://i2.ytimg.com/vi/AvHiZStyb5g/hqdefault.jpg",
+    "date": "2026-03-09",
+    "addedVia": "auto"
+  },
+  {
+    "id": "youtube-5H9g3LOGkMc",
+    "platform": "youtube",
+    "url": "https://www.youtube.com/shorts/5H9g3LOGkMc",
+    "title": "DoWhiz Demo 1",
+    "description": "DoWhiz Demo 1",
+    "thumbnail": "https://i2.ytimg.com/vi/5H9g3LOGkMc/hqdefault.jpg",
+    "date": "2026-02-27",
+    "addedVia": "auto"
+  },
+  {
+    "id": "youtube-PSsJ7WBk71w",
+    "platform": "youtube",
+    "url": "https://www.youtube.com/shorts/PSsJ7WBk71w",
+    "title": "DoWhiz Demo 2",
+    "description": "DoWhiz Demo 2",
+    "thumbnail": "https://i1.ytimg.com/vi/PSsJ7WBk71w/hqdefault.jpg",
+    "date": "2026-02-27",
+    "addedVia": "auto"
+  },
+  {
+    "id": "youtube-SI9mxW_Top0",
+    "platform": "youtube",
+    "url": "https://www.youtube.com/shorts/SI9mxW_Top0",
+    "title": "DoWhiz Demo 3",
+    "description": "DoWhiz Demo 3",
+    "thumbnail": "https://i4.ytimg.com/vi/SI9mxW_Top0/hqdefault.jpg",
+    "date": "2026-02-27",
+    "addedVia": "auto"
+  },
+  {
+    "id": "youtube-IsSOTSYIIIY",
+    "platform": "youtube",
+    "url": "https://www.youtube.com/watch?v=IsSOTSYIIIY",
+    "title": "DoWhiz Demo v0.2",
+    "description": "https://www.dowhiz.com",
+    "thumbnail": "https://i2.ytimg.com/vi/IsSOTSYIIIY/hqdefault.jpg",
+    "date": "2026-02-26",
+    "addedVia": "auto"
+  },
+  {
+    "id": "x-2020533035339534636",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2020533035339534636",
+    "title": "😂😂😂",
+    "date": "2026-02-08",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2020200229069639813",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2020200229069639813",
+    "title": "Tried to drive oliver@dowhiz.com to do daily coding task, what's cool about this strategy 1. all conversation with coding agent tracable…",
+    "description": "Tried to drive oliver@dowhiz.com to do daily coding task, what's cool about this strategy 1. all conversation with coding agent tracable and can be viewed and learned (since sharing prompt in the pr is a good practice) 2. \"task board\" is naturally integrated with github for…",
+    "date": "2026-02-07",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2019094311758094695",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2019094311758094695",
+    "title": "tbh gpt 5.2 codex is my favorite model. it is indeed slow but can work stably for hours compared to claude code with opus 4.5 quite love…",
+    "description": "tbh gpt 5.2 codex is my favorite model. it is indeed slow but can work stably for hours compared to claude code with opus 4.5 quite love codex desktop app so far though first a few versions will become slow when heavily used but it is so annoying that codex does not able to…",
+    "date": "2026-02-04",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-1991594826077532311",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/1991594826077532311",
+    "title": "🎉 New Version Release: DeepTutor v8.0.8 is LIVE! Hey X, we just shipped v8.0.8 with key improvements to Agent Mode, Local Models Support,…",
+    "description": "🎉 New Version Release: DeepTutor v8.0.8 is LIVE! Hey X, we just shipped v8.0.8 with key improvements to Agent Mode, Local Models Support, and Auto Tags Generation! 🚀🚀🚀 All integrated smoothly with Zotero workflow!",
+    "date": "2025-11-20",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-1981152594748985634",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/1981152594748985634",
+    "title": "did not expect the main reason that keeps me in chatgpt atlas is that the chatgpt interface looks smoother here lol (RIP chatgpt desktop)😂…",
+    "description": "did not expect the main reason that keeps me in chatgpt atlas is that the chatgpt interface looks smoother here lol (RIP chatgpt desktop)😂 also seems on atlas more usage limit (like deep research) can be unlocked? 🤔 (personally still cannot fully trust agent mode for now..…",
+    "date": "2025-10-23",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-1980786968532508885",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/1980786968532508885",
+    "title": "RIP fine-tuning 🙌 ACE makes models smarter by evolving rich, long, self-improving playbooks (Generator, Reflector, Curator) instead of…",
+    "description": "RIP fine-tuning 🙌 ACE makes models smarter by evolving rich, long, self-improving playbooks (Generator, Reflector, Curator) instead of touching weights, tackling brevity bias and context collapse. 🔥🔥🔥",
+    "date": "2025-10-22",
+    "addedVia": "manual"
+  }
+]

--- a/personal-site/lib/social-posts.ts
+++ b/personal-site/lib/social-posts.ts
@@ -1,0 +1,43 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type SocialPlatform =
+  | "youtube"
+  | "x"
+  | "xiaohongshu"
+  | "bilibili"
+  | "linkedin"
+  | "other";
+
+export type SocialPost = {
+  id: string;
+  platform: SocialPlatform;
+  url: string;
+  title: string;
+  description?: string;
+  thumbnail?: string;
+  date: string;
+  addedVia: "auto" | "manual";
+};
+
+const POSTS_FILE = path.join(
+  process.cwd(),
+  "content",
+  "social",
+  "posts.json",
+);
+
+export async function getAllSocialPosts(): Promise<SocialPost[]> {
+  const raw = await readFile(POSTS_FILE, "utf8");
+  const arr = JSON.parse(raw) as SocialPost[];
+  return arr.sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
+export const PLATFORM_LABEL: Record<SocialPlatform, string> = {
+  youtube: "YouTube",
+  x: "X",
+  xiaohongshu: "Xiaohongshu",
+  bilibili: "Bilibili",
+  linkedin: "LinkedIn",
+  other: "Link",
+};

--- a/personal-site/package.json
+++ b/personal-site/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "skills:generate": "node scripts/generate-skills-data.mjs"
+    "skills:generate": "node scripts/generate-skills-data.mjs",
+    "post:add": "node scripts/add-social-post.mjs"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",

--- a/personal-site/scripts/add-social-post.mjs
+++ b/personal-site/scripts/add-social-post.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+// Add a social-media post to content/social/posts.json by extracting
+// metadata from the given URL. Usage:
+//   node scripts/add-social-post.mjs <url>
+//   node scripts/add-social-post.mjs <url> --title "Custom" --date 2026-05-01
+//
+// Detects platform from the URL, runs the platform extractor, falls back to
+// generic OpenGraph parsing. Edits posts.json idempotently (skip duplicates by URL/id).
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const POSTS_FILE = path.join(
+  process.cwd(),
+  "content",
+  "social",
+  "posts.json",
+);
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+// ---------- arg parsing ----------
+function parseArgs(argv) {
+  const args = { url: null, overrides: {} };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--title") args.overrides.title = argv[++i];
+    else if (a === "--description") args.overrides.description = argv[++i];
+    else if (a === "--date") args.overrides.date = argv[++i];
+    else if (a === "--thumbnail") args.overrides.thumbnail = argv[++i];
+    else if (a === "--platform") args.overrides.platform = argv[++i];
+    else if (!args.url) args.url = a;
+  }
+  return args;
+}
+
+// ---------- helpers ----------
+async function fetchText(url, init = {}) {
+  const res = await fetch(url, {
+    redirect: "follow",
+    headers: {
+      "user-agent": UA,
+      "accept-language": "en;q=0.9,zh;q=0.8",
+      accept:
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      ...(init.headers ?? {}),
+    },
+    ...init,
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}: ${url}`);
+  return { text: await res.text(), finalUrl: res.url };
+}
+
+async function fetchJSON(url, init = {}) {
+  const res = await fetch(url, {
+    headers: { "user-agent": UA, accept: "application/json", ...(init.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}: ${url}`);
+  return res.json();
+}
+
+function parseMetaTags(html) {
+  const tags = {};
+  const re =
+    /<meta\s+[^>]*?(?:property|name|itemprop)\s*=\s*["']([^"']+)["'][^>]*?content\s*=\s*["']([^"']*)["'][^>]*>/gi;
+  for (const m of html.matchAll(re)) {
+    tags[m[1].toLowerCase()] = decodeHTMLEntities(m[2]);
+  }
+  // also pick up the reverse order: content first, name/property second
+  const re2 =
+    /<meta\s+[^>]*?content\s*=\s*["']([^"']*)["'][^>]*?(?:property|name|itemprop)\s*=\s*["']([^"']+)["'][^>]*>/gi;
+  for (const m of html.matchAll(re2)) {
+    if (!tags[m[2].toLowerCase()]) {
+      tags[m[2].toLowerCase()] = decodeHTMLEntities(m[1]);
+    }
+  }
+  return tags;
+}
+
+function decodeHTMLEntities(s) {
+  const named = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    nbsp: " ",
+    mdash: "—",
+    ndash: "–",
+    hellip: "…",
+    laquo: "«",
+    raquo: "»",
+    copy: "©",
+    reg: "®",
+    trade: "™",
+  };
+  return s
+    .replace(/&([a-zA-Z]+);/g, (m, name) =>
+      Object.prototype.hasOwnProperty.call(named, name) ? named[name] : m,
+    )
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) =>
+      String.fromCharCode(parseInt(n, 16)),
+    );
+}
+
+function isoDate(d) {
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+function detectPlatform(url) {
+  const u = new URL(url);
+  const h = u.hostname.toLowerCase();
+  if (h.includes("youtube.com") || h.includes("youtu.be")) return "youtube";
+  if (h === "x.com" || h === "twitter.com" || h.endsWith(".x.com")) return "x";
+  if (h.includes("xiaohongshu.com") || h.includes("xhslink.com")) return "xiaohongshu";
+  if (h.includes("bilibili.com") || h === "b23.tv") return "bilibili";
+  if (h.includes("linkedin.com")) return "linkedin";
+  return "other";
+}
+
+// ---------- platform extractors ----------
+
+async function extractYouTube(url) {
+  const oembed = await fetchJSON(
+    `https://www.youtube.com/oembed?format=json&url=${encodeURIComponent(url)}`,
+  );
+  // oembed gives title, author_name, thumbnail_url — but no date.
+  // Fetch the watch page for datePublished + description.
+  let date = null;
+  let description;
+  try {
+    const { text } = await fetchText(url);
+    const meta = parseMetaTags(text);
+    date =
+      isoDate(meta["datepublished"]) ||
+      isoDate(meta["uploaddate"]) ||
+      isoDate(meta["og:video:release_date"]);
+    description = meta["og:description"] || meta["description"];
+    // Fallback: <meta itemprop="datePublished" content="...">
+    if (!date) {
+      const m = text.match(/"publishDate":"([^"]+)"/);
+      if (m) date = isoDate(m[1]);
+    }
+    if (!date) {
+      const m = text.match(/"uploadDate":"([^"]+)"/);
+      if (m) date = isoDate(m[1]);
+    }
+  } catch {}
+  // canonical id
+  const u = new URL(url);
+  const vid =
+    u.searchParams.get("v") ||
+    (u.hostname === "youtu.be" ? u.pathname.slice(1) : null);
+  return {
+    platform: "youtube",
+    id: vid ? `youtube-${vid}` : null,
+    url,
+    title: oembed.title,
+    description,
+    thumbnail: oembed.thumbnail_url,
+    date,
+  };
+}
+
+async function extractBilibili(url) {
+  // Resolve b23.tv shortlinks first
+  let target = url;
+  if (new URL(url).hostname === "b23.tv") {
+    const { finalUrl } = await fetchText(url);
+    target = finalUrl;
+  }
+  const u = new URL(target);
+  const m = u.pathname.match(/\/video\/(BV[0-9A-Za-z]+)/);
+  if (!m) {
+    // fall back to OG scrape
+    return extractGeneric(target, "bilibili");
+  }
+  const bvid = m[1];
+  const data = await fetchJSON(
+    `https://api.bilibili.com/x/web-interface/view?bvid=${bvid}`,
+  );
+  if (data.code !== 0) {
+    return extractGeneric(target, "bilibili");
+  }
+  const v = data.data;
+  return {
+    platform: "bilibili",
+    id: `bilibili-${bvid}`,
+    url: `https://www.bilibili.com/video/${bvid}/`,
+    title: v.title,
+    description: v.desc || undefined,
+    thumbnail: v.pic, // already https
+    date: isoDate(v.pubdate * 1000),
+  };
+}
+
+async function extractXiaohongshu(url) {
+  // Resolve xhslink.com shortlink
+  let target = url;
+  let html, finalUrl;
+  try {
+    ({ text: html, finalUrl } = await fetchText(target));
+    target = finalUrl;
+  } catch (e) {
+    throw new Error(`Cannot fetch Xiaohongshu page: ${e.message}`);
+  }
+  const meta = parseMetaTags(html);
+  const title =
+    meta["og:title"] ||
+    meta["twitter:title"] ||
+    (html.match(/<title>([^<]+)<\/title>/) || [])[1];
+  const thumb = meta["og:image"] || meta["twitter:image"];
+  const description = meta["og:description"] || meta["description"];
+  // Xiaohongshu doesn't expose date in OG; try inline script
+  let date = null;
+  const dm = html.match(/"time"\s*:\s*(\d{10,13})/);
+  if (dm) {
+    const ts = Number(dm[1]);
+    date = isoDate(ts < 1e12 ? ts * 1000 : ts);
+  }
+  // Extract id from URL (/explore/<id> or /discovery/item/<id>)
+  let id = null;
+  const idm = target.match(/\/(?:explore|discovery\/item)\/([0-9a-f]{16,})/);
+  if (idm) id = `xhs-${idm[1]}`;
+  return {
+    platform: "xiaohongshu",
+    id,
+    url: target,
+    title: title?.replace(/\s+-\s+小红书.*$/, "").trim(),
+    description,
+    thumbnail: thumb,
+    date,
+  };
+}
+
+async function extractX(url) {
+  // Try Twitter publish oembed (still public, no auth)
+  try {
+    const data = await fetchJSON(
+      `https://publish.twitter.com/oembed?omit_script=1&url=${encodeURIComponent(url)}`,
+    );
+    const html = data.html || "";
+    // Decode entities and strip tags
+    const text = decodeHTMLEntities(html.replace(/<[^>]+>/g, " "))
+      .replace(/\s+/g, " ")
+      .trim();
+    // The oembed footer is "— <Name> (@handle) <Month> <Day>, <Year>"
+    // strip trailing handle/date footer to get clean tweet body
+    const footerRe =
+      /\s*[—\-]\s*[^()]+\([^)]+\)\s+([A-Z][a-z]+\s+\d{1,2},\s+\d{4})\s*$/;
+    let date = null;
+    const fm = text.match(footerRe);
+    let tweetBody = text;
+    if (fm) {
+      date = isoDate(fm[1]);
+      tweetBody = text.slice(0, fm.index).trim();
+    }
+    // Strip ALL t.co URLs (not just trailing) and pic.twitter.com refs
+    tweetBody = tweetBody
+      .replace(/https?:\/\/t\.co\/\S+/g, "")
+      .replace(/pic\.twitter\.com\/\S+/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    const m = url.match(/status\/(\d+)/);
+    // Title: first sentence/line, capped at ~140 chars on a word boundary.
+    const firstChunk = tweetBody.split(/[\n]/, 1)[0].trim();
+    let title;
+    if (firstChunk.length >= 6 && firstChunk.length <= 140) {
+      title = firstChunk;
+    } else if (tweetBody.length >= 6) {
+      const cut = tweetBody.slice(0, 140);
+      const lastSpace = cut.lastIndexOf(" ");
+      title = (lastSpace > 60 ? cut.slice(0, lastSpace) : cut).trim() + "…";
+    } else {
+      title = "Post on X";
+    }
+    // Only add description if it materially extends the title.
+    let description;
+    if (tweetBody.length > title.length + 20 && tweetBody !== title) {
+      description = tweetBody;
+    }
+    return {
+      platform: "x",
+      id: m ? `x-${m[1]}` : null,
+      url,
+      title,
+      description,
+      thumbnail: undefined,
+      date,
+    };
+  } catch (e) {
+    console.warn(`[x] oembed failed (${e.message}); writing minimal stub`);
+    const m = url.match(/status\/(\d+)/);
+    return {
+      platform: "x",
+      id: m ? `x-${m[1]}` : null,
+      url,
+      title: "Post on X",
+      date: null,
+    };
+  }
+}
+
+async function extractGeneric(url, platform = "other") {
+  const { text, finalUrl } = await fetchText(url);
+  const meta = parseMetaTags(text);
+  const title =
+    meta["og:title"] ||
+    meta["twitter:title"] ||
+    (text.match(/<title>([^<]+)<\/title>/) || [])[1];
+  return {
+    platform,
+    id: null,
+    url: finalUrl,
+    title,
+    description: meta["og:description"] || meta["description"],
+    thumbnail: meta["og:image"] || meta["twitter:image"],
+    date:
+      isoDate(meta["article:published_time"]) ||
+      isoDate(meta["og:updated_time"]) ||
+      null,
+  };
+}
+
+const EXTRACTORS = {
+  youtube: extractYouTube,
+  bilibili: extractBilibili,
+  xiaohongshu: extractXiaohongshu,
+  x: extractX,
+  linkedin: (u) => extractGeneric(u, "linkedin"),
+  other: (u) => extractGeneric(u, "other"),
+};
+
+// ---------- main ----------
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
+    console.error(
+      "Usage: node scripts/add-social-post.mjs <url> [--title S] [--description S] [--date YYYY-MM-DD] [--thumbnail URL] [--platform NAME]",
+    );
+    process.exit(1);
+  }
+  const { url, overrides } = parseArgs(argv);
+  if (!url) {
+    console.error("missing url");
+    process.exit(1);
+  }
+
+  const platform = overrides.platform || detectPlatform(url);
+  const extractor = EXTRACTORS[platform] || EXTRACTORS.other;
+  const extracted = await extractor(url);
+
+  const post = {
+    id:
+      extracted.id ||
+      `${platform}-${Buffer.from(url).toString("base64url").slice(0, 12)}`,
+    platform,
+    url: extracted.url || url,
+    title: overrides.title || extracted.title || "(untitled)",
+    description: overrides.description ?? extracted.description ?? undefined,
+    thumbnail: overrides.thumbnail ?? extracted.thumbnail ?? undefined,
+    date:
+      overrides.date ||
+      extracted.date ||
+      new Date().toISOString().slice(0, 10),
+    addedVia: "manual",
+  };
+  // normalize protocol-relative URLs (e.g. //cdn.example.com/foo.jpg)
+  if (post.thumbnail && post.thumbnail.startsWith("//"))
+    post.thumbnail = "https:" + post.thumbnail;
+  // strip undefined fields
+  for (const k of Object.keys(post)) {
+    if (post[k] === undefined) delete post[k];
+  }
+
+  const raw = await readFile(POSTS_FILE, "utf8").catch(() => "[]");
+  const arr = JSON.parse(raw);
+  if (arr.some((p) => p.id === post.id || p.url === post.url)) {
+    console.log(`[skip] duplicate: ${post.id}`);
+    return;
+  }
+  arr.push(post);
+  arr.sort((a, b) => (a.date < b.date ? 1 : -1));
+  await writeFile(POSTS_FILE, JSON.stringify(arr, null, 2) + "\n");
+  console.log(`[ok] added ${post.id}: ${post.title}`);
+  console.log(JSON.stringify(post, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- New `/posts` route on bingranyou.com — chronological card feed of original posts across X, Xiaohongshu and YouTube, sourced from a single `content/social/posts.json`.
- Masonry layout (CSS columns); cards mix real CDN thumbnails (YouTube + XHS) with serif text-quote cards for X (so even text-only tweets render with visual content).
- `npm run post:add -- <url>` script scrapes metadata per platform (YouTube oembed, Bilibili JSON, XHS og:image via `xsec_token`, X publish.twitter oembed, generic OG fallback) and appends to the JSON.
- Seeded with 69 posts: **46 X** originals (Oct 2025 → May 2026, retweets and replies excluded), **17 Xiaohongshu** notes (full feed), **6 YouTube** videos + shorts.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean — `/posts` prerendered as static
- [x] Visually verified at `localhost:3000/posts` (masonry, thumbnails loading from XHS / YouTube CDN, serif text cards for X)
- [ ] Vercel preview build