### PR TITLE
personal-site: fix vercel ignoreCommand to compare against previous deploy

### DIFF
--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
+  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD -- .",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

- The previous `ignoreCommand` (`git diff --quiet HEAD^ HEAD -- .`) only inspected the diff between the deployed tip and its first parent. When a single push contains multiple commits, only the tip's parent diff is checked — intermediate commits that *did* touch `personal-site/` get silently skipped if the merge/tip commit itself didn't.
- This is exactly what swallowed the v2.6 revert ([d20f2dc](https://github.com/bingran-you/bingran-you/commit/d20f2dc)): pushed alongside a merge commit (`ef96372`) whose first-parent diff under `personal-site/` was empty, so Vercel skipped deploying the revert. bingran.ai kept serving the v2.6 build from CDN.
- Switch to `${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}` so we compare against the last *successful deploy's* SHA. Falls back to `HEAD^` only on the very first deploy where the env var isn't set.
- This commit also acts as the trivial change that nudges Vercel into rebuilding now (it's the first `personal-site/` change since the broken push), which finally lands the revert on production.

## Test plan

- [ ] Confirm Vercel queues a Production deployment for this PR's merge commit.
- [ ] After merge, `curl -sI https://bingran.ai` returns a fresh `etag` (different from `3aeaf3ac1dd5a69bc851ac2a14bb8073`) and low `age`.
- [ ] Visit https://bingran.ai and verify the design is the pre-v2.6 version (revert is live).