### PR TITLE
personal-site: harden discoverability + ship security headers

### DIFF
--- a/personal-site/app/(personal)/about/page.tsx
+++ b/personal-site/app/(personal)/about/page.tsx
@@ -1,51 +1,12 @@
 import type { Metadata } from "next";
 import { education } from "@/lib/content";
-import { jsonLdScriptContent } from "@/lib/jsonld";
-import { SITE_URL } from "@/lib/site";
+import { jsonLdScriptContent, profilePageJsonLd } from "@/lib/jsonld";
 
 export const metadata: Metadata = {
   title: "About",
   description:
     "Bingran You — PhD candidate at UC Berkeley working on reliable AI systems and trapped-ion experiments in atomic, molecular and optical physics.",
   alternates: { canonical: "/about" },
-};
-
-const profilePageJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "ProfilePage",
-  url: `${SITE_URL}/about`,
-  mainEntity: {
-    "@type": "Person",
-    name: "Bingran You",
-    url: SITE_URL,
-    jobTitle: "PhD Candidate",
-    description:
-      "PhD candidate at UC Berkeley building reliable AI systems and running trapped-ion experiments in atomic, molecular and optical physics.",
-    affiliation: {
-      "@type": "Organization",
-      name: "Haeffner Lab, University of California, Berkeley",
-      url: "https://ions.berkeley.edu/",
-    },
-    knowsAbout: [
-      "Reliable AI Systems",
-      "AI Agents",
-      "Atomic, Molecular and Optical Physics",
-      "Trapped Ions",
-      "Integrated Photonics",
-      "Ion-Photon Interfaces",
-    ],
-    sameAs: [
-      "https://www.wikidata.org/wiki/Q139620371",
-      "https://x.com/bingran_bry",
-      "https://github.com/bingran-you",
-      "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en",
-      "https://orcid.org/0000-0002-0316-2115",
-      "https://huggingface.co/bingran-you",
-      "https://www.linkedin.com/in/bingran-you-775b4017b/",
-      "https://www.youtube.com/@BingranBRY",
-      "https://discord.gg/jsAnjCep",
-    ],
-  },
 };
 
 const facts = [
@@ -81,7 +42,7 @@ export default function AboutPage() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: jsonLdScriptContent(profilePageJsonLd),
+          __html: jsonLdScriptContent(profilePageJsonLd("/about")),
         }}
       />
 

--- a/personal-site/app/robots.ts
+++ b/personal-site/app/robots.ts
@@ -5,9 +5,31 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
-        userAgent: "*",
+        userAgent: [
+          "GPTBot",
+          "ClaudeBot",
+          "Claude-Web",
+          "PerplexityBot",
+          "Googlebot",
+          "Bingbot",
+          "Applebot",
+          "DuckDuckBot",
+          "YandexBot",
+          "CCBot",
+        ],
         allow: "/",
       },
+      {
+        userAgent: [
+          "AhrefsBot",
+          "SemrushBot",
+          "MJ12bot",
+          "DotBot",
+          "DataForSeoBot",
+        ],
+        disallow: "/",
+      },
+      { userAgent: "*", allow: "/" },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,
     host: SITE_URL,

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -38,10 +38,9 @@ const author = {
   url: SITE_URL,
 };
 
-export function personJsonLd() {
+function personEntity() {
   return {
-    "@context": "https://schema.org",
-    "@type": "Person",
+    "@type": "Person" as const,
     "@id": PERSON_ID,
     name: SITE_NAME,
     givenName: "Bingran",
@@ -73,6 +72,16 @@ export function personJsonLd() {
       name: "Haeffner Lab, University of California, Berkeley",
       url: "https://ions.berkeley.edu/",
     },
+    worksFor: {
+      "@type": "Organization",
+      name: "Haeffner Lab, University of California, Berkeley",
+      url: "https://ions.berkeley.edu/",
+      parentOrganization: {
+        "@type": "CollegeOrUniversity",
+        name: "University of California, Berkeley",
+        sameAs: "https://www.berkeley.edu/",
+      },
+    },
     knowsAbout: [
       "Reliable AI Systems",
       "AI Agents",
@@ -92,7 +101,14 @@ export function personJsonLd() {
       "https://www.youtube.com/@BingranBRY",
       "https://discord.gg/jsAnjCep",
     ],
-  } as const;
+  };
+}
+
+export function personJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    ...personEntity(),
+  };
 }
 
 export function websiteJsonLd() {
@@ -101,7 +117,7 @@ export function websiteJsonLd() {
     "@type": "WebSite",
     "@id": WEBSITE_ID,
     name: SITE_NAME,
-    alternateName: ["bingranyou.com", "bingran.you"],
+    alternateName: ["bingranyou.com"],
     url: SITE_URL,
     inLanguage: "en",
     author: { "@id": PERSON_ID },
@@ -121,8 +137,8 @@ export function profilePageJsonLd(path: "/" | "/about" = "/") {
     inLanguage: "en",
     isPartOf: { "@id": WEBSITE_ID },
     about: { "@id": PERSON_ID },
-    mainEntity: { "@id": PERSON_ID },
-  } as const;
+    mainEntity: personEntity(),
+  };
 }
 
 export function paperJsonLd(paper: Paper) {

--- a/personal-site/proxy.ts
+++ b/personal-site/proxy.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const CANONICAL_HOSTS = new Set([
+  "bingran.ai",
+  "www.bingran.ai",
+  "bingranyou.com",
+  "www.bingranyou.com",
+]);
+
+export function proxy(req: NextRequest) {
+  const host = (req.headers.get("host") ?? "").toLowerCase().split(":")[0];
+  const res = NextResponse.next();
+  if (!CANONICAL_HOSTS.has(host)) {
+    res.headers.set("X-Robots-Tag", "noindex, nofollow");
+  }
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -1,4 +1,27 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=()"
+        },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:; media-src 'self' https:; frame-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Two-part change addressing the "agents can't find me" and "what protects the site" threads in one PR.

### Part A — Discoverability (commit `620c511`)
Person / ProfilePage JSON-LD bugs that hurt entity recognition by Google Knowledge Panel and AI agents:

- Drop invalid \`bingran.you\` from \`WebSite.alternateName\` (\`.you\` is not a TLD; some parsers drop the whole property when one entry is malformed).
- Add \`worksFor\` (Haeffner Lab → UC Berkeley parentOrganization) to Person, in addition to \`affiliation\`. Google specifically reads \`worksFor\` for the "Works at" Knowledge Panel field.
- Inline the full Person object as \`ProfilePage.mainEntity\` instead of a bare \`@id\` reference, so parsers that don't merge \`@graph\` across separate \`<script>\` tags (Bing/Brave/many AI agent crawlers) still see a self-contained ProfilePage on \`/\` and \`/about\`.
- Replace the 35-line hand-rolled ProfilePage in \`app/(personal)/about/page.tsx\` with the shared \`profilePageJsonLd("/about")\` helper so the two definitions can't drift.

### Part B — Protection (commit `50c8d16\`)
Defensive layer that doesn't block humans or LLM agents:

- \`vercel.json\`: HSTS (preload), \`X-Content-Type-Options: nosniff\`, \`Referrer-Policy: strict-origin-when-cross-origin\`, \`X-Frame-Options: DENY\`, \`Permissions-Policy\` disabling camera/mic/geo/Topics/FLoC, \`Cross-Origin-Opener-Policy: same-origin\`, and a Content-Security-Policy that blocks framing, restricts \`script-src\` to \`self\` + inline (needed for Next's inline JSON-LD), and upgrades any \`http:\` subresources.
- \`proxy.ts\` (Next 16's replacement for \`middleware.ts\`): stamps \`X-Robots-Tag: noindex, nofollow\` on any host that isn't \`bingran.ai\` / \`bingranyou.com\` (apex + www). Stops \`personal-site-lovat-seven.vercel.app\` and any preview deploy from competing for SEO or being a back door around the canonical site.
- \`app/robots.ts\`: explicit allow for GPTBot / ClaudeBot / Claude-Web / PerplexityBot / Googlebot / Bingbot / Applebot / DuckDuckBot / YandexBot / CCBot. Explicit disallow for AhrefsBot / SemrushBot / MJ12bot / DotBot / DataForSeoBot. Wildcard \`allow: /\` fallback so nothing legitimate is accidentally locked out.

## Three goals from the original ask
- **Humans:** zero friction. Headers are HTTP-level and invisible. CSP allows everything the static site uses (own origin + inline + https images).
- **LLM agents:** smoother than before. robots.txt explicitly lists them; JSON-LD ProfilePage is now self-contained for parsers that don't follow \`@id\` refs.
- **Malicious traffic:** framing blocked, mixed content auto-upgraded, Topics API off, indexable preview alias removed, scraper farms told to leave.

## Test plan
- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npm test\` — 35/35 passing
- [x] \`npm run build\` — succeeds; output shows \`ƒ Proxy (Middleware)\` registered
- [x] Local \`npm start\` + \`curl -H "Host: …"\` confirms canonical hosts get no X-Robots-Tag, \`*.vercel.app\` hosts get \`noindex, nofollow\`
- [x] \`/\`, \`/about\`, \`/blog\`, \`/skills\`, \`/llms.txt\`, \`/sitemap.xml\` all return 200
- [x] Verified rendered HTML: \`worksFor\` present, \`alternateName: ["bingranyou.com"]\` only, \`ProfilePage.mainEntity\` is a full inline Person on both \`/\` and \`/about\`
- [ ] Post-merge: re-submit sitemap in Google Search Console + Bing Webmaster Tools
- [ ] Post-merge: validate at https://search.google.com/test/rich-results?url=https%3A%2F%2Fbingran.ai
- [ ] Post-merge (manual, registrar / DNS): CAA records, SPF/DMARC nullzone for bingran.ai, real SPF/DMARC for bingranyou.com — see analysis in this branch's chat for the exact records.