### PR TITLE
personal-site: pair Newsreader with Noto Serif SC for Han typography

### DIFF
--- a/personal-site/app/(personal)/page.tsx
+++ b/personal-site/app/(personal)/page.tsx
@@ -31,7 +31,7 @@ export default function Home() {
           </h1>
           <p
             lang="zh-Hans"
-            className="mt-2 font-display text-2xl leading-tight tracking-tight text-[var(--muted)] sm:text-3xl"
+            className="mt-3 font-display text-4xl leading-[1.1] text-foreground/85 sm:text-5xl"
           >
             尤炳然
           </p>

--- a/personal-site/app/globals.css
+++ b/personal-site/app/globals.css
@@ -18,9 +18,15 @@
   --color-border: var(--border);
   --color-accent: var(--accent);
   --color-accent-strong: var(--accent-strong);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-display: var(--font-newsreader);
+  /* Per-glyph fallback: Latin → Geist/Newsreader, Han → Noto Serif SC for
+     display contexts, system Han sans (PingFang/Hiragino/YaHei) for body.
+     The browser walks the stack per glyph, so mixed Latin+Han text inside
+     a single element is rendered with the right typeface for each script. */
+  --font-sans: var(--font-geist-sans), -apple-system, BlinkMacSystemFont,
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, monospace;
+  --font-display: var(--font-newsreader), var(--font-noto-serif-sc),
+    "Songti SC", "STSong", "Source Han Serif SC", serif;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -58,6 +64,29 @@ body {
 ::selection {
   background: var(--accent);
   color: var(--background);
+}
+
+/* Han typography: square ideographs need slightly looser tracking than the
+   Latin defaults, and the Newsreader text-feature settings (ss01/ss02/cv01/
+   cv11 from `body`) target Latin glyphs only — Noto Serif SC ignores them
+   but inheriting them is harmless. Apply a small letter-spacing nudge so
+   inline Han inside Latin paragraphs (e.g. "Bingran You (Chinese: 尤炳然)")
+   reads as a deliberate inset, not a jam-up. */
+:lang(zh-Hans),
+:lang(zh-Hant),
+:lang(zh) {
+  letter-spacing: 0.02em;
+  font-feature-settings: normal;
+}
+
+/* Display Han (h1 byline, future zh display headings) — open up tracking
+   and sit at the regular Noto Serif SC weight so the glyphs feel airy
+   alongside Newsreader's modulated Latin contours. */
+.font-display:lang(zh-Hans),
+.font-display:lang(zh-Hant),
+.font-display:lang(zh) {
+  letter-spacing: 0.04em;
+  font-weight: 400;
 }
 
 /* Map Tailwind Typography to the Berkeley-dusk palette so prose pages

--- a/personal-site/app/layout.tsx
+++ b/personal-site/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Newsreader } from "next/font/google";
+import { Geist, Geist_Mono, Newsreader, Noto_Serif_SC } from "next/font/google";
 import "./globals.css";
 import {
   jsonLdScriptContent,
@@ -26,6 +26,18 @@ const geistMono = Geist_Mono({
 const newsreader = Newsreader({
   variable: "--font-newsreader",
   subsets: ["latin"],
+});
+
+// Noto Serif SC pairs with Newsreader for harmonious Han + Latin display.
+// subsets: ["latin"] only controls preload hints; CJK glyphs are still
+// served via unicode-range and lazy-loaded when Chinese characters render.
+// preload: false — most pages have no Chinese, so don't waste a preload slot.
+const notoSerifSC = Noto_Serif_SC({
+  variable: "--font-noto-serif-sc",
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  preload: false,
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -82,7 +94,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} ${newsreader.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${newsreader.variable} ${notoSerifSC.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <script


### PR DESCRIPTION
## Summary
- Load **Noto Serif SC** via `next/font/google` (`weight: ["400","500"]`, `preload: false`, `display: "swap"`). CJK glyphs are lazy-loaded via unicode-range when Chinese characters render — pages with no Han see zero overhead.
- Extend `--font-display` to `var(--font-newsreader), var(--font-noto-serif-sc), "Songti SC", "STSong", "Source Han Serif SC", serif`. Browser walks the stack per glyph, so mixed Latin+Han inside one element renders Latin in Newsreader and Han in Noto Serif SC automatically.
- Extend `--font-sans` with explicit system Han sans (`PingFang SC`, `Hiragino Sans GB`, `Microsoft YaHei`) so body Han stays sans-paired with Geist Sans. Display contexts go serif, body contexts go sans — editorial-correct dual treatment.
- Add `:lang(zh-*)` typographic refinements: 0.02em letter-spacing globally, 0.04em + weight 400 in `.font-display` contexts. Square ideographs need more breathing room than Latin.
- Bump homepage byline: `text-2xl/3xl` → `text-4xl/5xl`, `text-[var(--muted)]` → `text-foreground/85`, `mt-2` → `mt-3`. 尤炳然 now reads as a paired name rather than a muted subtitle.

## Why
Previous SEO PR added 尤炳然 to the homepage but it fell back to PingFang sans, clashing visually with the Newsreader serif Latin h1. The Chinese name looked like a generic OS-default subtitle, not part of the editorial identity. This change unifies Han + Latin under one serif treatment for display, and one sans treatment for body — applied globally so any future Chinese on the site (posts, glossary, footer) inherits the right stack automatically.

## Test plan
- [ ] Vercel preview build succeeds
- [ ] Homepage h1 byline 尤炳然 renders in Noto Serif SC (visible serif strokes, not block sans), at ~75-80% the height of "Bingran You", at near-foreground color
- [ ] Footer "© 2026 Bingran You · 尤炳然 · Berkeley, CA" 尤炳然 stays in sans (system Han fallback) — body context, not display
- [ ] About page first sentence "Bingran You (Chinese: 尤炳然)" — inline 尤炳然 stays sans
- [ ] DevTools → Computed font-family on h1 byline shows Noto Serif SC in the cascade
- [ ] No FOIT or layout shift on slow 3G (display: swap)
- [ ] Light + dark mode both render correctly