### PR TITLE
personal-site: surface 尤炳然 as canonical Chinese name across SEO surfaces

### DIFF
--- a/personal-site/app/(personal)/about/page.tsx
+++ b/personal-site/app/(personal)/about/page.tsx
@@ -5,12 +5,12 @@ import { jsonLdScriptContent, profilePageJsonLd } from "@/lib/jsonld";
 export const metadata: Metadata = {
   title: "About",
   description:
-    "Bingran You — PhD candidate at UC Berkeley working on reliable AI systems and trapped-ion experiments in atomic, molecular and optical physics.",
+    "Bingran You (尤炳然) — PhD candidate at UC Berkeley working on reliable AI systems and trapped-ion experiments in atomic, molecular and optical physics.",
   alternates: { canonical: "/about" },
 };
 
 const facts = [
-  "I am Bingran You, a PhD candidate in Applied Science & Technology at UC Berkeley, advised in the Haeffner Lab.",
+  "I am Bingran You (Chinese: 尤炳然), a PhD candidate in Applied Science & Technology at UC Berkeley, advised in the Haeffner Lab.",
   "I build reliable AI systems — agent infrastructure, evaluation harnesses, and applied AI products that need to behave under noisy real-world conditions.",
   "I run trapped-ion experiments in atomic, molecular and optical physics — integrated photonics for individual ion addressing, ion-photon interfaces, and 3D-printed micro ion traps for scalable hardware.",
   "Both tracks share one craft: turning complex, noisy systems into something that behaves on purpose.",

--- a/personal-site/app/(personal)/layout.tsx
+++ b/personal-site/app/(personal)/layout.tsx
@@ -26,7 +26,7 @@ export default function PersonalLayout({
       <footer className="border-t border-[var(--border)]">
         <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 sm:py-10 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-[var(--muted)]">
-            © {new Date().getFullYear()} Bingran You · Berkeley, CA
+            © {new Date().getFullYear()} Bingran You · <span lang="zh-Hans">尤炳然</span> · Berkeley, CA
           </p>
           <SocialLinks />
         </div>

--- a/personal-site/app/(personal)/page.tsx
+++ b/personal-site/app/(personal)/page.tsx
@@ -29,6 +29,12 @@ export default function Home() {
           <h1 className="font-display text-5xl leading-[1.02] tracking-[-0.035em] sm:text-6xl">
             Bingran You
           </h1>
+          <p
+            lang="zh-Hans"
+            className="mt-2 font-display text-2xl leading-tight tracking-tight text-[var(--muted)] sm:text-3xl"
+          >
+            尤炳然
+          </p>
           <ul className="mt-7 space-y-3 text-base text-[var(--muted)]">
             <li className="flex flex-wrap items-center gap-x-6 gap-y-2">
               <span className="inline-flex items-center gap-2">

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -4,15 +4,17 @@ import { SITE_URL } from "@/lib/site";
 export { SITE_URL };
 export const SITE_NAME = "Bingran You";
 export const SITE_DESCRIPTION =
-  "Bingran You — PhD candidate at UC Berkeley building reliable AI systems and running trapped-ion experiments in atomic, molecular and optical physics.";
+  "Bingran You (尤炳然) — PhD candidate at UC Berkeley building reliable AI systems and running trapped-ion experiments in atomic, molecular and optical physics.";
 export const SITE_OG_DESCRIPTION =
-  "PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion atomic, molecular and optical physics.";
+  "Bingran You (尤炳然) — PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion atomic, molecular and optical physics.";
 export const OG_IMAGE_URL = `${SITE_URL}/images/profile/bingran-you-portrait.jpg`;
 export const PERSON_ID = `${SITE_URL}#person`;
 export const WEBSITE_ID = `${SITE_URL}#website`;
 export const PROFILE_PAGE_ID = `${SITE_URL}#profile`;
 export const SITE_KEYWORDS = [
   "Bingran You",
+  "尤炳然",
+  "You Bingran",
   "AI agents",
   "reliable AI systems",
   "agent evaluation",
@@ -43,6 +45,7 @@ function personEntity() {
     "@type": "Person" as const,
     "@id": PERSON_ID,
     name: SITE_NAME,
+    alternateName: ["尤炳然", "You Bingran"],
     givenName: "Bingran",
     familyName: "You",
     url: SITE_URL,
@@ -117,7 +120,7 @@ export function websiteJsonLd() {
     "@type": "WebSite",
     "@id": WEBSITE_ID,
     name: SITE_NAME,
-    alternateName: ["bingranyou.com"],
+    alternateName: ["尤炳然", "bingranyou.com"],
     url: SITE_URL,
     inLanguage: "en",
     author: { "@id": PERSON_ID },


### PR DESCRIPTION
## Summary
- Add `尤炳然` as a small subtitle under the homepage `<h1>Bingran You</h1>`, in the about-page intro fact, and in the footer copyright line.
- Inject `尤炳然` (and Latin variant `You Bingran`) into `Person.alternateName`, `WebSite.alternateName`, `SITE_DESCRIPTION`, `SITE_OG_DESCRIPTION`, and `SITE_KEYWORDS` so all `<meta>` descriptions and JSON-LD on every page carry the Chinese name.
- Keep `<html lang="en">` unchanged — site is genuinely English; faking hreflang for a non-existent zh variant would hurt SEO. Chinese strings on visible elements are scoped with `lang="zh-Hans"`.

## Why
Currently a Google search for "尤炳然" never surfaces bingran.ai — there are zero occurrences of the Chinese name anywhere on the site, and the JSON-LD `Person` schema only carries the Latin name. This change gives both Google's classical index and its Knowledge Graph a clean signal that bingran.ai is the canonical home of 尤炳然.

This is the on-page half of the strategy. Off-page (Wikidata Q139620371 Chinese label, LinkedIn additional name, GitHub bio, Scholar/ORCID alternate names) is being handled out-of-band and is where the bigger ranking win comes from.

## Test plan
- [ ] Vercel preview build succeeds
- [ ] Preview homepage shows 尤炳然 byline rendered with the Newsreader display font, color `var(--muted)`
- [ ] Preview about page first sentence reads "I am Bingran You (Chinese: 尤炳然)…"
- [ ] Preview footer reads `© 2026 Bingran You · 尤炳然 · Berkeley, CA`
- [ ] View source on `/`: `<meta name="description">` contains `尤炳然`; JSON-LD `Person.alternateName` includes `尤炳然`
- [ ] After merge: GSC URL Inspection → Request Indexing on `/` and `/about`