### PR TITLE
personal-site: add Zero-Human Company pillar + cluster posts

### DIFF
--- a/personal-site/app/(personal)/zero-human-company/page.tsx
+++ b/personal-site/app/(personal)/zero-human-company/page.tsx
@@ -1,0 +1,429 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  articleJsonLd,
+  breadcrumbJsonLd,
+  definedTermJsonLd,
+  graphScriptContent,
+} from "@/lib/jsonld";
+
+const PATH = "/zero-human-company";
+const PUBLISHED = "2026-05-08";
+
+const ONE_LINER =
+  "A company where every execution function — code, support, sales, marketing, ops — is run by software agents and automated infrastructure. The founder is the only human in the loop.";
+
+export const metadata: Metadata = {
+  title: "Zero-Human Company — Definition, Stack, and What's Achievable Today",
+  description:
+    "A zero-human company is a company where every execution function is run by software agents and automated infrastructure — not employees. Definition, comparison with one-person company and solopreneur, the 3-layer agent stack, and what is actually achievable today.",
+  alternates: { canonical: PATH },
+  keywords: [
+    "zero-human company",
+    "zero human company",
+    "zero-employee company",
+    "one person company",
+    "one-person company",
+    "AI-native company",
+    "agent-run company",
+    "solo AI startup",
+    "autonomous company",
+    "AI agents",
+    "Bingran You",
+  ],
+  openGraph: {
+    title: "Zero-Human Company",
+    description: ONE_LINER,
+    url: PATH,
+    type: "article",
+    publishedTime: new Date(PUBLISHED).toISOString(),
+    authors: ["Bingran You"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Zero-Human Company",
+    description: ONE_LINER,
+  },
+};
+
+const definedTerm = definedTermJsonLd({
+  path: PATH,
+  name: "Zero-Human Company",
+  alternateName: [
+    "Zero Human Company",
+    "Zero-Employee Company",
+    "Agent-Run Company",
+    "AI-Native Company",
+  ],
+  description: ONE_LINER,
+  termCode: "zero-human-company",
+});
+
+const article = articleJsonLd({
+  path: PATH,
+  title: "Zero-Human Company — Definition, Stack, and What's Achievable Today",
+  description: ONE_LINER,
+  date: PUBLISHED,
+  about: "Zero-Human Company",
+  keywords: [
+    "zero-human company",
+    "one person company",
+    "AI agents",
+    "autonomous company",
+  ],
+});
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: "Home", path: "/" },
+  { name: "Zero-Human Company", path: PATH },
+]);
+
+const distinctions: Array<{ term: string; definition: string }> = [
+  {
+    term: "One-Person Company (OPC)",
+    definition:
+      "A legal corporate structure (notably under Indian Companies Act, 2013) for a single shareholder. It is a legal form, not an operating model. A zero-human company is an operating model and can be incorporated as an OPC, an LLC, a C-corp, or anything else.",
+  },
+  {
+    term: "Solopreneur",
+    definition:
+      "A one-person business where the human does the execution work. The bottleneck is the founder's hours. A zero-human company removes that bottleneck by moving execution to agents.",
+  },
+  {
+    term: "Agency / micro-team",
+    definition:
+      "A small group of paid humans executing for clients. Same operating model as a traditional company, smaller headcount.",
+  },
+  {
+    term: "Lifestyle business",
+    definition:
+      "A description of intent (modest scale, owner-led) rather than execution model. Lifestyle businesses are usually solopreneur or micro-team. A zero-human company is closer to the opposite — leverage maximized.",
+  },
+  {
+    term: "Traditional startup",
+    definition:
+      "Raises capital, hires employees, scales headcount in step with revenue. A zero-human company tries to break the headcount-revenue link entirely.",
+  },
+];
+
+const stackLayers: Array<{
+  layer: string;
+  role: string;
+  examples: string;
+}> = [
+  {
+    layer: "1. Intent layer",
+    role:
+      "The single human in the loop — usually the founder. Sets strategy, picks markets, allocates capital, makes irreversible decisions, owns legal and fiduciary duty. Does not execute day-to-day work.",
+    examples:
+      "Quarterly bets, pricing changes, hiring (of agents and tools), kill/keep calls.",
+  },
+  {
+    layer: "2. Agent layer",
+    role:
+      "LLM-driven agents and skills that do work historically done by employees. Each agent has a scope, a budget, an evaluation, and a clear handoff back to the intent layer when it gets stuck.",
+    examples:
+      "A marketing agent drafts and ships posts. A support agent answers tickets. An eng agent ships code behind tests. A finance agent reconciles invoices.",
+  },
+  {
+    layer: "3. Infrastructure layer",
+    role:
+      "Deterministic plumbing the agents call into. Boring, automatable, well-documented. This is what makes the agent layer cheap and reliable instead of slow and fragile.",
+    examples:
+      "Stripe, Vercel, Resend, Supabase, GitHub Actions, observability, IaC, payments, email, queues.",
+  },
+];
+
+const achievableToday: Array<{ status: string; items: string[] }> = [
+  {
+    status: "Achievable today",
+    items: [
+      "Single-product SaaS with agent-driven content marketing, support, and most engineering.",
+      "Newsletter, course, or info-product business run end-to-end by agents with periodic founder review.",
+      "Template / asset stores where agents handle production, listing, and customer service.",
+      "Niche directory and aggregator sites where agents handle ingestion, ranking, and updates.",
+    ],
+  },
+  {
+    status: "Partially achievable, with friction",
+    items: [
+      "B2B SaaS with enterprise customers — procurement and contracting still want a human voice.",
+      "Anything regulated (health, finance, legal) — the human-in-the-loop requirement is structural, not technical.",
+      "High-touch sales — agents close small deals reliably; complex deals still need a human closer.",
+    ],
+  },
+  {
+    status: "Not yet",
+    items: [
+      "Companies that need physical operations — warehousing, logistics, manufacturing — at scale without humans.",
+      "Long-horizon, multi-quarter agent execution without drift. State-of-the-art evaluation harnesses still measure agent reliability in tasks, not in quarters.",
+      "Anything that requires the founder to be invisible. The intent layer is load-bearing; remove it and the company drifts.",
+    ],
+  },
+];
+
+const faq: Array<{ q: string; a: string }> = [
+  {
+    q: "Is a zero-human company the same as a one-person company?",
+    a: "No. 'One-Person Company' is a legal corporate structure (most commonly under the Indian Companies Act, 2013) — it describes ownership, not operations. A zero-human company is an operating model: all execution is done by software, with the founder as the only human in the loop. A zero-human company can be incorporated as a one-person company, an LLC, a C-corp, or any other legal form.",
+  },
+  {
+    q: "Does 'zero-human' mean literally zero humans?",
+    a: "No. The founder is still a human, and so are customers, regulators, and counterparties. The claim is narrower: no paid employees or contractors execute the day-to-day operations. Execution is done by AI agents and automated infrastructure.",
+  },
+  {
+    q: "Who coined the term zero-human company?",
+    a: "The phrase has been used informally on tech Twitter and in startup communities since around 2024–2025. This page, by Bingran You, is an attempt to give it a precise operating definition and a reusable architecture (the 3-layer stack: intent, agent, infrastructure).",
+  },
+  {
+    q: "What is the difference between a zero-human company and a solopreneur?",
+    a: "A solopreneur does the work themselves — the bottleneck is the founder's hours. A zero-human company moves execution to agents and automated infrastructure, so the founder spends time on strategy and direction instead of operations.",
+  },
+  {
+    q: "How does a zero-human company actually make money?",
+    a: "Same way any company does — by selling something customers value. The novelty is on the cost side: payroll is replaced by API spend, tooling, and infrastructure. The unit economics shift from labor-bound (revenue per employee) to capital-and-compute-bound (revenue per dollar of agent and infra spend).",
+  },
+  {
+    q: "Is this realistic in 2026?",
+    a: "For some categories, yes — single-product SaaS, info-products, content businesses, niche directories. For others — regulated industries, complex enterprise sales, physical operations — the answer is 'partially' or 'not yet.' See the section on what's achievable today.",
+  },
+];
+
+export default function ZeroHumanCompanyPage() {
+  return (
+    <div className="space-y-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: graphScriptContent([definedTerm, article, breadcrumb]),
+        }}
+      />
+
+      <header className="space-y-6">
+        <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Definition · Field notes
+        </p>
+        <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight text-pretty">
+          Zero-Human Company
+        </h1>
+        <p className="text-lg leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          {ONE_LINER}
+        </p>
+        <p className="text-sm text-[var(--muted)]">
+          By{" "}
+          <Link href="/about" className="underline hover:opacity-70">
+            Bingran You
+          </Link>
+          . Last updated {PUBLISHED}.
+        </p>
+      </header>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Definition
+        </h2>
+        <div className="space-y-4 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          <p>
+            A <strong className="text-foreground">zero-human company</strong> is
+            a company where every execution function — engineering, marketing,
+            support, sales, finance, ops — is performed by software agents and
+            automated infrastructure rather than paid employees or contractors.
+            The founder remains as the strategic operator. There is exactly one
+            human in the loop, and that human does not do day-to-day work.
+          </p>
+          <p>
+            The term is sometimes used loosely to mean &quot;a company with no
+            employees,&quot; which collides with the legal{" "}
+            <em>One-Person Company</em> structure. The narrower, more useful
+            sense is operational: not zero humans, but zero human{" "}
+            <em>execution</em>.
+          </p>
+          <p>
+            Three criteria, in plain language:
+          </p>
+          <ol className="list-decimal pl-6 space-y-2">
+            <li>
+              No payroll for execution work. Founder draws or doesn&apos;t, but
+              employees and contractors do not run operations.
+            </li>
+            <li>
+              Agents and automated infrastructure handle the bulk of recurring
+              work, with documented scopes, budgets, and evals.
+            </li>
+            <li>
+              The founder&apos;s time is spent on direction, capital allocation,
+              and irreversible decisions — not tickets, posts, or PRs.
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          What it is not
+        </h2>
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          {distinctions.map((d) => (
+            <li key={d.term} className="py-5">
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-foreground">
+                {d.term}
+              </p>
+              <p className="mt-2 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+                {d.definition}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          The 3-layer zero-human stack
+        </h2>
+        <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          A working zero-human company has three clearly separated layers. Mixing
+          them is the most common reason these companies fail to scale beyond a
+          founder demo: when the agent layer leaks into the intent layer, the
+          founder ends up doing operations again.
+        </p>
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          {stackLayers.map((l) => (
+            <li key={l.layer} className="py-5 space-y-2">
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-foreground">
+                {l.layer}
+              </p>
+              <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+                {l.role}
+              </p>
+              <p className="text-sm leading-relaxed text-[var(--muted)] max-w-2xl text-pretty italic">
+                Examples: {l.examples}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          What&apos;s actually achievable today
+        </h2>
+        <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          As of 2026, a useful filter for &quot;can this category be a
+          zero-human company today?&quot; is whether the work is digital,
+          repeatable, and tolerant of agent error rates in the low single
+          digits.
+        </p>
+        <div className="space-y-8">
+          {achievableToday.map((bucket) => (
+            <div key={bucket.status}>
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-foreground">
+                {bucket.status}
+              </p>
+              <ul className="mt-3 list-disc pl-6 space-y-2 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+                {bucket.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Why I am writing this
+        </h2>
+        <div className="space-y-4 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          <p>
+            I build agent systems for a living. The companies I help and the
+            ones I run myself sit somewhere on the spectrum from
+            traditional-startup to zero-human. The phrase{" "}
+            <em>zero-human company</em> kept showing up in conversation with
+            no shared definition, which made every conversation start from
+            scratch.
+          </p>
+          <p>
+            This page is the working definition I use. It distinguishes the
+            term from one-person company (legal structure), solopreneur
+            (execution model with a human bottleneck), and traditional
+            startup (headcount-bound scaling). It names a stack — intent,
+            agent, infrastructure — that I find load-bearing across every
+            real implementation I have seen.
+          </p>
+          <p>
+            I will keep updating this page as the constraints move. The
+            achievable-today section, in particular, has a short half-life.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Frequently asked questions
+        </h2>
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          {faq.map((item) => (
+            <li key={item.q} className="py-5 space-y-2">
+              <p className="text-base font-medium text-foreground">{item.q}</p>
+              <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+                {item.a}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Further reading
+        </h2>
+        <ul className="space-y-2 text-base leading-relaxed">
+          <li>
+            <Link
+              href="/blog/zero-human-vs-one-person-company"
+              className="underline hover:opacity-70"
+            >
+              Zero-human vs one-person company: a definitional breakdown
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/blog/the-zero-human-stack"
+              className="underline hover:opacity-70"
+            >
+              The 3-layer zero-human stack, in practice
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/blog/running-projects-with-zero-employees"
+              className="underline hover:opacity-70"
+            >
+              Running projects with zero employees: what worked, what didn&apos;t
+            </Link>
+          </li>
+        </ul>
+      </section>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: graphScriptContent([
+            {
+              "@context": "https://schema.org",
+              "@type": "FAQPage",
+              mainEntity: faq.map((item) => ({
+                "@type": "Question",
+                name: item.q,
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: item.a,
+                },
+              })),
+            },
+          ]),
+        }}
+      />
+    </div>
+  );
+}

--- a/personal-site/app/llms-full.txt/route.ts
+++ b/personal-site/app/llms-full.txt/route.ts
@@ -68,6 +68,41 @@ ${projects
   .map((p) => `- ${p.name} (${p.href})\n  ${p.description}`)
   .join("\n\n")}
 
+## Defined terms
+
+### Zero-Human Company
+
+URL: ${SITE}/zero-human-company
+Author: Bingran You
+Last updated: 2026-05-08
+Also known as: zero human company, zero-employee company, agent-run company, AI-native company
+
+A zero-human company is a company where every execution function — engineering, marketing, support, sales, finance, operations — is performed by software agents and automated infrastructure rather than paid employees or contractors. The founder remains as the strategic operator. There is exactly one human in the loop, and that human does not do day-to-day work.
+
+The term is sometimes used loosely to mean "a company with no employees," which collides with the legal One-Person Company structure (notably under the Indian Companies Act, 2013). The narrower, more useful sense is operational: not zero humans, but zero human execution.
+
+Three criteria:
+
+1. No payroll for execution work. Founder draws or doesn't, but employees and contractors do not run operations.
+2. Agents and automated infrastructure handle the bulk of recurring work, with documented scopes, budgets, and evaluations.
+3. The founder's time is spent on direction, capital allocation, and irreversible decisions — not tickets, posts, or pull requests.
+
+Distinct from related concepts:
+
+- One-Person Company (OPC): a legal corporate structure for a single shareholder. Describes ownership, not operations. A zero-human company can be incorporated as an OPC, an LLC, a C-corp, or any other legal form.
+- Solopreneur: a one-person business where the human does the execution work. The bottleneck is the founder's hours.
+- Agency / micro-team: a small group of paid humans executing for clients.
+- Lifestyle business: a description of intent (modest scale, owner-led), not execution model.
+- Traditional startup: raises capital, hires employees, scales headcount with revenue.
+
+The 3-layer zero-human stack:
+
+1. Intent layer — the founder. Sets strategy, picks markets, allocates capital, makes irreversible decisions. Does not execute day-to-day work.
+2. Agent layer — LLM-driven agents and skills doing work historically done by employees. Each agent has a scope, a budget, an evaluation, and a clear handoff back to the intent layer.
+3. Infrastructure layer — deterministic plumbing the agents call into. Stripe, Vercel, Resend, Supabase, GitHub Actions, observability. Boring and well-documented.
+
+What is achievable today (as of 2026): single-product SaaS, info-products, content businesses, niche directories, template stores. Partially achievable with friction: enterprise B2B, regulated industries, high-touch sales. Not yet: physical operations at scale, long-horizon multi-quarter execution without drift.
+
 ## Blog posts
 
 ${postBodies

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -38,6 +38,11 @@ I work on two tracks: reliable AI agent systems, and trapped-ion atomic, molecul
 - [Projects](${SITE}/projects)
 - [Papers](${SITE}/papers)
 - [Blog](${SITE}/blog)
+- [Zero-Human Company — definition and stack](${SITE}/zero-human-company)
+
+## Defined terms
+
+- **Zero-Human Company** — a company where every execution function (engineering, marketing, support, sales, finance, ops) is performed by software agents and automated infrastructure rather than paid employees or contractors. The founder remains as the strategic operator and is the only human in the loop. See [${SITE}/zero-human-company](${SITE}/zero-human-company) for the full definition, the 3-layer stack (intent / agent / infrastructure), distinctions from one-person company and solopreneur, and what is achievable today.
 
 ## Selected papers
 

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -103,6 +103,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    {
+      url: `${SITE_URL}/zero-human-company`,
+      lastModified: await getLatestLastModified([
+        "app/(personal)/zero-human-company/page.tsx",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
   ];
 
   const skillEntries: MetadataRoute.Sitemap = getAllSkills().map((skill) => ({

--- a/personal-site/content/posts/running-projects-with-zero-employees.mdx
+++ b/personal-site/content/posts/running-projects-with-zero-employees.mdx
@@ -1,0 +1,51 @@
+export const metadata = {
+  title: "Running Projects with Zero Employees: What Worked, What Didn't",
+  description:
+    "Field notes from running several side projects without hiring. Where agents bought leverage, where they didn't, and what I had to do myself anyway.",
+  date: "2026-05-08",
+};
+
+# Running Projects with Zero Employees
+
+Field notes from a year of running several side projects without hiring. None of these are billion-dollar companies. They are the right size to actually test whether the [zero-human company](/zero-human-company) idea survives contact with shipping software to real users.
+
+I am writing this because most posts on the topic are either breathless hype or skeptical takedowns. The honest answer in 2026 is &quot;yes, but in a narrower band than the hype suggests.&quot;
+
+## What worked
+
+**Content and SEO, fully.** Drafting, editing, publishing, internal linking, schema markup — all of it can be agent-driven with a strong style guide and an eval that catches voice drift and hallucinated facts. The SEO surface of every project I run is largely agent-shipped at this point. I review weekly; I do not write.
+
+**First-line support, mostly.** A support agent with read access to the docs, write access to a structured ticket system, and a clear escalation path handles 70–80% of inbound questions on small products. The remaining 20% are real edge cases that benefit from a human eye, and that is the only place I personally touch tickets.
+
+**Routine engineering, with caveats.** Bug fixes inside a well-tested module, small features behind feature flags, dependency upgrades — agents ship these reliably when the test suite is honest. The caveat: the agent layer is only as good as the test layer. Skimping on tests means the agent ships bad code confidently.
+
+**Operations and reporting.** Reconciling invoices, generating weekly metrics, drafting quarterly reviews. Boring, repetitive, well-bounded — exactly what agents are good at.
+
+## What didn&apos;t work
+
+**Anything with a deadline and external dependencies.** Coordinating with a podcast guest, scheduling a launch, chasing a partner&apos;s legal team — agents either get politely ignored or come across as off-key. I do these myself.
+
+**Cold sales and high-stakes negotiation.** Agents can warm leads. They cannot, in 2026, replace me on a sales call where a real human is deciding whether to trust the company. I have not seen anyone solve this honestly.
+
+**Anything that required taste under uncertainty.** Picking the next product to build, deciding to kill a feature, choosing a brand voice from scratch — these are intent-layer decisions and the agent layer is bad at them by design. When I tried to push these down to agents, the output was confident and wrong. When I kept them at the intent layer, things worked.
+
+**Long-horizon execution.** Anything that took more than a couple of days of agent runtime started drifting. The agent would forget context, recompute things it had already decided, or quietly change direction. State-of-the-art evaluation harnesses still measure agent reliability in tasks, not in quarters, and that gap is real in production.
+
+## What I had to do myself anyway
+
+A short list, honestly:
+
+- Strategy and pricing decisions.
+- The first version of the brand voice (after which agents kept it consistent).
+- Customer calls with anyone whose contract was over a few thousand dollars.
+- Anything legal — contracts, disputes, compliance.
+- Hard kills. Agents will not voluntarily turn themselves off; the founder has to.
+- This blog. I write these myself. I think the trust hit from auto-generated personal essays is bigger than the time saved.
+
+## The honest summary
+
+A zero-human company today is real for a specific shape of business: digital, repeatable, tolerant of single-digit error rates, with a founder willing to operate strictly at the intent layer. For that shape, the leverage is unreasonable — the cost structure does not look like a traditional business at all.
+
+For other shapes — regulated, deeply relational, physical — the term is aspirational. Worth tracking, not worth committing to as an operating model in 2026.
+
+I plan to keep updating this page as the constraints move. The list of &quot;what didn&apos;t work&quot; gets shorter every quarter.

--- a/personal-site/content/posts/the-zero-human-stack.mdx
+++ b/personal-site/content/posts/the-zero-human-stack.mdx
@@ -1,0 +1,54 @@
+export const metadata = {
+  title: "The 3-Layer Zero-Human Stack, in Practice",
+  description:
+    "Intent, agents, infrastructure — the three layers of a zero-human company, and the specific failure modes I keep hitting at each one.",
+  date: "2026-05-08",
+};
+
+# The 3-Layer Zero-Human Stack, in Practice
+
+Every working [zero-human company](/zero-human-company) I have built or watched closely has the same three layers. The labels are mine; the structure is not. Mixing the layers is the single most common reason a zero-human-flavored project quietly turns into a solopreneur grind with extra steps.
+
+This is the stack, top down, with the failure mode I keep hitting at each layer.
+
+## Layer 1 — Intent
+
+This is the founder. One person, full stop. The intent layer decides what the company does, who it serves, what it costs, what it stops doing. It owns capital allocation and irreversible decisions.
+
+It does **not** write tickets, post on social, ship code, or answer customer email. The moment it does, the company is no longer a zero-human company; it is a solopreneur business with a fancy CI pipeline.
+
+The failure mode: scope creep down. The founder gets bored, or impatient, or insecure about what the agents are shipping, and starts &quot;just&quot; doing things by hand. Within two weeks they are back to running operations. The fix is structural — give the agent layer enough authority that the founder cannot helpfully intervene at the line level.
+
+## Layer 2 — Agents
+
+This is the LLM-driven work. Each agent has four things: a scope, a budget (tokens, dollars, calls per day), an evaluation that tells you whether it is doing its job, and a clear handoff back to the intent layer when it gets stuck.
+
+Concrete example from my own work. The marketing agent for a small product I run has scope &quot;produce one short post per platform per week, in the brand voice, citing only verified facts.&quot; Budget is a fixed monthly token spend. Evaluation is a weekly score from a judge model on voice fidelity, factual grounding, and engagement. Handoff is a daily summary with anything the agent flagged as uncertain.
+
+The failure mode: scope creep up. Agents will quietly take on more than their scope if you let them. The marketing agent starts answering DMs. The support agent starts making product decisions. The eng agent starts changing infra. Without budgets and evals, the agent layer eats the intent layer.
+
+## Layer 3 — Infrastructure
+
+This is the boring deterministic plumbing. Stripe for payments. Vercel for hosting. Resend for email. Supabase or Postgres for state. GitHub Actions for CI. Observability for everything.
+
+This layer is what makes the agent layer cheap and reliable instead of slow and fragile. Every time I have caught an agent flailing — looping on a task, burning tokens, missing an obvious solution — the underlying problem was that the infrastructure layer was forcing the agent to reason about something a deterministic call should have handled.
+
+The failure mode: agents reasoning about plumbing. If your agent has to figure out which API key to use for which environment, you have an infrastructure problem, not an agent problem. Push as much determinism down as you can. The agent layer should be reasoning about strategy and language, not URLs and credentials.
+
+## How the layers talk
+
+Intent → Agent: through written briefs, OKRs, kill/keep decisions. Slow cadence. Days to weeks.
+
+Agent → Agent: through documented hand-offs in shared state (a task queue, a project board, a doc). Medium cadence. Hours to days.
+
+Agent → Infrastructure: through tool calls, with retries, idempotency, and observability. Fast cadence. Seconds to minutes.
+
+Infrastructure → Agent: through structured returns, not raw text. The agent should rarely be parsing a string when it could be reading a typed response.
+
+When the layers talk in their proper cadences, the company runs. When the founder is talking to infrastructure (logging into Stripe to refund someone) or the agents are talking to intent (asking the founder to make a low-stakes pricing call), one of the layers is broken.
+
+## What this is good for
+
+This stack is good for thinking about *where* a problem lives. New customer complaint? It&apos;s an agent-layer eval miss. Burning too much money? Probably an infrastructure-layer determinism gap, surfacing as agent thrash. Strategy drift? Intent layer hasn&apos;t made a decision and the agents are filling in.
+
+It is not a finished blueprint. The interesting work is in the connective tissue — the briefs, the evals, the handoffs — and that is where most of my engineering time on these projects actually goes.

--- a/personal-site/content/posts/zero-human-vs-one-person-company.mdx
+++ b/personal-site/content/posts/zero-human-vs-one-person-company.mdx
@@ -1,0 +1,57 @@
+export const metadata = {
+  title: "Zero-Human vs One-Person Company: A Definitional Breakdown",
+  description:
+    "These two phrases get used as synonyms and they should not. One is a legal corporate form, the other is an operating model. Here is the difference, why it matters, and how to choose which one applies to you.",
+  date: "2026-05-08",
+};
+
+# Zero-Human vs One-Person Company
+
+Two phrases keep getting used as if they are the same thing: **zero-human company** and **one-person company**. They aren&apos;t. One describes a legal corporate form. The other describes how the work gets done. Conflating them produces bad advice in both directions — founders set up the wrong legal entity, and they design the wrong operating model.
+
+Here is the cleanest split I have found.
+
+## One-Person Company is a legal structure
+
+In India, the *Companies Act, 2013* introduced "One Person Company" (OPC) as a corporate form for a single shareholder. It has rules — minimum paid-up capital, nominee director, restrictions on conversion to a private limited company past certain revenue or capital thresholds. In casual usage, people also stretch the phrase to cover a US LLC with one member or a UK company with one director.
+
+The point: it&apos;s a description of *who owns and is liable for the entity*. It does not say anything about who does the work. A One-Person Company can have ten employees. Or a hundred. It just has one shareholder.
+
+If your question is "what should I incorporate as," this is the relevant term.
+
+## Zero-human company is an operating model
+
+A [zero-human company](/zero-human-company), as I use the phrase, is a company where no paid humans execute the day-to-day work. Engineering, marketing, support, sales, finance, ops — all done by software agents and automated infrastructure. The founder is the only human in the loop, and the founder does not run operations.
+
+This is silent on legal form. A zero-human company can be incorporated as an OPC, a Delaware C-corp, a UK Ltd, an LLC, anything.
+
+If your question is "how is the work going to get done," this is the relevant term.
+
+## Why the conflation is expensive
+
+Two real-world failure modes I&apos;ve seen:
+
+**Founder picks OPC because they read about &quot;zero-employee companies.&quot;** They incorporate the OPC, then realize they need a contractor for accounting, a freelancer for design, and a part-time engineer. The OPC&apos;s nominee-director and conversion rules now bite into a structure that was supposed to stay simple. The legal form was solving the wrong problem.
+
+**Founder builds a &quot;solo AI startup&quot; with no agent layer.** They are technically a one-person operation, but every customer ticket, every blog post, every PR is written by them. They are a solopreneur with extra steps. There is no leverage. The operating model was solving the wrong problem.
+
+The first founder needed a flexible legal form (LLC) and an OPC mindset. The second founder needed agent infrastructure and a zero-human operating model.
+
+## How to pick
+
+Use this table mentally:
+
+- If the question is **how do I incorporate**, you are deciding between OPC, LLC, Pte Ltd, C-corp, and so on. Talk to a lawyer in your jurisdiction.
+- If the question is **how do I scale without hiring**, you are deciding whether you want to be a solopreneur, a micro-team, or a zero-human company. Talk to your tooling and your evals.
+
+These two decisions are independent. Pick each on its own merits.
+
+## A working definition, restated
+
+For this site, I will keep using these terms as follows:
+
+- **One-Person Company / OPC**: a legal corporate form with a single shareholder.
+- **Solopreneur**: a one-person operating model where the human does the execution work.
+- **[Zero-human company](/zero-human-company)**: a one-or-zero-employee operating model where software agents and automated infrastructure do the execution work, and the founder operates as strategic intent layer only.
+
+Mix and match across the legal axis as your jurisdiction and tax situation require.

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -198,6 +198,81 @@ export function blogPostingJsonLd(args: {
   } as const;
 }
 
+export function definedTermJsonLd(args: {
+  path: string;
+  name: string;
+  alternateName?: ReadonlyArray<string>;
+  description: string;
+  termCode?: string;
+}) {
+  const url = `${SITE_URL}${args.path}`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "DefinedTerm",
+    "@id": `${url}#term`,
+    name: args.name,
+    ...(args.alternateName ? { alternateName: [...args.alternateName] } : {}),
+    description: args.description,
+    ...(args.termCode ? { termCode: args.termCode } : {}),
+    url,
+    inDefinedTermSet: {
+      "@type": "DefinedTermSet",
+      name: "Bingran You — Glossary",
+      url: `${SITE_URL}/`,
+    },
+  } as const;
+}
+
+export function articleJsonLd(args: {
+  path: string;
+  title: string;
+  description: string;
+  date: string;
+  modifiedTime?: string;
+  about?: string;
+  keywords?: ReadonlyArray<string>;
+}) {
+  const url = `${SITE_URL}${args.path}`;
+  const publishedTime = isoDate(args.date);
+  return {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "@id": `${url}#article`,
+    headline: args.title,
+    name: args.title,
+    description: args.description,
+    datePublished: publishedTime,
+    dateModified: args.modifiedTime ?? publishedTime,
+    url,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${url}#webpage`,
+    },
+    author,
+    publisher: author,
+    image: [OG_IMAGE_URL],
+    isAccessibleForFree: true,
+    inLanguage: "en",
+    ...(args.about ? { about: args.about } : {}),
+    ...(args.keywords ? { keywords: [...args.keywords] } : {}),
+  } as const;
+}
+
+export function breadcrumbJsonLd(
+  trail: ReadonlyArray<{ name: string; path: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: trail.map((step, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: step.name,
+      item: `${SITE_URL}${step.path}`,
+    })),
+  } as const;
+}
+
 export function graphScriptContent(items: ReadonlyArray<object>) {
   const graph = {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary

Stand up topical authority for "zero-human company" / "one person company" queries on bingran.ai.

- New pillar route `/zero-human-company` with definition, 3-layer stack (intent / agent / infrastructure), distinctions from One-Person Company and solopreneur, achievable-today guidance, author note, and an FAQ.
- Three internally-linked cluster posts: OPC-vs-zero-human definitional breakdown, the stack in practice, and a candid retrospective on running projects with no employees.
- New `lib/jsonld` helpers (`definedTermJsonLd`, `articleJsonLd`, `breadcrumbJsonLd`); pillar emits `DefinedTerm` + `TechArticle` + `BreadcrumbList` + `FAQPage` schema.
- Sitemap adds `/zero-human-company` at priority 0.9.
- `/llms.txt` gains a "Defined terms" section; `/llms-full.txt` inlines the canonical definition + stack so LLM crawlers index it without following links.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` (vitest) — 35/35 passed
- [x] `npm run build` — 229 static pages, 4 new routes registered
- [x] Verified rendered pillar HTML contains `DefinedTerm`, `TechArticle`, `BreadcrumbList`, `FAQPage` JSON-LD blocks
- [x] Verified `sitemap.xml` includes pillar + 3 cluster post URLs
- [ ] After merge / deploy: `npm run indexnow:ping` and submit `/zero-human-company` to Google Search Console + Bing Webmaster Tools