### PR TITLE
skills: add karpathy-guidelines and refresh mirror entrypoints

### DIFF
--- a/.agents/skills/8-bit-orbit-video-template
+++ b/.agents/skills/8-bit-orbit-video-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/8-bit-orbit-video-template

--- a/.agents/skills/after-hours-editorial-template
+++ b/.agents/skills/after-hours-editorial-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/after-hours-editorial-template

--- a/.agents/skills/clinical-case-report
+++ b/.agents/skills/clinical-case-report
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/clinical-case-report

--- a/.agents/skills/co-marketing
+++ b/.agents/skills/co-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/co-marketing

--- a/.agents/skills/dcf-valuation
+++ b/.agents/skills/dcf-valuation
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/dcf-valuation

--- a/.agents/skills/digits-fintech-swiss-template
+++ b/.agents/skills/digits-fintech-swiss-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/digits-fintech-swiss-template

--- a/.agents/skills/editorial-burgundy-principles-template
+++ b/.agents/skills/editorial-burgundy-principles-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/editorial-burgundy-principles-template

--- a/.agents/skills/field-notes-editorial-template
+++ b/.agents/skills/field-notes-editorial-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/field-notes-editorial-template

--- a/.agents/skills/flowai-live-dashboard-template
+++ b/.agents/skills/flowai-live-dashboard-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/flowai-live-dashboard-template

--- a/.agents/skills/github-dashboard
+++ b/.agents/skills/github-dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/github-dashboard

--- a/.agents/skills/html-ppt-retro-quarterly-review
+++ b/.agents/skills/html-ppt-retro-quarterly-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-retro-quarterly-review

--- a/.agents/skills/html-ppt-zhangzara-8-bit-orbit
+++ b/.agents/skills/html-ppt-zhangzara-8-bit-orbit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-8-bit-orbit

--- a/.agents/skills/html-ppt-zhangzara-biennale-yellow
+++ b/.agents/skills/html-ppt-zhangzara-biennale-yellow
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-biennale-yellow

--- a/.agents/skills/html-ppt-zhangzara-block-frame
+++ b/.agents/skills/html-ppt-zhangzara-block-frame
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-block-frame

--- a/.agents/skills/html-ppt-zhangzara-blue-professional
+++ b/.agents/skills/html-ppt-zhangzara-blue-professional
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-blue-professional

--- a/.agents/skills/html-ppt-zhangzara-bold-poster
+++ b/.agents/skills/html-ppt-zhangzara-bold-poster
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-bold-poster

--- a/.agents/skills/html-ppt-zhangzara-broadside
+++ b/.agents/skills/html-ppt-zhangzara-broadside
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-broadside

--- a/.agents/skills/html-ppt-zhangzara-capsule
+++ b/.agents/skills/html-ppt-zhangzara-capsule
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-capsule

--- a/.agents/skills/html-ppt-zhangzara-cartesian
+++ b/.agents/skills/html-ppt-zhangzara-cartesian
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cartesian

--- a/.agents/skills/html-ppt-zhangzara-cobalt-grid
+++ b/.agents/skills/html-ppt-zhangzara-cobalt-grid
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cobalt-grid

--- a/.agents/skills/html-ppt-zhangzara-coral
+++ b/.agents/skills/html-ppt-zhangzara-coral
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-coral

--- a/.agents/skills/html-ppt-zhangzara-creative-mode
+++ b/.agents/skills/html-ppt-zhangzara-creative-mode
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-creative-mode

--- a/.agents/skills/html-ppt-zhangzara-daisy-days
+++ b/.agents/skills/html-ppt-zhangzara-daisy-days
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-daisy-days

--- a/.agents/skills/html-ppt-zhangzara-editorial-tri-tone
+++ b/.agents/skills/html-ppt-zhangzara-editorial-tri-tone
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-editorial-tri-tone

--- a/.agents/skills/html-ppt-zhangzara-grove
+++ b/.agents/skills/html-ppt-zhangzara-grove
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-grove

--- a/.agents/skills/html-ppt-zhangzara-long-table
+++ b/.agents/skills/html-ppt-zhangzara-long-table
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-long-table

--- a/.agents/skills/html-ppt-zhangzara-mat
+++ b/.agents/skills/html-ppt-zhangzara-mat
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-mat

--- a/.agents/skills/html-ppt-zhangzara-monochrome
+++ b/.agents/skills/html-ppt-zhangzara-monochrome
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-monochrome

--- a/.agents/skills/html-ppt-zhangzara-neo-grid-bold
+++ b/.agents/skills/html-ppt-zhangzara-neo-grid-bold
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-neo-grid-bold

--- a/.agents/skills/html-ppt-zhangzara-peoples-platform
+++ b/.agents/skills/html-ppt-zhangzara-peoples-platform
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-peoples-platform

--- a/.agents/skills/html-ppt-zhangzara-pin-and-paper
+++ b/.agents/skills/html-ppt-zhangzara-pin-and-paper
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pin-and-paper

--- a/.agents/skills/html-ppt-zhangzara-pink-script
+++ b/.agents/skills/html-ppt-zhangzara-pink-script
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pink-script

--- a/.agents/skills/html-ppt-zhangzara-playful
+++ b/.agents/skills/html-ppt-zhangzara-playful
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-playful

--- a/.agents/skills/html-ppt-zhangzara-raw-grid
+++ b/.agents/skills/html-ppt-zhangzara-raw-grid
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-raw-grid

--- a/.agents/skills/html-ppt-zhangzara-retro-windows
+++ b/.agents/skills/html-ppt-zhangzara-retro-windows
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-windows

--- a/.agents/skills/html-ppt-zhangzara-retro-zine
+++ b/.agents/skills/html-ppt-zhangzara-retro-zine
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-zine

--- a/.agents/skills/html-ppt-zhangzara-sakura-chroma
+++ b/.agents/skills/html-ppt-zhangzara-sakura-chroma
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-sakura-chroma

--- a/.agents/skills/html-ppt-zhangzara-scatterbrain
+++ b/.agents/skills/html-ppt-zhangzara-scatterbrain
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-scatterbrain

--- a/.agents/skills/html-ppt-zhangzara-signal
+++ b/.agents/skills/html-ppt-zhangzara-signal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-signal

--- a/.agents/skills/html-ppt-zhangzara-soft-editorial
+++ b/.agents/skills/html-ppt-zhangzara-soft-editorial
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-soft-editorial

--- a/.agents/skills/html-ppt-zhangzara-stencil-tablet
+++ b/.agents/skills/html-ppt-zhangzara-stencil-tablet
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-stencil-tablet

--- a/.agents/skills/html-ppt-zhangzara-studio
+++ b/.agents/skills/html-ppt-zhangzara-studio
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-studio

--- a/.agents/skills/html-ppt-zhangzara-vellum
+++ b/.agents/skills/html-ppt-zhangzara-vellum
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-vellum

--- a/.agents/skills/ib-pitch-book
+++ b/.agents/skills/ib-pitch-book
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ib-pitch-book

--- a/.agents/skills/kami-deck
+++ b/.agents/skills/kami-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/kami-deck

--- a/.agents/skills/kami-landing
+++ b/.agents/skills/kami-landing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/kami-landing

--- a/.agents/skills/karpathy-guidelines
+++ b/.agents/skills/karpathy-guidelines
@@ -1,0 +1,1 @@
+../../repo-skills/karpathy-guidelines

--- a/.agents/skills/last30days
+++ b/.agents/skills/last30days
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/last30days

--- a/.agents/skills/live-artifact
+++ b/.agents/skills/live-artifact
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/live-artifact

--- a/.agents/skills/live-dashboard
+++ b/.agents/skills/live-dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/live-dashboard

--- a/.agents/skills/login-flow
+++ b/.agents/skills/login-flow
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/login-flow

--- a/.agents/skills/open-design-landing
+++ b/.agents/skills/open-design-landing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/open-design-landing

--- a/.agents/skills/open-design-landing-deck
+++ b/.agents/skills/open-design-landing-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/open-design-landing-deck

--- a/.agents/skills/orbit-general
+++ b/.agents/skills/orbit-general
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-general

--- a/.agents/skills/orbit-github
+++ b/.agents/skills/orbit-github
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-github

--- a/.agents/skills/orbit-gmail
+++ b/.agents/skills/orbit-gmail
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-gmail

--- a/.agents/skills/orbit-linear
+++ b/.agents/skills/orbit-linear
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-linear

--- a/.agents/skills/orbit-notion
+++ b/.agents/skills/orbit-notion
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-notion

--- a/.agents/skills/release-notes-one-pager
+++ b/.agents/skills/release-notes-one-pager
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/release-notes-one-pager

--- a/.agents/skills/social-media-dashboard
+++ b/.agents/skills/social-media-dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/social-media-dashboard

--- a/.agents/skills/social-media-matrix-tracker-template
+++ b/.agents/skills/social-media-matrix-tracker-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/social-media-matrix-tracker-template

--- a/.agents/skills/swiss-creative-mode-template
+++ b/.agents/skills/swiss-creative-mode-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/swiss-creative-mode-template

--- a/.agents/skills/swiss-user-research-video-template
+++ b/.agents/skills/swiss-user-research-video-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/swiss-user-research-video-template

--- a/.agents/skills/sync-gbrain
+++ b/.agents/skills/sync-gbrain
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/sync-gbrain

--- a/.agents/skills/trading-analysis-dashboard-template
+++ b/.agents/skills/trading-analysis-dashboard-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/trading-analysis-dashboard-template

--- a/.agents/skills/waitlist-page
+++ b/.agents/skills/waitlist-page
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/waitlist-page

--- a/.agents/skills/x-research
+++ b/.agents/skills/x-research
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/x-research

--- a/.claude/skills/8-bit-orbit-video-template
+++ b/.claude/skills/8-bit-orbit-video-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/8-bit-orbit-video-template

--- a/.claude/skills/after-hours-editorial-template
+++ b/.claude/skills/after-hours-editorial-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/after-hours-editorial-template

--- a/.claude/skills/clinical-case-report
+++ b/.claude/skills/clinical-case-report
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/clinical-case-report

--- a/.claude/skills/co-marketing
+++ b/.claude/skills/co-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/marketingskills/skills/co-marketing

--- a/.claude/skills/dcf-valuation
+++ b/.claude/skills/dcf-valuation
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/dcf-valuation

--- a/.claude/skills/digits-fintech-swiss-template
+++ b/.claude/skills/digits-fintech-swiss-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/digits-fintech-swiss-template

--- a/.claude/skills/editorial-burgundy-principles-template
+++ b/.claude/skills/editorial-burgundy-principles-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/editorial-burgundy-principles-template

--- a/.claude/skills/field-notes-editorial-template
+++ b/.claude/skills/field-notes-editorial-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/field-notes-editorial-template

--- a/.claude/skills/flowai-live-dashboard-template
+++ b/.claude/skills/flowai-live-dashboard-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/flowai-live-dashboard-template

--- a/.claude/skills/github-dashboard
+++ b/.claude/skills/github-dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/github-dashboard

--- a/.claude/skills/html-ppt-retro-quarterly-review
+++ b/.claude/skills/html-ppt-retro-quarterly-review
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-retro-quarterly-review

--- a/.claude/skills/html-ppt-zhangzara-8-bit-orbit
+++ b/.claude/skills/html-ppt-zhangzara-8-bit-orbit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-8-bit-orbit

--- a/.claude/skills/html-ppt-zhangzara-biennale-yellow
+++ b/.claude/skills/html-ppt-zhangzara-biennale-yellow
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-biennale-yellow

--- a/.claude/skills/html-ppt-zhangzara-block-frame
+++ b/.claude/skills/html-ppt-zhangzara-block-frame
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-block-frame

--- a/.claude/skills/html-ppt-zhangzara-blue-professional
+++ b/.claude/skills/html-ppt-zhangzara-blue-professional
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-blue-professional

--- a/.claude/skills/html-ppt-zhangzara-bold-poster
+++ b/.claude/skills/html-ppt-zhangzara-bold-poster
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-bold-poster

--- a/.claude/skills/html-ppt-zhangzara-broadside
+++ b/.claude/skills/html-ppt-zhangzara-broadside
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-broadside

--- a/.claude/skills/html-ppt-zhangzara-capsule
+++ b/.claude/skills/html-ppt-zhangzara-capsule
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-capsule

--- a/.claude/skills/html-ppt-zhangzara-cartesian
+++ b/.claude/skills/html-ppt-zhangzara-cartesian
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cartesian

--- a/.claude/skills/html-ppt-zhangzara-cobalt-grid
+++ b/.claude/skills/html-ppt-zhangzara-cobalt-grid
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cobalt-grid

--- a/.claude/skills/html-ppt-zhangzara-coral
+++ b/.claude/skills/html-ppt-zhangzara-coral
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-coral

--- a/.claude/skills/html-ppt-zhangzara-creative-mode
+++ b/.claude/skills/html-ppt-zhangzara-creative-mode
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-creative-mode

--- a/.claude/skills/html-ppt-zhangzara-daisy-days
+++ b/.claude/skills/html-ppt-zhangzara-daisy-days
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-daisy-days

--- a/.claude/skills/html-ppt-zhangzara-editorial-tri-tone
+++ b/.claude/skills/html-ppt-zhangzara-editorial-tri-tone
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-editorial-tri-tone

--- a/.claude/skills/html-ppt-zhangzara-grove
+++ b/.claude/skills/html-ppt-zhangzara-grove
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-grove

--- a/.claude/skills/html-ppt-zhangzara-long-table
+++ b/.claude/skills/html-ppt-zhangzara-long-table
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-long-table

--- a/.claude/skills/html-ppt-zhangzara-mat
+++ b/.claude/skills/html-ppt-zhangzara-mat
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-mat

--- a/.claude/skills/html-ppt-zhangzara-monochrome
+++ b/.claude/skills/html-ppt-zhangzara-monochrome
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-monochrome

--- a/.claude/skills/html-ppt-zhangzara-neo-grid-bold
+++ b/.claude/skills/html-ppt-zhangzara-neo-grid-bold
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-neo-grid-bold

--- a/.claude/skills/html-ppt-zhangzara-peoples-platform
+++ b/.claude/skills/html-ppt-zhangzara-peoples-platform
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-peoples-platform

--- a/.claude/skills/html-ppt-zhangzara-pin-and-paper
+++ b/.claude/skills/html-ppt-zhangzara-pin-and-paper
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pin-and-paper

--- a/.claude/skills/html-ppt-zhangzara-pink-script
+++ b/.claude/skills/html-ppt-zhangzara-pink-script
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pink-script

--- a/.claude/skills/html-ppt-zhangzara-playful
+++ b/.claude/skills/html-ppt-zhangzara-playful
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-playful

--- a/.claude/skills/html-ppt-zhangzara-raw-grid
+++ b/.claude/skills/html-ppt-zhangzara-raw-grid
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-raw-grid

--- a/.claude/skills/html-ppt-zhangzara-retro-windows
+++ b/.claude/skills/html-ppt-zhangzara-retro-windows
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-windows

--- a/.claude/skills/html-ppt-zhangzara-retro-zine
+++ b/.claude/skills/html-ppt-zhangzara-retro-zine
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-zine

--- a/.claude/skills/html-ppt-zhangzara-sakura-chroma
+++ b/.claude/skills/html-ppt-zhangzara-sakura-chroma
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-sakura-chroma

--- a/.claude/skills/html-ppt-zhangzara-scatterbrain
+++ b/.claude/skills/html-ppt-zhangzara-scatterbrain
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-scatterbrain

--- a/.claude/skills/html-ppt-zhangzara-signal
+++ b/.claude/skills/html-ppt-zhangzara-signal
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-signal

--- a/.claude/skills/html-ppt-zhangzara-soft-editorial
+++ b/.claude/skills/html-ppt-zhangzara-soft-editorial
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-soft-editorial

--- a/.claude/skills/html-ppt-zhangzara-stencil-tablet
+++ b/.claude/skills/html-ppt-zhangzara-stencil-tablet
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-stencil-tablet

--- a/.claude/skills/html-ppt-zhangzara-studio
+++ b/.claude/skills/html-ppt-zhangzara-studio
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-studio

--- a/.claude/skills/html-ppt-zhangzara-vellum
+++ b/.claude/skills/html-ppt-zhangzara-vellum
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-vellum

--- a/.claude/skills/ib-pitch-book
+++ b/.claude/skills/ib-pitch-book
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ib-pitch-book

--- a/.claude/skills/kami-deck
+++ b/.claude/skills/kami-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/kami-deck

--- a/.claude/skills/kami-landing
+++ b/.claude/skills/kami-landing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/kami-landing

--- a/.claude/skills/karpathy-guidelines
+++ b/.claude/skills/karpathy-guidelines
@@ -1,0 +1,1 @@
+../../repo-skills/karpathy-guidelines

--- a/.claude/skills/last30days
+++ b/.claude/skills/last30days
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/last30days

--- a/.claude/skills/live-artifact
+++ b/.claude/skills/live-artifact
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/live-artifact

--- a/.claude/skills/live-dashboard
+++ b/.claude/skills/live-dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/live-dashboard

--- a/.claude/skills/login-flow
+++ b/.claude/skills/login-flow
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/login-flow

--- a/.claude/skills/open-design-landing
+++ b/.claude/skills/open-design-landing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/open-design-landing

--- a/.claude/skills/open-design-landing-deck
+++ b/.claude/skills/open-design-landing-deck
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/open-design-landing-deck

--- a/.claude/skills/orbit-general
+++ b/.claude/skills/orbit-general
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-general

--- a/.claude/skills/orbit-github
+++ b/.claude/skills/orbit-github
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-github

--- a/.claude/skills/orbit-gmail
+++ b/.claude/skills/orbit-gmail
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-gmail

--- a/.claude/skills/orbit-linear
+++ b/.claude/skills/orbit-linear
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-linear

--- a/.claude/skills/orbit-notion
+++ b/.claude/skills/orbit-notion
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/orbit-notion

--- a/.claude/skills/release-notes-one-pager
+++ b/.claude/skills/release-notes-one-pager
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/release-notes-one-pager

--- a/.claude/skills/social-media-dashboard
+++ b/.claude/skills/social-media-dashboard
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/social-media-dashboard

--- a/.claude/skills/social-media-matrix-tracker-template
+++ b/.claude/skills/social-media-matrix-tracker-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/social-media-matrix-tracker-template

--- a/.claude/skills/swiss-creative-mode-template
+++ b/.claude/skills/swiss-creative-mode-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/swiss-creative-mode-template

--- a/.claude/skills/swiss-user-research-video-template
+++ b/.claude/skills/swiss-user-research-video-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/swiss-user-research-video-template

--- a/.claude/skills/sync-gbrain
+++ b/.claude/skills/sync-gbrain
@@ -1,0 +1,1 @@
+../../trusted-external-repos/gstack/sync-gbrain

--- a/.claude/skills/trading-analysis-dashboard-template
+++ b/.claude/skills/trading-analysis-dashboard-template
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/trading-analysis-dashboard-template

--- a/.claude/skills/waitlist-page
+++ b/.claude/skills/waitlist-page
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/waitlist-page

--- a/.claude/skills/x-research
+++ b/.claude/skills/x-research
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/x-research

--- a/repo-skills/karpathy-guidelines/SKILL.md
+++ b/repo-skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.


### PR DESCRIPTION
## Summary

- Add Andrej Karpathy's LLM coding guidelines as a new repo-local skill at `repo-skills/karpathy-guidelines/SKILL.md` (source: [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills/tree/main/skills/karpathy-guidelines))
- Rebuild `.claude/skills` and `.agents/skills` via `scripts/sync_skills.sh refresh` so they pick up the new skill plus skills the `open-design` and `gstack` submodules added upstream since the last committed sync
- All 134 new mirror entries are symlinks into tracked submodule paths — verified each target exists

## Test plan

- [x] `scripts/sync_skills.sh refresh` reports 246 mirrored skills, no name conflicts, no invalid names
- [x] `karpathy-guidelines` shows up in the harness skills list
- [x] Spot-checked symlink targets resolve to real `SKILL.md` files