### PR TITLE
personal-site: extract skills-browser ViewModel and add vitest

### DIFF
--- a/personal-site/app/(personal)/page.tsx
+++ b/personal-site/app/(personal)/page.tsx
@@ -1,6 +1,10 @@
 import Image from "next/image";
 import Link from "next/link";
-import { education, projects, papers } from "@/lib/content";
+import {
+  education,
+  getAiPaperHighlights,
+  getAiProjectHighlights,
+} from "@/lib/content";
 import { jsonLdScriptContent, profilePageJsonLd } from "@/lib/jsonld";
 import {
   AtomIcon,
@@ -9,8 +13,8 @@ import {
 } from "@/components/bio-icons";
 
 export default function Home() {
-  const aiHighlights = projects.filter((p) => p.track === "ai").slice(0, 5);
-  const paperHighlights = papers.filter((p) => p.track === "ai").slice(0, 2);
+  const aiHighlights = getAiProjectHighlights();
+  const paperHighlights = getAiPaperHighlights();
 
   return (
     <div className="space-y-16 sm:space-y-24">

--- a/personal-site/app/(personal)/skills/_components/skills-browser.tsx
+++ b/personal-site/app/(personal)/skills/_components/skills-browser.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useDeferredValue, useMemo, useState } from "react";
 import type { Skill, SkillCategory } from "@/lib/skills";
+import { buildSkillsViewModel } from "@/lib/skills-browser-vm";
 
 type Props = {
   skills: Skill[];
@@ -16,36 +17,14 @@ export function SkillsBrowser({ skills, categories }: Props) {
   );
   const deferredQuery = useDeferredValue(query);
 
-  const q = deferredQuery.trim().toLowerCase();
-
-  const queryMatches = useMemo(() => {
-    if (!q) return skills;
-    return skills.filter(
-      (s) =>
-        s.name.toLowerCase().includes(q) ||
-        s.slug.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q) ||
-        (s.triggers?.some((t) => t.toLowerCase().includes(q)) ?? false),
-    );
-  }, [skills, q]);
-
-  const filtered = useMemo(() => {
-    if (activeCategory === "All") return queryMatches;
-    return queryMatches.filter((s) => s.category === activeCategory);
-  }, [queryMatches, activeCategory]);
-
-  const queryMatchesAcrossCategories =
-    q && activeCategory !== "All" ? queryMatches.length : 0;
-
-  const grouped = useMemo(() => {
-    const map = new Map<SkillCategory, Skill[]>();
-    for (const cat of categories) map.set(cat, []);
-    for (const s of filtered) {
-      if (!map.has(s.category)) map.set(s.category, []);
-      map.get(s.category)!.push(s);
-    }
-    return Array.from(map.entries()).filter(([, list]) => list.length > 0);
-  }, [filtered, categories]);
+  const vm = useMemo(
+    () =>
+      buildSkillsViewModel(skills, categories, {
+        query: deferredQuery,
+        activeCategory,
+      }),
+    [skills, categories, deferredQuery, activeCategory],
+  );
 
   return (
     <div className="space-y-8">
@@ -64,25 +43,22 @@ export function SkillsBrowser({ skills, categories }: Props) {
 
         <div className="-mx-4 flex gap-1.5 overflow-x-auto px-4 pb-1 sm:-mx-1 sm:flex-wrap sm:overflow-visible sm:px-1 sm:pb-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <CategoryChip
-            label={`All · ${skills.length}`}
+            label={`All · ${vm.totalCount}`}
             active={activeCategory === "All"}
             onClick={() => setActiveCategory("All")}
           />
-          {categories.map((cat) => {
-            const count = skills.filter((s) => s.category === cat).length;
-            return (
-              <CategoryChip
-                key={cat}
-                label={`${cat} · ${count}`}
-                active={activeCategory === cat}
-                onClick={() => setActiveCategory(cat)}
-              />
-            );
-          })}
+          {categories.map((cat) => (
+            <CategoryChip
+              key={cat}
+              label={`${cat} · ${vm.categoryCounts.get(cat) ?? 0}`}
+              active={activeCategory === cat}
+              onClick={() => setActiveCategory(cat)}
+            />
+          ))}
         </div>
       </div>
 
-      {filtered.length === 0 ? (
+      {vm.isEmpty ? (
         <div className="py-16 text-center text-sm text-[var(--muted)]">
           <p>
             No skills match{" "}
@@ -95,19 +71,19 @@ export function SkillsBrowser({ skills, categories }: Props) {
             ) : null}
             .
           </p>
-          {queryMatchesAcrossCategories > 0 ? (
+          {vm.queryMatchesAcrossCategories > 0 ? (
             <button
               type="button"
               onClick={() => setActiveCategory("All")}
               className="mt-3 rounded-full border border-[var(--border)] px-3 py-1 text-xs text-foreground transition hover:border-foreground/30"
             >
-              Search all categories ({queryMatchesAcrossCategories})
+              Search all categories ({vm.queryMatchesAcrossCategories})
             </button>
           ) : null}
         </div>
       ) : (
         <div className="space-y-12">
-          {grouped.map(([cat, list]) => (
+          {vm.groups.map(([cat, list]) => (
             <section key={cat}>
               <div className="mb-4 flex items-baseline justify-between">
                 <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">

--- a/personal-site/lib/content.test.ts
+++ b/personal-site/lib/content.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAiPaperHighlights,
+  getAiProjectHighlights,
+  papers,
+  projects,
+} from "./content";
+
+describe("getAiProjectHighlights", () => {
+  it("returns up to 5 ai-track projects by default", () => {
+    const result = getAiProjectHighlights();
+    expect(result.length).toBeLessThanOrEqual(5);
+    expect(result.every((p) => p.track === "ai")).toBe(true);
+  });
+
+  it("respects a custom limit", () => {
+    const result = getAiProjectHighlights(2);
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.track === "ai")).toBe(true);
+  });
+
+  it("preserves source order", () => {
+    const aiProjects = projects.filter((p) => p.track === "ai");
+    const result = getAiProjectHighlights(3);
+    expect(result.map((p) => p.name)).toEqual(
+      aiProjects.slice(0, 3).map((p) => p.name),
+    );
+  });
+
+  it("excludes ion-track projects", () => {
+    const result = getAiProjectHighlights(99);
+    expect(result.every((p) => p.track !== "ion")).toBe(true);
+  });
+});
+
+describe("getAiPaperHighlights", () => {
+  it("returns up to 2 ai-track papers by default", () => {
+    const result = getAiPaperHighlights();
+    expect(result.length).toBeLessThanOrEqual(2);
+    expect(result.every((p) => p.track === "ai")).toBe(true);
+  });
+
+  it("respects a custom limit", () => {
+    const result = getAiPaperHighlights(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it("excludes ion-track papers", () => {
+    const result = getAiPaperHighlights(99);
+    expect(result.every((p) => p.track !== "ion")).toBe(true);
+  });
+
+  it("matches the slice of source data", () => {
+    const aiPapers = papers.filter((p) => p.track === "ai");
+    expect(getAiPaperHighlights(aiPapers.length).map((p) => p.title)).toEqual(
+      aiPapers.map((p) => p.title),
+    );
+  });
+});

--- a/personal-site/lib/content.ts
+++ b/personal-site/lib/content.ts
@@ -149,6 +149,14 @@ export const papers: Paper[] = [
   },
 ];
 
+export function getAiProjectHighlights(limit = 5): Project[] {
+  return projects.filter((p) => p.track === "ai").slice(0, limit);
+}
+
+export function getAiPaperHighlights(limit = 2): Paper[] {
+  return papers.filter((p) => p.track === "ai").slice(0, limit);
+}
+
 export const education: Education[] = [
   {
     institution: "University of California, Berkeley",

--- a/personal-site/lib/skills-browser-vm.test.ts
+++ b/personal-site/lib/skills-browser-vm.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import type { Skill, SkillCategory } from "./skills";
+import { buildSkillsViewModel } from "./skills-browser-vm";
+
+function makeSkill(overrides: {
+  slug: string;
+  category: SkillCategory;
+  name?: string;
+  description?: string;
+  triggers?: string[];
+}): Skill {
+  return {
+    slug: overrides.slug,
+    name: overrides.name ?? overrides.slug,
+    description: overrides.description ?? "",
+    triggers: overrides.triggers,
+    updatedAt: "2024-01-01T00:00:00Z",
+    bodyHtml: "",
+    bodyChars: 0,
+    source: { collection: "test", author: "test", repoPath: overrides.slug },
+    downloadUrl: `/skill-files/${overrides.slug}.md`,
+    category: overrides.category,
+  };
+}
+
+const fixtures: Skill[] = [
+  makeSkill({ slug: "html-ppt", category: "Slides & Decks", name: "HTML PPT" }),
+  makeSkill({
+    slug: "frontend-slides",
+    category: "Slides & Decks",
+    name: "Frontend Slides",
+    description: "stunning animation rich slides",
+  }),
+  makeSkill({
+    slug: "playwright",
+    category: "Browser & Testing",
+    name: "Playwright",
+    triggers: ["browser", "automation"],
+  }),
+  makeSkill({
+    slug: "deep-research",
+    category: "Research & Analysis",
+    name: "Deep Research",
+    description: "research benchmark",
+  }),
+];
+
+const allCategories: SkillCategory[] = [
+  "Slides & Decks",
+  "Browser & Testing",
+  "Research & Analysis",
+];
+
+describe("buildSkillsViewModel", () => {
+  it("returns all skills with empty query and All category", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "",
+      activeCategory: "All",
+    });
+    expect(vm.totalCount).toBe(4);
+    expect(vm.isEmpty).toBe(false);
+    expect(vm.queryMatchesAcrossCategories).toBe(0);
+    expect(vm.groups.map(([cat]) => cat)).toEqual([
+      "Slides & Decks",
+      "Browser & Testing",
+      "Research & Analysis",
+    ]);
+    expect(vm.groups[0][1]).toHaveLength(2);
+  });
+
+  it("preserves categories ordering even when only some have results", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "playwright",
+      activeCategory: "All",
+    });
+    expect(vm.groups).toHaveLength(1);
+    expect(vm.groups[0][0]).toBe("Browser & Testing");
+  });
+
+  it("filters by name", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "Playwright",
+      activeCategory: "All",
+    });
+    expect(vm.isEmpty).toBe(false);
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat).toHaveLength(1);
+    expect(flat[0].slug).toBe("playwright");
+  });
+
+  it("filters by slug", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "html-ppt",
+      activeCategory: "All",
+    });
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat.map((s) => s.slug)).toEqual(["html-ppt"]);
+  });
+
+  it("filters by description", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "stunning",
+      activeCategory: "All",
+    });
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat.map((s) => s.slug)).toEqual(["frontend-slides"]);
+  });
+
+  it("filters by trigger", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "automation",
+      activeCategory: "All",
+    });
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat.map((s) => s.slug)).toEqual(["playwright"]);
+  });
+
+  it("trims and lowercases query", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "  PLAYWRIGHT  ",
+      activeCategory: "All",
+    });
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat.map((s) => s.slug)).toEqual(["playwright"]);
+  });
+
+  it("restricts to active category", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "",
+      activeCategory: "Slides & Decks",
+    });
+    expect(vm.groups).toHaveLength(1);
+    expect(vm.groups[0][1]).toHaveLength(2);
+  });
+
+  it("reports queryMatchesAcrossCategories when query has hits outside active category", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "playwright",
+      activeCategory: "Slides & Decks",
+    });
+    expect(vm.isEmpty).toBe(true);
+    expect(vm.queryMatchesAcrossCategories).toBe(1);
+  });
+
+  it("reports queryMatchesAcrossCategories=0 when active category is All", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "playwright",
+      activeCategory: "All",
+    });
+    expect(vm.queryMatchesAcrossCategories).toBe(0);
+  });
+
+  it("returns isEmpty with no matches anywhere", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "no-such-thing",
+      activeCategory: "All",
+    });
+    expect(vm.isEmpty).toBe(true);
+    expect(vm.groups).toEqual([]);
+    expect(vm.queryMatchesAcrossCategories).toBe(0);
+  });
+
+  it("computes categoryCounts from full skills list, not filtered", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "playwright",
+      activeCategory: "Slides & Decks",
+    });
+    expect(vm.categoryCounts.get("Slides & Decks")).toBe(2);
+    expect(vm.categoryCounts.get("Browser & Testing")).toBe(1);
+    expect(vm.categoryCounts.get("Research & Analysis")).toBe(1);
+  });
+
+  it("appends groups for skills whose category is not in the categories param", () => {
+    const extra = makeSkill({ slug: "stray", category: "Other", name: "Stray" });
+    const vm = buildSkillsViewModel([...fixtures, extra], allCategories, {
+      query: "",
+      activeCategory: "All",
+    });
+    const cats = vm.groups.map(([cat]) => cat);
+    expect(cats).toContain("Other");
+    expect(cats[cats.length - 1]).toBe("Other");
+  });
+});

--- a/personal-site/lib/skills-browser-vm.ts
+++ b/personal-site/lib/skills-browser-vm.ts
@@ -1,0 +1,62 @@
+import type { Skill, SkillCategory } from "./skills";
+
+export type SkillsFilterState = {
+  query: string;
+  activeCategory: SkillCategory | "All";
+};
+
+export type SkillsViewModel = {
+  totalCount: number;
+  categoryCounts: Map<SkillCategory, number>;
+  groups: Array<[SkillCategory, Skill[]]>;
+  isEmpty: boolean;
+  queryMatchesAcrossCategories: number;
+};
+
+function matchesQuery(skill: Skill, q: string): boolean {
+  if (!q) return true;
+  return (
+    skill.name.toLowerCase().includes(q) ||
+    skill.slug.toLowerCase().includes(q) ||
+    skill.description.toLowerCase().includes(q) ||
+    (skill.triggers?.some((t) => t.toLowerCase().includes(q)) ?? false)
+  );
+}
+
+export function buildSkillsViewModel(
+  skills: Skill[],
+  categories: SkillCategory[],
+  state: SkillsFilterState,
+): SkillsViewModel {
+  const q = state.query.trim().toLowerCase();
+  const queryMatches = q ? skills.filter((s) => matchesQuery(s, q)) : skills;
+  const filtered =
+    state.activeCategory === "All"
+      ? queryMatches
+      : queryMatches.filter((s) => s.category === state.activeCategory);
+
+  const buckets = new Map<SkillCategory, Skill[]>();
+  for (const cat of categories) buckets.set(cat, []);
+  for (const s of filtered) {
+    if (!buckets.has(s.category)) buckets.set(s.category, []);
+    buckets.get(s.category)!.push(s);
+  }
+  const groups = Array.from(buckets.entries()).filter(
+    ([, list]) => list.length > 0,
+  );
+
+  const categoryCounts = new Map<SkillCategory, number>();
+  for (const cat of categories) categoryCounts.set(cat, 0);
+  for (const s of skills) {
+    categoryCounts.set(s.category, (categoryCounts.get(s.category) ?? 0) + 1);
+  }
+
+  return {
+    totalCount: skills.length,
+    categoryCounts,
+    groups,
+    isEmpty: filtered.length === 0,
+    queryMatchesAcrossCategories:
+      q && state.activeCategory !== "All" ? queryMatches.length : 0,
+  };
+}

--- a/personal-site/lib/skills.test.ts
+++ b/personal-site/lib/skills.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { SKILL_CATEGORIES, inferCategory } from "./skills";
+
+describe("inferCategory", () => {
+  it("classifies html-ppt-* slugs as Slides & Decks", () => {
+    expect(inferCategory("html-ppt-pitch-deck")).toBe("Slides & Decks");
+    expect(inferCategory("html-ppt-weekly-report")).toBe("Slides & Decks");
+  });
+
+  it("classifies named slide skills as Slides & Decks", () => {
+    expect(inferCategory("simple-deck")).toBe("Slides & Decks");
+    expect(inferCategory("frontend-slides")).toBe("Slides & Decks");
+  });
+
+  it("classifies document skills", () => {
+    expect(inferCategory("docx")).toBe("Documents");
+    expect(inferCategory("pdf")).toBe("Documents");
+    expect(inferCategory("pptx")).toBe("Documents");
+    expect(inferCategory("xlsx")).toBe("Documents");
+    expect(inferCategory("invoice")).toBe("Documents");
+  });
+
+  it("classifies web-prototype-* slugs as Apps & Web", () => {
+    expect(inferCategory("web-prototype")).toBe("Apps & Web");
+    expect(inferCategory("web-prototype-taste-soft")).toBe("Apps & Web");
+  });
+
+  it("classifies playwright-* slugs as Browser & Testing", () => {
+    expect(inferCategory("playwright")).toBe("Browser & Testing");
+    expect(inferCategory("playwright-cli")).toBe("Browser & Testing");
+    expect(inferCategory("playwright-interactive")).toBe("Browser & Testing");
+  });
+
+  it("classifies media skills", () => {
+    expect(inferCategory("video")).toBe("Media");
+    expect(inferCategory("image-poster")).toBe("Media");
+    expect(inferCategory("audio-jingle")).toBe("Media");
+  });
+
+  it("classifies review/plan skills", () => {
+    expect(inferCategory("review")).toBe("Reviews & Plans");
+    expect(inferCategory("design-review")).toBe("Reviews & Plans");
+    expect(inferCategory("plan-eng-review")).toBe("Reviews & Plans");
+  });
+
+  it("classifies security skills", () => {
+    expect(inferCategory("security-best-practices")).toBe("Security");
+    expect(inferCategory("cso")).toBe("Security");
+    expect(inferCategory("skill-vetter")).toBe("Security");
+  });
+
+  it("classifies research skills", () => {
+    expect(inferCategory("deep-research")).toBe("Research & Analysis");
+    expect(inferCategory("equity-investment-memo")).toBe("Research & Analysis");
+  });
+
+  it("classifies design system skills", () => {
+    expect(inferCategory("frontend-design")).toBe("Design Systems");
+    expect(inferCategory("theme-factory")).toBe("Design Systems");
+    expect(inferCategory("design-shotgun")).toBe("Design Systems");
+  });
+
+  it("classifies marketing skills", () => {
+    expect(inferCategory("ad-creative")).toBe("Marketing & Growth");
+    expect(inferCategory("seo-audit")).toBe("Marketing & Growth");
+    expect(inferCategory("xiaohongshu-knowledge")).toBe("Marketing & Growth");
+  });
+
+  it("classifies engineering skills", () => {
+    expect(inferCategory("ship")).toBe("Engineering");
+    expect(inferCategory("careful")).toBe("Engineering");
+    expect(inferCategory("vercel-deploy")).toBe("Engineering");
+    expect(inferCategory("gh-fix-ci")).toBe("Engineering");
+  });
+
+  it("falls back to Other for unknown slugs", () => {
+    expect(inferCategory("totally-novel-skill")).toBe("Other");
+    expect(inferCategory("zzz")).toBe("Other");
+  });
+
+  it("returns a value from SKILL_CATEGORIES for any input", () => {
+    const samples = ["html-ppt-foo", "playwright-bar", "unknown", ""];
+    for (const slug of samples) {
+      const cat = inferCategory(slug);
+      expect(SKILL_CATEGORIES).toContain(cat);
+    }
+  });
+});

--- a/personal-site/lib/skills.ts
+++ b/personal-site/lib/skills.ts
@@ -44,7 +44,7 @@ export const SKILL_CATEGORIES = [
 
 export type SkillCategory = (typeof SKILL_CATEGORIES)[number];
 
-function inferCategory(slug: string): SkillCategory {
+export function inferCategory(slug: string): SkillCategory {
   if (
     slug.startsWith("html-ppt") ||
     /^(simple-deck|replit-deck|frontend-slides|weekly-update|guizang-ppt|magazine-poster|pptx-html-fidelity-audit|social-carousel)$/.test(

--- a/personal-site/package-lock.json
+++ b/personal-site/package-lock.json
@@ -30,7 +30,8 @@
         "eslint-config-next": "16.2.4",
         "marked": "^18.0.3",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1347,6 +1348,299 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1452,6 +1746,13 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1757,6 +2058,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1765,6 +2077,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2430,6 +2749,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2659,6 +3091,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -2898,6 +3340,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3400,6 +3852,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4026,6 +4485,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4183,6 +4652,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7137,6 +7621,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -7305,6 +7800,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7335,9 +7837,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -7787,6 +8289,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8120,6 +8656,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -8158,6 +8701,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8421,6 +8978,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -8467,6 +9041,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8926,6 +9510,200 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -9039,6 +9817,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/personal-site/package.json
+++ b/personal-site/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "skills:generate": "node scripts/generate-skills-data.mjs",
-    "post:add": "node scripts/add-social-post.mjs"
+    "post:add": "node scripts/add-social-post.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",
@@ -33,6 +35,7 @@
     "eslint-config-next": "16.2.4",
     "marked": "^18.0.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/personal-site/vitest.config.ts
+++ b/personal-site/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["lib/**/*.test.ts", "app/**/*.test.ts", "components/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Extract `buildSkillsViewModel` from `skills-browser.tsx` into a pure function in `lib/skills-browser-vm.ts`. The View becomes a thin binding around one `useMemo`. VM is now testable without React.
- Lift homepage AI highlight slicing into `getAiProjectHighlights` / `getAiPaperHighlights` helpers in `lib/content.ts`.
- Add `vitest` with 35 unit tests covering `inferCategory`, the new VM, and the highlight helpers. Export `inferCategory` (was private) so it can be tested directly.

Token-efficiency / agent-friendliness payoff: filter logic now lives in a 57-line file independent of the 240-line View. Catalog of skills is unchanged in this PR.

## Test plan
- [x] `npm test` — 35 passed (3 files), 1.4s
- [x] `npm run lint` — clean
- [x] `npm run build` — 207 pages, no TS errors
- [x] dev server smoke: `/` shows 5 AI projects + 2 AI papers, `/skills` renders 194 cards, search/filter/empty-state behavior identical to prior