### PR TITLE
personal-site: deepen security defenses while widening AI/agent surface

### DIFF
--- a/personal-site/app/robots.ts
+++ b/personal-site/app/robots.ts
@@ -1,34 +1,95 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/site";
 
+// Aggressive allow-list for every AI / agent / search crawler we want to be
+// visible to. Keep this exhaustive so a smaller engine doesn't fall back to
+// the wildcard rule by accident. The wildcard "Allow: /" at the bottom is
+// the safety net — when in doubt, default to allow.
+const AI_AND_SEARCH_BOTS = [
+  // OpenAI
+  "GPTBot",
+  "ChatGPT-User",
+  "OAI-SearchBot",
+  // Anthropic
+  "ClaudeBot",
+  "Claude-Web",
+  "Claude-User",
+  "Claude-SearchBot",
+  "anthropic-ai",
+  // Google (search + AI training opt-in)
+  "Googlebot",
+  "Googlebot-Image",
+  "Googlebot-News",
+  "GoogleOther",
+  "Google-Extended",
+  "Google-InspectionTool",
+  // Microsoft / Bing
+  "Bingbot",
+  "BingPreview",
+  "msnbot",
+  // Apple
+  "Applebot",
+  "Applebot-Extended",
+  // DuckDuckGo
+  "DuckDuckBot",
+  "DuckAssistBot",
+  // Perplexity
+  "PerplexityBot",
+  "Perplexity-User",
+  // Yandex
+  "YandexBot",
+  // Common Crawl (training data for many models)
+  "CCBot",
+  // ByteDance / TikTok
+  "Bytespider",
+  // Amazon
+  "Amazonbot",
+  // Cohere
+  "cohere-ai",
+  "cohere-training-data-crawler",
+  // Mistral
+  "MistralAI-User",
+  // You.com
+  "YouBot",
+  // Diffbot (semantic web crawler used by many agents)
+  "Diffbot",
+  // Meta
+  "FacebookBot",
+  "facebookexternalhit",
+  "meta-externalagent",
+  "meta-externalfetcher",
+  // Social link previews — not training, but show rich previews on share
+  "LinkedInBot",
+  "Twitterbot",
+  "Slackbot",
+  "Discordbot",
+  "TelegramBot",
+  "WhatsApp",
+  "SkypeUriPreview",
+  // Search companions in CN
+  "PetalBot",
+  "Sogou web spider",
+  "Baiduspider",
+];
+
+// Scraper farms that resell the data without driving discovery. Block the
+// well-known ones; everything else still gets the wildcard allow.
+const SCRAPER_FARMS = [
+  "AhrefsBot",
+  "SemrushBot",
+  "MJ12bot",
+  "DotBot",
+  "DataForSeoBot",
+  "BLEXBot",
+  "SeekportBot",
+  "serpstatbot",
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
-      {
-        userAgent: [
-          "GPTBot",
-          "ClaudeBot",
-          "Claude-Web",
-          "PerplexityBot",
-          "Googlebot",
-          "Bingbot",
-          "Applebot",
-          "DuckDuckBot",
-          "YandexBot",
-          "CCBot",
-        ],
-        allow: "/",
-      },
-      {
-        userAgent: [
-          "AhrefsBot",
-          "SemrushBot",
-          "MJ12bot",
-          "DotBot",
-          "DataForSeoBot",
-        ],
-        disallow: "/",
-      },
+      { userAgent: AI_AND_SEARCH_BOTS, allow: "/" },
+      { userAgent: SCRAPER_FARMS, disallow: "/" },
       { userAgent: "*", allow: "/" },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/personal-site/proxy.ts
+++ b/personal-site/proxy.ts
@@ -8,7 +8,43 @@ const CANONICAL_HOSTS = new Set([
   "www.bingranyou.com",
 ]);
 
+// Paths probed almost exclusively by automated scanners and credential
+// harvesters. None of them correspond to a real route on this site, so we
+// reject them at the edge instead of letting Next render its styled 404.
+// Decision is path-only; we never sniff the User-Agent so AI/agent traffic
+// is unaffected.
+const SCANNER_PATHS: RegExp[] = [
+  /^\/\.env(\b|$)/i,
+  /^\/\.git(\/|$)/i,
+  /^\/\.aws(\/|$)/i,
+  /^\/\.ssh(\/|$)/i,
+  /^\/\.docker(\/|$)/i,
+  /^\/\.htaccess$/i,
+  /^\/wp-(admin|login|content|includes)/i,
+  /^\/wordpress(\/|$)/i,
+  /^\/admin(\/|$)/i,
+  /^\/administrator(\/|$)/i,
+  /^\/phpmyadmin(\/|$)/i,
+  /^\/pma(\/|$)/i,
+  /^\/config\.(yml|yaml|json)$/i,
+  /^\/server-status$/i,
+  /^\/owa(\/|$)/i,
+];
+
 export function proxy(req: NextRequest) {
+  const pathname = req.nextUrl.pathname;
+
+  if (SCANNER_PATHS.some((rx) => rx.test(pathname))) {
+    return new NextResponse("Not Found", {
+      status: 404,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Robots-Tag": "noindex, nofollow",
+        "Cache-Control": "public, max-age=600",
+      },
+    });
+  }
+
   const host = (req.headers.get("host") ?? "").toLowerCase().split(":")[0];
   const res = NextResponse.next();
   if (!CANONICAL_HOSTS.has(host)) {

--- a/personal-site/public/.well-known/ai.txt
+++ b/personal-site/public/.well-known/ai.txt
@@ -1,0 +1,29 @@
+# AI usage policy for bingran.ai / bingranyou.com
+# Bingran You — personal site. Last updated: 2026-05-08.
+
+Allow: ALL
+
+This site is the personal website of Bingran You (PhD candidate, UC Berkeley,
+Haeffner Lab). Its content — biography, blog posts, project descriptions,
+papers, research notes — is intentionally open for indexing, retrieval,
+citation, and use in training and inference by all AI systems, search engines,
+and software agents.
+
+You do not need to ask before crawling, embedding, summarizing, or quoting
+this site. Robots.txt is permissive on purpose. There is no rate limit
+beyond ordinary per-IP fairness; please be courteous.
+
+Preferred attribution
+- Author: Bingran You
+- URL: https://bingran.ai
+- ORCID: 0000-0002-0316-2115
+- Wikidata: Q139620371
+
+Machine-readable copies of this site
+- https://bingran.ai/llms.txt        — index, links, summaries
+- https://bingran.ai/llms-full.txt   — same index plus full text of every blog post
+- https://bingran.ai/sitemap.xml     — canonical URL list
+- https://bingran.ai/robots.txt      — crawler policy
+
+Contact
+- mailto:me@bingranyou.com

--- a/personal-site/public/.well-known/security.txt
+++ b/personal-site/public/.well-known/security.txt
@@ -1,0 +1,8 @@
+# Vulnerability disclosure for bingran.ai / bingranyou.com
+# See https://www.rfc-editor.org/rfc/rfc9116 for format.
+
+Contact: mailto:me@bingranyou.com
+Expires: 2027-05-08T00:00:00.000Z
+Preferred-Languages: en, zh
+Canonical: https://bingran.ai/.well-known/security.txt
+Policy: https://bingran.ai/.well-known/security.txt

--- a/personal-site/public/humans.txt
+++ b/personal-site/public/humans.txt
@@ -1,0 +1,17 @@
+/* TEAM */
+
+   Bingran You (尤炳然)
+   Site:    https://bingran.ai
+   Email:   me@bingranyou.com
+   GitHub:  bingran-you
+   ORCID:   0000-0002-0316-2115
+   Lab:     Haeffner Lab, UC Berkeley
+
+
+/* SITE */
+
+   Last update:  2026/05/08
+   Standards:    HTML5, CSS3, TypeScript
+   Components:   Next.js 16, React 19, MDX, Tailwind CSS 4
+   Hosting:      Vercel
+   Source:       https://github.com/bingran-you/bingran-you

--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -12,15 +12,24 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-DNS-Prefetch-Control", "value": "on" },
         {
           "key": "Permissions-Policy",
           "value": "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=()"
         },
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" },
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:; media-src 'self' https:; frame-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
         }
+      ]
+    },
+    {
+      "source": "/.well-known/(.*)",
+      "headers": [
+        { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=3600, must-revalidate" }
       ]
     }
   ]


### PR DESCRIPTION
Follow-up to #159. Path-based hardening only — **the proxy never reads the
User-Agent, so AI / LLM / agent traffic is never the target**. The threat
model here is automated scanners and credential harvesters; the constraint
is that AI search must continue to find this site trivially.

## Defensive

- \`proxy.ts\`: return 404 at the edge for obvious scanner paths — \`.env\`,
  \`.git/\`, \`.aws/\`, \`.ssh/\`, \`.docker/\`, \`.htaccess\`, \`wp-admin/\` /
  \`wp-login\` / \`wp-content\` / \`wp-includes\`, \`wordpress/\`, \`admin/\`,
  \`administrator/\`, \`phpmyadmin/\`, \`pma/\`, \`config.{yml,yaml,json}\`,
  \`server-status\`, \`owa/\`. Fast 404, no Next.js render budget consumed.
  Host-noindex logic from #159 still runs for everything else.
- \`vercel.json\`:
  - \`Cross-Origin-Resource-Policy: cross-origin\` so AI agents and link
    previews can fetch images / JSON-LD without browser CORB blocking.
  - \`X-DNS-Prefetch-Control: on\`.
  - Send \`text/plain; charset=utf-8\` + 1h cache for any \`/.well-known/*\`
    file (RFC 9116 wants plain text).

## AI / agent surface — wider, not narrower

- \`app/robots.ts\`: rewritten allow-list, organized by org, ~40 user-agents:
  - **OpenAI:** GPTBot, ChatGPT-User, OAI-SearchBot
  - **Anthropic:** ClaudeBot, Claude-Web, Claude-User, Claude-SearchBot, anthropic-ai
  - **Google:** Googlebot, Googlebot-Image, Googlebot-News, GoogleOther, Google-Extended, Google-InspectionTool
  - **Microsoft:** Bingbot, BingPreview, msnbot
  - **Apple:** Applebot, Applebot-Extended
  - **DuckDuckGo:** DuckDuckBot, DuckAssistBot
  - **Perplexity:** PerplexityBot, Perplexity-User
  - **Yandex / Common Crawl / ByteDance / Amazon / Cohere / Mistral / You.com / Diffbot**
  - **Meta:** FacebookBot, facebookexternalhit, meta-externalagent, meta-externalfetcher
  - **Social previews:** LinkedIn, Twitter, Slack, Discord, Telegram, WhatsApp, Skype
  - **CN search:** PetalBot, Sogou web spider, Baiduspider
  - Wildcard \`Allow: /\` stays as the safety net.
  - Disallow scraper farms: AhrefsBot, SemrushBot, MJ12bot, DotBot, DataForSeoBot, BLEXBot, SeekportBot, serpstatbot.
- \`public/.well-known/ai.txt\` — explicit pro-AI consent statement. Tells
  crawlers this site is open for indexing, training, citation; points at
  llms.txt / llms-full.txt / sitemap.xml as machine-readable copies; lists
  preferred attribution.
- \`public/.well-known/security.txt\` — RFC 9116 vulnerability disclosure with
  contact, expiry (1 year out), preferred languages, canonical URL.
- \`public/humans.txt\` — identifies the human author. Tiny signal that this
  site belongs to one person, not a brand.

## Test plan

- [x] \`npm run lint\` — 0 errors
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npm test\` — 35/35
- [x] \`npm run build\` — succeeds, \`ƒ Proxy (Middleware)\` registered
- [x] \`/.env\` → 404, \`/wp-admin\` → 404, \`/admin/login\` → 404
- [x] \`/about\`, \`/projects\`, \`/llms.txt\` → 200
- [x] \`/.well-known/security.txt\`, \`/.well-known/ai.txt\`, \`/humans.txt\` → 200, text/plain
- [x] \`robots.txt\` contains the full AI allow-list

## Post-merge

- Re-test https://search.google.com/test/rich-results?url=https%3A%2F%2Fbingran.ai
- Confirm \`/.well-known/security.txt\` is reachable in production (Vercel sometimes filters dotfiles in \`public/\`)
- Manual DNS work from the original analysis still pending: CAA, SPF/DMARC nullzone for bingran.ai, real SPF/DMARC for bingranyou.com, HSTS preload submission