### PR TITLE
personal-site: add One-Person Company sibling pillar + cross-links

### DIFF
--- a/personal-site/app/(personal)/one-person-company/page.tsx
+++ b/personal-site/app/(personal)/one-person-company/page.tsx
@@ -1,0 +1,404 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  articleJsonLd,
+  breadcrumbJsonLd,
+  definedTermJsonLd,
+  graphScriptContent,
+} from "@/lib/jsonld";
+
+const PATH = "/one-person-company";
+const PUBLISHED = "2026-05-08";
+
+const ONE_LINER =
+  "A company with exactly one person at the helm — owner, operator, decision-maker. The operating-model question is how that one person scales: alone (solopreneur), with tools (indie hacker), or with agents doing the execution work (a zero-human company).";
+
+export const metadata: Metadata = {
+  title:
+    "One-Person Company — Operating-Model Definition, Modes, and 2026 Reality",
+  description:
+    "A one-person company is a company with one human owner-operator. There is the legal sense (the India OPC) and the operating-model sense (solopreneur, indie hacker, zero-human company). This page is about the operating model — definition, modes along the leverage spectrum, what is realistic in 2026, and how it relates to a zero-human company.",
+  alternates: { canonical: PATH },
+  keywords: [
+    "one person company",
+    "one-person company",
+    "OPC",
+    "solopreneur",
+    "indie hacker",
+    "solo founder",
+    "micro SaaS",
+    "zero-human company",
+    "AI-native company",
+    "Bingran You",
+  ],
+  openGraph: {
+    title: "One-Person Company",
+    description: ONE_LINER,
+    url: PATH,
+    type: "article",
+    publishedTime: new Date(PUBLISHED).toISOString(),
+    authors: ["Bingran You"],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "One-Person Company",
+    description: ONE_LINER,
+  },
+};
+
+const definedTerm = definedTermJsonLd({
+  path: PATH,
+  name: "One-Person Company",
+  alternateName: [
+    "One Person Company",
+    "Solo Company",
+    "OPC (Operating Model)",
+  ],
+  description: ONE_LINER,
+  termCode: "one-person-company",
+});
+
+const article = articleJsonLd({
+  path: PATH,
+  title: "One-Person Company — Operating-Model Definition and Modes",
+  description: ONE_LINER,
+  date: PUBLISHED,
+  about: "One-Person Company",
+  keywords: [
+    "one person company",
+    "solopreneur",
+    "indie hacker",
+    "zero-human company",
+  ],
+});
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: "Home", path: "/" },
+  { name: "One-Person Company", path: PATH },
+]);
+
+const modes: Array<{
+  label: string;
+  description: ReactNode;
+  leverage: string;
+}> = [
+  {
+    label: "Solopreneur",
+    description:
+      "One human does all the execution work — code, design, content, support, sales, ops. The bottleneck is the founder's hours.",
+    leverage: "Low. Revenue is bounded by working hours.",
+  },
+  {
+    label: "Freelancer / consultant",
+    description:
+      "One human sells time to clients. Often dressed up as a company, but the operating model is selling labor, not a product.",
+    leverage: "Low. Revenue is bounded by hours and rate.",
+  },
+  {
+    label: "Indie hacker / micro-SaaS founder",
+    description:
+      "One human ships a small product, leans heavily on no-code, off-the-shelf SaaS, and templated content. Some agent assist for support and marketing.",
+    leverage:
+      "Medium. Decoupled from hours via product, but still hands-on for most operational work.",
+  },
+  {
+    label: "Zero-human company",
+    description: (
+      <>
+        One human at the intent layer. All execution — code, content,
+        marketing, support, ops — runs through software agents and automated
+        infrastructure. See the{" "}
+        <Link
+          href="/zero-human-company"
+          className="underline hover:opacity-70"
+        >
+          full definition
+        </Link>{" "}
+        and the 3-layer stack.
+      </>
+    ),
+    leverage:
+      "High. Revenue is bounded by capital and compute, not hours.",
+  },
+];
+
+const realityChecks: Array<{ status: string; items: string[] }> = [
+  {
+    status: "Realistic single-person operations in 2026",
+    items: [
+      "Single-product SaaS at $0–$1M ARR — one founder, agents handling content / SEO / first-line support, automated billing and reporting.",
+      "Newsletter, course, or info-product business — agents draft, founder edits, automated delivery and payments.",
+      "Niche directories, aggregators, programmatic-SEO sites — agents ingest and refresh, founder picks the niche and the schema.",
+      "Templates, prompts, and digital asset stores — agents handle marketplace operations, founder curates the catalog.",
+      "Indie consulting or research practice with agent-augmented deliverables.",
+    ],
+  },
+  {
+    status: "Workable but with friction",
+    items: [
+      "Two-sided marketplaces — agents handle most operations but trust events (disputes, fraud, legal) need a human.",
+      "Mid-market B2B SaaS — agents handle inbound, but enterprise procurement still wants a human.",
+      "Communities and creator businesses — automation works for backend; the front of the house is the person, by design.",
+    ],
+  },
+  {
+    status: "Not realistic as a one-person operation in 2026",
+    items: [
+      "Anything physical at scale — manufacturing, fulfillment, fleet, retail.",
+      "Heavily regulated industries — finance, healthcare, legal — where the human-in-the-loop requirement is structural.",
+      "Anything dependent on enterprise relationship sales above $100K ACV.",
+    ],
+  },
+];
+
+const faq: Array<{ q: string; a: string }> = [
+  {
+    q: "What is a one-person company?",
+    a: "A company with exactly one human at the helm — owner, operator, decision-maker. The phrase is used in two distinct senses: a legal sense (the India One-Person Company corporate structure under the Companies Act, 2013) and an operating-model sense (any company actually run by one person, regardless of legal form). This page is about the operating-model sense.",
+  },
+  {
+    q: "Is one-person company the same as solopreneur?",
+    a: "Not quite. Solopreneur describes a specific operating mode where the human does the execution work directly. One-person company is a broader category — it includes solopreneurs, indie hackers, micro-SaaS founders, freelancers, and zero-human companies. They differ on how much leverage the one human has.",
+  },
+  {
+    q: "Is one-person company the same as zero-human company?",
+    a: "No. A zero-human company is a specific kind of one-person company — the one where software agents and automated infrastructure do the execution work, and the founder operates only at the intent layer. Every zero-human company is a one-person company; not every one-person company is zero-human.",
+  },
+  {
+    q: "Can a one-person company actually scale?",
+    a: "It depends on the operating mode. A solopreneur scales linearly with hours and rates, which means it scales poorly. An indie hacker scales with their product's ability to compound without their direct involvement. A zero-human company scales with capital and compute. The shape of the ceiling is set by the operating model, not by being one person.",
+  },
+  {
+    q: "Should I incorporate as a One-Person Company (OPC)?",
+    a: "That is a legal question, distinct from this page. The legal OPC structure exists primarily under the Indian Companies Act, 2013, and has specific rules about nominee directors and conversion thresholds. In other jurisdictions, the equivalent is usually a single-member LLC or a single-shareholder C-corp / Pte Ltd. Talk to a lawyer in your jurisdiction. Pick the legal form for tax and liability reasons. Pick the operating model for execution reasons.",
+  },
+  {
+    q: "What is the difference between a one-person company and a small startup?",
+    a: "A traditional startup raises capital and hires employees as it grows; headcount and revenue scale together. A one-person company tries to break that link — the one human stays one, while revenue, product surface, and customer count grow through tools and agents. Different game, different math.",
+  },
+  {
+    q: "Who writes about one-person companies?",
+    a: "The space is mostly indie founders writing on their own blogs and on platforms like Indie Hackers, Hacker News, X, and Substack. This page, by Bingran You, is an attempt to give the operating-model sense of the term a clear definition and a useful set of modes (solopreneur, indie hacker, zero-human company) so the conversation has shared vocabulary.",
+  },
+];
+
+export default function OnePersonCompanyPage() {
+  return (
+    <div className="space-y-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: graphScriptContent([definedTerm, article, breadcrumb]),
+        }}
+      />
+
+      <header className="space-y-6">
+        <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Definition · Field notes
+        </p>
+        <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight text-pretty">
+          One-Person Company
+        </h1>
+        <p className="text-lg leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          {ONE_LINER}
+        </p>
+        <p className="text-sm text-[var(--muted)]">
+          By{" "}
+          <Link href="/about" className="underline hover:opacity-70">
+            Bingran You
+          </Link>
+          . Last updated {PUBLISHED}.
+        </p>
+      </header>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Two senses of the phrase
+        </h2>
+        <div className="space-y-4 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          <p>
+            <strong className="text-foreground">The legal sense.</strong>{" "}
+            &quot;One-Person Company&quot; (OPC) is a corporate form
+            introduced under the Indian Companies Act, 2013 for a single
+            shareholder, with rules around nominee directors, paid-up
+            capital, and conversion thresholds. In other jurisdictions, the
+            equivalent is usually a single-member LLC, a single-shareholder
+            Pte Ltd, or a one-shareholder C-corp.
+          </p>
+          <p>
+            <strong className="text-foreground">
+              The operating-model sense.
+            </strong>{" "}
+            Any company actually run by one human — regardless of how it is
+            incorporated. This page is about the second sense. The first is
+            a question for a lawyer in your jurisdiction. The second is a
+            question about how the work gets done.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          The leverage spectrum
+        </h2>
+        <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          Every one-person company sits somewhere on a spectrum from
+          &quot;the founder does everything&quot; to &quot;the founder does
+          nothing operational.&quot; The phrase is too generic to be useful
+          on its own; the operating mode is what matters.
+        </p>
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          {modes.map((mode) => (
+            <li key={mode.label} className="py-5 space-y-2">
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-foreground">
+                {mode.label}
+              </p>
+              <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+                {mode.description}
+              </p>
+              <p className="text-sm leading-relaxed text-[var(--muted)] max-w-2xl text-pretty italic">
+                Leverage: {mode.leverage}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          What is realistic in 2026
+        </h2>
+        <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          Whether a category is workable as a one-person company depends on
+          how much of the work can be moved off the human, and how
+          fault-tolerant the customer relationship is to single-digit error
+          rates from agents.
+        </p>
+        <div className="space-y-8">
+          {realityChecks.map((bucket) => (
+            <div key={bucket.status}>
+              <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-foreground">
+                {bucket.status}
+              </p>
+              <ul className="mt-3 list-disc pl-6 space-y-2 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+                {bucket.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Why split the term this way
+        </h2>
+        <div className="space-y-4 text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+          <p>
+            Most posts I read about &quot;one-person companies&quot; quietly
+            mean one of three different things — solopreneur, indie hacker,
+            or zero-human company — and the advice that follows is good
+            advice for one of them and bad advice for the other two.
+          </p>
+          <p>
+            Splitting the term into legal sense vs. operating-model sense,
+            and the operating-model sense into a leverage spectrum, gives
+            us shared vocabulary. If you tell me you are running a
+            one-person company, my first question is{" "}
+            <em>which mode</em>. The answer changes everything else — what
+            tools you need, what you should build next, what the ceiling
+            looks like.
+          </p>
+          <p>
+            For my own framing of the high-leverage end of the spectrum, see{" "}
+            <Link
+              href="/zero-human-company"
+              className="underline hover:opacity-70"
+            >
+              the zero-human company definition
+            </Link>{" "}
+            and the 3-layer stack (intent / agent / infrastructure).
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Frequently asked questions
+        </h2>
+        <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          {faq.map((item) => (
+            <li key={item.q} className="py-5 space-y-2">
+              <p className="text-base font-medium text-foreground">{item.q}</p>
+              <p className="text-base leading-relaxed text-[var(--muted)] max-w-2xl text-pretty">
+                {item.a}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-[var(--muted)]">
+          Further reading
+        </h2>
+        <ul className="space-y-2 text-base leading-relaxed">
+          <li>
+            <Link
+              href="/zero-human-company"
+              className="underline hover:opacity-70"
+            >
+              Zero-Human Company — the high-leverage end of the spectrum
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/blog/zero-human-vs-one-person-company"
+              className="underline hover:opacity-70"
+            >
+              Zero-human vs one-person company: a definitional breakdown
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/blog/the-zero-human-stack"
+              className="underline hover:opacity-70"
+            >
+              The 3-layer zero-human stack, in practice
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/blog/running-projects-with-zero-employees"
+              className="underline hover:opacity-70"
+            >
+              Running projects with zero employees: what worked, what didn&apos;t
+            </Link>
+          </li>
+        </ul>
+      </section>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: graphScriptContent([
+            {
+              "@context": "https://schema.org",
+              "@type": "FAQPage",
+              mainEntity: faq.map((item) => ({
+                "@type": "Question",
+                name: item.q,
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: item.a,
+                },
+              })),
+            },
+          ]),
+        }}
+      />
+    </div>
+  );
+}

--- a/personal-site/app/(personal)/zero-human-company/page.tsx
+++ b/personal-site/app/(personal)/zero-human-company/page.tsx
@@ -82,7 +82,7 @@ const distinctions: Array<{ term: string; definition: string }> = [
   {
     term: "One-Person Company (OPC)",
     definition:
-      "A legal corporate structure (notably under Indian Companies Act, 2013) for a single shareholder. It is a legal form, not an operating model. A zero-human company is an operating model and can be incorporated as an OPC, an LLC, a C-corp, or anything else.",
+      "Used in two senses. (1) Legal: a corporate structure (notably under the Indian Companies Act, 2013) for a single shareholder. (2) Operating model: any company actually run by one human. A zero-human company is one mode of the operating-model sense — see /one-person-company for the full leverage spectrum.",
   },
   {
     term: "Solopreneur",
@@ -378,6 +378,15 @@ export default function ZeroHumanCompanyPage() {
           Further reading
         </h2>
         <ul className="space-y-2 text-base leading-relaxed">
+          <li>
+            <Link
+              href="/one-person-company"
+              className="underline hover:opacity-70"
+            >
+              One-Person Company — the broader category and leverage
+              spectrum
+            </Link>
+          </li>
           <li>
             <Link
               href="/blog/zero-human-vs-one-person-company"

--- a/personal-site/app/llms-full.txt/route.ts
+++ b/personal-site/app/llms-full.txt/route.ts
@@ -70,6 +70,30 @@ ${projects
 
 ## Defined terms
 
+### One-Person Company
+
+URL: ${SITE}/one-person-company
+Author: Bingran You
+Last updated: 2026-05-08
+Also known as: one person company, OPC, solo company
+
+A one-person company is a company with exactly one human at the helm — owner, operator, decision-maker. The phrase is used in two distinct senses.
+
+The legal sense: "One-Person Company" (OPC) is a corporate structure introduced under the Indian Companies Act, 2013, for a single shareholder, with rules around nominee directors, paid-up capital, and conversion thresholds. In other jurisdictions, the equivalent is usually a single-member LLC, a single-shareholder Pte Ltd, or a one-shareholder C-corp.
+
+The operating-model sense: any company actually run by one human, regardless of how it is incorporated. This is the sense that matters for execution decisions.
+
+In the operating-model sense, one-person companies sit on a leverage spectrum:
+
+- Solopreneur: the human does all the execution work — code, design, content, support, sales, ops. Bottleneck is hours. Low leverage.
+- Freelancer / consultant: the human sells time to clients. Often dressed up as a company; operating model is selling labor, not a product. Low leverage.
+- Indie hacker / micro-SaaS founder: the human ships a small product, leans heavily on no-code, off-the-shelf SaaS, and templated content. Some agent assist for support and marketing. Medium leverage.
+- Zero-human company: the human operates only at the intent layer. All execution runs through software agents and automated infrastructure. High leverage. See zero-human-company defined term above.
+
+What is realistic as a one-person company in 2026: single-product SaaS at $0–$1M ARR, info-products and courses, niche directories and aggregators, template / asset stores, indie consulting and research practices. Workable with friction: two-sided marketplaces, mid-market B2B SaaS, communities and creator businesses. Not realistic: physical operations at scale, regulated industries, enterprise relationship sales above $100K ACV.
+
+The relationship to zero-human company: every zero-human company is a one-person company. Not every one-person company is zero-human — most are solopreneurs or indie hackers.
+
 ### Zero-Human Company
 
 URL: ${SITE}/zero-human-company

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -39,10 +39,12 @@ I work on two tracks: reliable AI agent systems, and trapped-ion atomic, molecul
 - [Papers](${SITE}/papers)
 - [Blog](${SITE}/blog)
 - [Zero-Human Company — definition and stack](${SITE}/zero-human-company)
+- [One-Person Company — operating-model definition and modes](${SITE}/one-person-company)
 
 ## Defined terms
 
 - **Zero-Human Company** — a company where every execution function (engineering, marketing, support, sales, finance, ops) is performed by software agents and automated infrastructure rather than paid employees or contractors. The founder remains as the strategic operator and is the only human in the loop. See [${SITE}/zero-human-company](${SITE}/zero-human-company) for the full definition, the 3-layer stack (intent / agent / infrastructure), distinctions from one-person company and solopreneur, and what is achievable today.
+- **One-Person Company** — used in two senses. (1) Legal: a corporate structure for a single shareholder, notably under the Indian Companies Act, 2013. (2) Operating model: any company actually run by one human, regardless of legal form, spanning a leverage spectrum from solopreneur (human does the work) to indie hacker (product + tools) to zero-human company (agents do the work). See [${SITE}/one-person-company](${SITE}/one-person-company) for the operating-model sense, the leverage spectrum, what is realistic in 2026, and how it relates to zero-human company.
 
 ## Selected papers
 

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -111,6 +111,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly",
       priority: 0.9,
     },
+    {
+      url: `${SITE_URL}/one-person-company`,
+      lastModified: await getLatestLastModified([
+        "app/(personal)/one-person-company/page.tsx",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
   ];
 
   const skillEntries: MetadataRoute.Sitemap = getAllSkills().map((skill) => ({

--- a/personal-site/content/posts/zero-human-vs-one-person-company.mdx
+++ b/personal-site/content/posts/zero-human-vs-one-person-company.mdx
@@ -21,7 +21,7 @@ If your question is "what should I incorporate as," this is the relevant term.
 
 ## Zero-human company is an operating model
 
-A [zero-human company](/zero-human-company), as I use the phrase, is a company where no paid humans execute the day-to-day work. Engineering, marketing, support, sales, finance, ops — all done by software agents and automated infrastructure. The founder is the only human in the loop, and the founder does not run operations.
+A [zero-human company](/zero-human-company), as I use the phrase, is a company where no paid humans execute the day-to-day work. It is one specific point on the broader [one-person company](/one-person-company) leverage spectrum — the high-leverage end. Engineering, marketing, support, sales, finance, ops — all done by software agents and automated infrastructure. The founder is the only human in the loop, and the founder does not run operations.
 
 This is silent on legal form. A zero-human company can be incorporated as an OPC, a Delaware C-corp, a UK Ltd, an LLC, anything.
 
@@ -50,8 +50,9 @@ These two decisions are independent. Pick each on its own merits.
 
 For this site, I will keep using these terms as follows:
 
-- **One-Person Company / OPC**: a legal corporate form with a single shareholder.
-- **Solopreneur**: a one-person operating model where the human does the execution work.
-- **[Zero-human company](/zero-human-company)**: a one-or-zero-employee operating model where software agents and automated infrastructure do the execution work, and the founder operates as strategic intent layer only.
+- **One-Person Company (legal sense)**: a corporate form with a single shareholder, e.g. the Indian OPC. A question for your lawyer.
+- **[One-person company (operating-model sense)](/one-person-company)**: any company actually run by one human, sitting somewhere on a leverage spectrum.
+- **Solopreneur**: a low-leverage one-person company where the human does the execution work directly.
+- **[Zero-human company](/zero-human-company)**: a high-leverage one-person company where software agents and automated infrastructure do the execution work, and the founder operates as strategic intent layer only.
 
 Mix and match across the legal axis as your jurisdiction and tax situation require.


### PR DESCRIPTION
## Summary

Second sibling pillar to capture "one person company" / "one-person company" queries on bingran.ai, separate from the legal Indian OPC sense.

- New pillar route `/one-person-company` defines the term, splits the two senses (legal vs operating model), lays out the leverage spectrum (solopreneur → freelancer → indie hacker → zero-human company), and includes a 2026 reality check + FAQ.
- Cross-link the two pillars: `/one-person-company` points to `/zero-human-company` as the high-leverage end of the spectrum; `/zero-human-company` surfaces `/one-person-company` as the broader category. The `zero-human-vs-one-person-company` cluster post links to both.
- Pillar emits `DefinedTerm` + `TechArticle` + `BreadcrumbList` + `FAQPage` schema.
- Sitemap adds `/one-person-company` at priority 0.9.
- `/llms.txt` gains the second defined-term entry; `/llms-full.txt` inlines the full definition + leverage spectrum.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` (vitest) — 35/35 passed
- [x] `npm run build` — both `/zero-human-company` and `/one-person-company` registered as static routes
- [x] Verified rendered pillar HTML contains all four schema types
- [x] Verified `sitemap.xml` includes `/one-person-company` + the existing zero-human URLs
- [ ] After merge + deploy: `npm run indexnow:ping` for `/one-person-company` and submit to GSC + Bing Webmaster