### PR TITLE
social-scraping-policy: consolidate know-how, slim AGENTS.md pointers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,17 +153,12 @@ Daily files are journal. `MEMORY.md` is workspace wisdom. `PRIVATE_MEMORY.md` is
 - Running deploys, touching production
 - Any action whose effect leaves this machine
 
-## Task-Specific Skill Triggers
+## Skills that own a domain
 
-Some workspace tasks have a **mandatory entry skill** — invoke it via the Skill tool *before* you start running commands or writing code. The skills exist because we already paid for the lessons; future-you doesn't need to repeat them.
+Some skills are the single source of truth for a domain — invoke them *first* and let them tell you what to do. Don't re-derive their lessons.
 
-| If the task involves … | Always invoke first |
-|---|---|
-| Reading / scraping / metadata-extraction from X (twitter), Xiaohongshu (xhslink, rednote), YouTube, Bilibili, LinkedIn — including any "add this to /posts" / "把这条加到个人网站" / pasted post URL with intent to land it as a card on bingran.ai/posts | **`social-scraping-policy`** — defines tool order (claude-in-chrome MCP, NOT Playwright/headless), pacing budgets, the `/posts` pipeline scripts (`personal-site/scripts/add-social-post.mjs`), and the XHS login-wall fallback recipe |
-| Anything that would `navigate` / `fetch` x.com, xiaohongshu.com, xhslink.com, rednote.com on Bingran's account | **`social-scraping-policy`** — same skill, account-safety side |
-| Writing or planning Xiaohongshu posts (creative side: copy, hashtags, cover design) | **`xiaohongshu-knowledge`** |
-
-Rule of thumb: if the task could risk Bingran's account *or* there's a known-good script you'd otherwise re-derive, the skill exists. Spending 10 seconds reading the skill saves 10 minutes re-discovering its lessons.
+- **`social-scraping-policy`** — anything touching X / Xiaohongshu / xhslink / YouTube / Bilibili / LinkedIn. Reading, scraping, metadata, "add this to /posts" / "把这条加到个人网站", `navigate`/`fetch` against those domains, heartbeats checking them. Owns scripts, fallbacks, account-safety budgets.
+- **`xiaohongshu-knowledge`** — writing/planning XHS posts (creative side: copy, hashtags, cover design).
 
 ## Task Delivery
 

--- a/personal-site/AGENTS.md
+++ b/personal-site/AGENTS.md
@@ -4,12 +4,6 @@
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
 
-## Adding posts to /posts goes through `social-scraping-policy`
+## Adding posts to /posts → `social-scraping-policy`
 
-If the user pastes a post URL (X / Xiaohongshu / YouTube / Bilibili / LinkedIn) with intent like "add this to /posts" / "把这条加进来" / "更新到个人网站", **invoke the `social-scraping-policy` skill before doing anything**. It owns:
-
-- the `npm run post:add -- "<url>"` recipe (the only script you should call)
-- the XHS login-wall fallback (claude-in-chrome MCP against Bingran's signed-in Chrome — **not** Playwright, not headless Chromium, not `WebFetch`)
-- the diff-discipline rules (hand-edit `content/social/posts.json` instead of re-running the script's resort, so the diff stays at +8/-0)
-
-Source of truth: `repo-skills/social-scraping-policy/SKILL.md` (mirrored into `.claude/skills/` and `.agents/skills/` automatically).
+Any pasted social post URL ("add this to /posts" / "把这条加到个人网站" / X / Xiaohongshu / YouTube / Bilibili / LinkedIn) is owned by the `social-scraping-policy` skill — invoke it first; it documents `npm run post:add`, the XHS Chrome-MCP fallback, and the diff discipline.

--- a/personal-site/scripts/add-social-post.mjs
+++ b/personal-site/scripts/add-social-post.mjs
@@ -6,6 +6,10 @@
 //
 // Detects platform from the URL, runs the platform extractor, falls back to
 // generic OpenGraph parsing. Edits posts.json idempotently (skip duplicates by URL/id).
+//
+// Canonical docs (when this script returns a canary, when XHS login-walls,
+// account-safety budgets, full /posts pipeline): see the social-scraping-policy
+// skill at repo-skills/social-scraping-policy/SKILL.md.
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";

--- a/repo-skills/social-scraping-policy/SKILL.md
+++ b/repo-skills/social-scraping-policy/SKILL.md
@@ -13,6 +13,23 @@ How to read / scrape X (Twitter) and Xiaohongshu (RedNote) without damaging Bing
 
 This skill is the gate AND the playbook. If you read it and still don't know what to do, stop and ask Bingran.
 
+## Canonical index — code & docs that belong to this skill
+
+Everything you'd reach for when handling these tasks. The skill is the single source of truth; AGENTS.md just points here.
+
+| Asset | Where it lives | Why it isn't inside this skill dir |
+|---|---|---|
+| `add-social-post.mjs` — URL → metadata → JSON-append script | `personal-site/scripts/add-social-post.mjs` | Wired into `personal-site/package.json` as `npm run post:add`; moving it would break that workflow. Treat *this* SKILL.md as the docs of record; `--help` in the script is intentionally terse. |
+| `posts.json` — the data | `personal-site/content/social/posts.json` | It's the personal-site's content, not a skill artifact. |
+| `social-post-card.tsx` — render component | `personal-site/components/social-post-card.tsx` | Same — site code. |
+| Thumbnail bucket | `personal-site/public/posts-thumbs/xiaohongshu/<note-id>.jpg` | Public site assets. |
+| Account / pacing / threat-model rules | this file, §§ Part 1–2 | — |
+| Per-platform extractor recipes & XHS fallback | this file, §§ 3.3–3.4 | — |
+| Trigger phrases & decision rule | this file, § 3 preamble + § 3.8 | — |
+| Process discipline ("ship complete, not half-done") | this file, § 3.10 below | — |
+
+If you find scraping-related know-how *anywhere else* in the workspace (random `memory/*.md`, an outdated CLAUDE.md note, a stray script in `social-media/`), the right move is: lift it into this skill, drop a one-line pointer at the original location, and tell Bingran in your status update. The skill stays canonical.
+
 ## When this skill applies
 
 Trigger if the task involves any of:
@@ -566,6 +583,24 @@ The `/posts` pipeline mostly stays out of § Part 2 risk because:
 - **YouTube oembed, Bilibili JSON, XHS image CDN, Twitter syndication (via react-tweet)** are unauthenticated public endpoints. ToS-fine for personal use. (XHS share-URL HTML *was* one too; as of 2026-05-07 it's blocking anonymous fetches — see § 3.3.)
 - The browser-driven steps are the **bulk harvest** (§ 3.6) and now the **per-post XHS fallback** when the script's server-side path 404s. Both touch Bingran's logged-in Chrome session, so apply § Part 2 budgets: stay under 50 items / 10 min / 6 navs/min on X, under 30 / 8 / 4 on XHS. A single fallback add (one navigate, one JS read, one image download) is well under any budget; don't queue ten of them in a tight loop.
 - **Don't rebuild the harvest just to "refresh" data.** New posts come in trickle; use the paste-a-link flow per post. Re-running a full harvest is the kind of pattern that flips a yellow signal.
+
+### 3.10 Process discipline — ship the whole thing, not half
+
+Bingran's standing rule for these tasks: **one PR contains the complete change.** No "I'll add the thumbnail in a follow-up", no "let me ship the JSON now and update the skill later." If you can't finish all of it, don't push yet.
+
+A complete /posts add is:
+
+1. ✅ The post entry in `personal-site/content/social/posts.json` (correct id, url, title, date, `addedVia: "manual"`).
+2. ✅ The thumbnail file present at `personal-site/public/posts-thumbs/xiaohongshu/<note-id>.jpg` (for XHS) or the remote URL verified loadable (YouTube/Bilibili).
+3. ✅ The `thumbnail` field set in the JSON entry, pointing at #2.
+4. ✅ Diff = +8/-0 in `posts.json`, +1 binary thumbnail file. No regenerated `skills.generated.json`, no other unrelated files.
+5. ✅ Any new pitfall observed during this add → folded back into this SKILL.md *in the same PR*, not as a follow-up.
+6. ✅ Trigger surfaces still pointing at this skill — workspace `AGENTS.md` and `personal-site/AGENTS.md` need at most one short sentence each, and they should still match what this file says.
+7. ✅ PR description names what shipped + what was verified. Squash-merge after Vercel preview goes green.
+
+If step 5 produced changes (new fallback recipe, new gotcha), those changes go in **this file** — not in `memory/`, not in `MEMORY.md`, not in a workspace doc. The skill is canonical; everything else is a pointer.
+
+The reason: shipping in halves means future-you reads the half that landed and assumes the job is done. Bingran will read `posts.json`, see no thumbnail, and fix it himself. That's the failure mode this rule prevents.
 
 ---
 


### PR DESCRIPTION
## Summary

Following up on #169: now that XHS thumbnails work end-to-end via Chrome MCP, codify the rule that the **skill is the single source of truth** for these tasks and keep AGENTS.md concise.

- **`repo-skills/social-scraping-policy/SKILL.md`** — adds two sections:
  - **Canonical index** at the top: every script, data file, component, and thumbnail bucket related to /posts work, with explicit rationale for any item that lives outside the skill dir (e.g. `personal-site/scripts/add-social-post.mjs` is wired into `package.json` and can't move without breaking `npm run post:add`).
  - **§ 3.10 Process discipline** — "ship the whole thing, not half" 7-item checklist (post entry + thumbnail + JSON `thumbnail` field + diff hygiene + skill update folded in + concise AGENTS pointers + green PR). Codifies the rule Bingran called out after I shipped a thumbnail-less post first.
- **`AGENTS.md`** (workspace) — replaces the verbose Task-Specific Skill Triggers table with a slim **Skills that own a domain** list (two bullets, one per skill).
- **`personal-site/AGENTS.md`** — compresses the /posts pointer to a single sentence.
- **`personal-site/scripts/add-social-post.mjs`** — header comment points back at the skill as canonical docs.

## Test plan

- [x] `posts.json` untouched (no data churn in this PR).
- [x] Skill mirror under `.claude/skills/social-scraping-policy/` is a directory symlink to source — edits propagate without re-syncing.
- [x] AGENTS.md / personal-site/AGENTS.md are each shorter than before, still flag `social-scraping-policy` clearly.
- [x] Trigger description hasn't regressed — still aggressive on `xhslink` / `把这条加到个人网站` / etc.
- [ ] Vercel preview build green (no personal-site code changed; `ignoreCommand` should skip).