### PR TITLE
personal-site: add latest X post to /posts

### DIFF
--- a/personal-site/content/social/posts.json
+++ b/personal-site/content/social/posts.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "x-2053303104985329892",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2053303104985329892",
+    "date": "2026-05-09",
+    "addedVia": "manual"
+  },
+  {
     "id": "xhs-69ff9d24000000003601866c",
     "platform": "xiaohongshu",
     "url": "https://www.xiaohongshu.com/explore/69ff9d24000000003601866c?xsec_token=CBpefz9x_fdFP-UWh6zWguSkU72Zd0MA5VQGXS5B-szVE%3D&xsec_source=pc_user",


### PR DESCRIPTION
## Summary
- Adds [x-2053303104985329892](https://x.com/bingran_bry/status/2053303104985329892) to `personal-site/content/social/posts.json`.
- Standard X stub (id + url + date + addedVia + platform) — react-tweet renders the tweet body, author, media, and timestamp at request time.

## Test plan
- [x] `posts.json` parses, no duplicate ids (72 entries total)
- [x] Diff is +7/-0 (no resort churn)
- [ ] Vercel preview shows the new card at the top of /posts