### PR TITLE
personal-site: /palace — 3D memory palace + agent-readable SSR

### DIFF
--- a/memory/2026-05-10.md
+++ b/memory/2026-05-10.md
@@ -1,0 +1,23 @@
+# 2026-05-10
+
+## /palace shipped — 3D memory palace at bingranyou.com
+
+Built a Henry Heffernan-style 3D room as `/palace` on personal-site, end-to-end. PR: https://github.com/bingran-you/bingran-you/pull/183
+
+Stack: `three@^0.184` + `@react-three/fiber@^9.6` + `@react-three/drei@^10.7`. Pure primitive-mesh geometry — no GLTF model files, no HDR environment. Keeps the bundle lean and the scene under designer control.
+
+Architecture lessons worth keeping:
+
+- **Dual-rendering for SEO + agent reads.** Server component (`app/palace/page.tsx`) emits a fully populated visually-hidden text index (~80KB of static HTML: every project, paper, blog post, social post, education entry, contact link sourced from existing `lib/content.ts`, `lib/posts.ts`, `lib/social-posts.ts`). `<noscript>` flips the index to visible and hides the canvas. Crawlers and LLM agents read everything; humans see the room. Henry Heffernan's site has zero SSR content — this avoids that mistake.
+- **Client mount via `dynamic(import('./PalaceClient'), { ssr: false })`** from a thin `PalaceMount.tsx` client wrapper, called by the server component. The Canvas never tries to import three on the server.
+- **Aspect-aware FOV.** Three.js cameras specify vertical FOV; portrait viewports get a horizontal sliver. `fovForAspect(baseFov, aspect)` in `CameraRig.tsx` boosts FOV when aspect < 16:9 so phones still see the desk.
+- **State machine: `intro` → `idle` → `monitor`.** Auto-skip intro at 5s. Clicking the monitor mesh triggers `setMode("monitor")`; ESC closes. Camera lerps between three named presets in `useFrame`.
+- **BingranOS overlay** is a regular DOM panel (not `<Html transform>` in 3D). Reliable on mobile, real focusable links, scroll works, accessible. Camera flies square-on to the screen at the same time so the overlay reads as "on" the monitor.
+
+Content discipline: zero new prose. About facts, focus areas, project list, paper list, education, social posts, contact — all pulled from existing site data. The 3D scene is a *view* of the existing site, not a parallel content store.
+
+Personal-site uses **Next.js 16** (not the one most training data knows). `dynamic({ ssr: false })` requires being called from a client component; root `<html>+<body>` plus JSON-LD live in `app/layout.tsx` and apply to `/palace` automatically.
+
+Three.js deprecation warnings in console (`THREE.Clock`, `PCFSoftShadowMap`) come from `@react-three/fiber` internals — not actionable from app code, will go away on the next R3F release.
+
+`.claude/launch.json` (Claude Code preview config) added to `personal-site/.gitignore` — it's a local dev artifact.

--- a/personal-site/.gitignore
+++ b/personal-site/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .vercel
+
+# Local Claude Code preview config
+/.claude/

--- a/personal-site/app/(personal)/page.tsx
+++ b/personal-site/app/(personal)/page.tsx
@@ -54,6 +54,18 @@ export default function Home() {
               </span>
             </li>
           </ul>
+
+          <Link
+            href="/palace"
+            className="mt-7 inline-flex items-center gap-3 rounded-full border border-[var(--accent)]/40 bg-[var(--accent)]/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.28em] text-[var(--accent-strong)] transition hover:bg-[var(--accent)]/20 hover:border-[var(--accent)]"
+          >
+            <span aria-hidden className="relative inline-flex h-2 w-2">
+              <span className="absolute inset-0 rounded-full bg-[var(--accent)]" />
+              <span className="absolute inset-0 rounded-full bg-[var(--accent)] animate-ping opacity-70" />
+            </span>
+            Enter the Memory Palace
+            <span aria-hidden>→</span>
+          </Link>
         </div>
 
         <div className="relative h-32 w-32 shrink-0 overflow-hidden rounded-full ring-1 ring-[var(--border)] sm:h-52 sm:w-52">

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -38,6 +38,7 @@ I work on two tracks: reliable AI agent systems, and trapped-ion atomic, molecul
 - [Projects](${SITE}/projects)
 - [Papers](${SITE}/papers)
 - [Blog](${SITE}/blog)
+- [Memory Palace (3D room with same content)](${SITE}/palace)
 - [Zero-Human Company — definition and stack](${SITE}/zero-human-company)
 - [One-Person Company — operating-model definition and modes](${SITE}/one-person-company)
 

--- a/personal-site/app/palace/PalaceClient.tsx
+++ b/personal-site/app/palace/PalaceClient.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { Canvas } from "@react-three/fiber";
+import type { PalaceData } from "./palace-data";
+import styles from "./styles.module.css";
+import { Lighting } from "./scene/Lighting";
+import { Room } from "./scene/Room";
+import { Desk } from "./scene/Desk";
+import { Computer } from "./scene/Computer";
+import { Decor } from "./scene/Decor";
+import { CameraRig } from "./scene/CameraRig";
+import { IntroOverlay } from "./ui/IntroOverlay";
+import { HUD } from "./ui/HUD";
+import { BingranOS } from "./ui/BingranOS";
+
+export type PalaceMode = "intro" | "idle" | "monitor";
+
+export default function PalaceClient({ data }: { data: PalaceData }) {
+  const [mode, setMode] = useState<PalaceMode>("intro");
+  const mouseRef = useRef<[number, number]>([0, 0]);
+
+  const enterRoom = useCallback(() => setMode("idle"), []);
+  const enterMonitor = useCallback(() => setMode("monitor"), []);
+  const exitMonitor = useCallback(() => setMode("idle"), []);
+
+  // Auto-advance intro to idle after 5s if the user doesn't click "Enter"
+  useEffect(() => {
+    if (mode !== "intro") return;
+    const t = setTimeout(() => setMode("idle"), 5000);
+    return () => clearTimeout(t);
+  }, [mode]);
+
+  // ESC exits monitor mode
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && mode === "monitor") exitMonitor();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mode, exitMonitor]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const y = ((e.clientY - rect.top) / rect.height) * 2 - 1;
+    mouseRef.current = [x, y];
+  }, []);
+
+  return (
+    <>
+      <div
+        className={`palace-canvas ${styles.canvasWrap}`}
+        onPointerMove={onPointerMove}
+      >
+        <Canvas
+          shadows
+          dpr={[1, 1.8]}
+          gl={{ antialias: true, powerPreference: "high-performance" }}
+        >
+          <Suspense fallback={null}>
+            <color attach="background" args={["#15110b"]} />
+            <fog attach="fog" args={["#15110b", 6, 18]} />
+            <Lighting />
+            <Room />
+            <Desk />
+            <Computer
+              onScreenClick={enterMonitor}
+              screenActive={mode === "monitor"}
+            />
+            <Decor />
+            <CameraRig mode={mode} mouseRef={mouseRef} />
+          </Suspense>
+        </Canvas>
+      </div>
+
+      <IntroOverlay visible={mode === "intro"} onEnter={enterRoom} />
+      <HUD mode={mode} onExitMonitor={exitMonitor} />
+      <BingranOS data={data} visible={mode === "monitor"} onClose={exitMonitor} />
+    </>
+  );
+}

--- a/personal-site/app/palace/PalaceClient.tsx
+++ b/personal-site/app/palace/PalaceClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import type { PalaceData } from "./palace-data";
 import styles from "./styles.module.css";
@@ -16,13 +16,40 @@ import { BingranOS } from "./ui/BingranOS";
 
 export type PalaceMode = "intro" | "idle" | "monitor";
 
+const HASH_TO_TAB: Record<string, string> = {
+  "#about": "about",
+  "#projects": "projects",
+  "#papers": "papers",
+  "#blog": "blog",
+  "#posts": "posts",
+  "#skills": "skills",
+  "#tetris": "tetris",
+  "#snake": "snake",
+  "#contact": "contact",
+};
+
 export default function PalaceClient({ data }: { data: PalaceData }) {
-  const [mode, setMode] = useState<PalaceMode>("intro");
+  // Honour a hash like /palace#tetris by jumping straight to the OS with that tab.
+  const initialTab = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    return HASH_TO_TAB[window.location.hash] ?? null;
+  }, []);
+  const [mode, setMode] = useState<PalaceMode>(initialTab ? "monitor" : "intro");
+  const [osTab, setOsTab] = useState<string | null>(initialTab);
   const mouseRef = useRef<[number, number]>([0, 0]);
 
   const enterRoom = useCallback(() => setMode("idle"), []);
-  const enterMonitor = useCallback(() => setMode("monitor"), []);
-  const exitMonitor = useCallback(() => setMode("idle"), []);
+  const enterMonitor = useCallback(() => {
+    setOsTab(null);
+    setMode("monitor");
+  }, []);
+  const exitMonitor = useCallback(() => {
+    setMode("idle");
+    setOsTab(null);
+    if (typeof window !== "undefined" && window.location.hash) {
+      history.replaceState(null, "", window.location.pathname);
+    }
+  }, []);
 
   // Auto-advance intro to idle after 5s if the user doesn't click "Enter"
   useEffect(() => {
@@ -30,6 +57,19 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
     const t = setTimeout(() => setMode("idle"), 5000);
     return () => clearTimeout(t);
   }, [mode]);
+
+  // React to hash changes (allows linking between tabs without reload)
+  useEffect(() => {
+    const sync = () => {
+      const tab = HASH_TO_TAB[window.location.hash];
+      if (tab) {
+        setOsTab(tab);
+        setMode("monitor");
+      }
+    };
+    window.addEventListener("hashchange", sync);
+    return () => window.removeEventListener("hashchange", sync);
+  }, []);
 
   // ESC exits monitor mode
   useEffect(() => {
@@ -76,7 +116,12 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
 
       <IntroOverlay visible={mode === "intro"} onEnter={enterRoom} />
       <HUD mode={mode} onExitMonitor={exitMonitor} />
-      <BingranOS data={data} visible={mode === "monitor"} onClose={exitMonitor} />
+      <BingranOS
+        data={data}
+        visible={mode === "monitor"}
+        initialTab={osTab}
+        onClose={exitMonitor}
+      />
     </>
   );
 }

--- a/personal-site/app/palace/PalaceClient.tsx
+++ b/personal-site/app/palace/PalaceClient.tsx
@@ -36,6 +36,10 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
   }, []);
   const [mode, setMode] = useState<PalaceMode>(initialTab ? "monitor" : "intro");
   const [osTab, setOsTab] = useState<string | null>(initialTab);
+  // OS overlay only appears AFTER the dolly-in completes — keeps the
+  // entrance feeling like Henry's where you actually arrive at the screen
+  // before any UI surfaces.
+  const [osReady, setOsReady] = useState(false);
   const mouseRef = useRef<[number, number]>([0, 0]);
 
   const enterRoom = useCallback(() => setMode("idle"), []);
@@ -56,6 +60,19 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
     if (mode !== "intro") return;
     const t = setTimeout(() => setMode("idle"), 5000);
     return () => clearTimeout(t);
+  }, [mode]);
+
+  // Hold the OS overlay back until the camera has nearly arrived at the
+  // monitor pose (camera dolly-in is 1.15s; we wait 0.95s so the OS fades
+  // up over the final 200ms of camera travel + its own 0.45s opacity
+  // transition). On exit, drop it immediately so the panel fades out
+  // while the camera is still close to the screen.
+  useEffect(() => {
+    if (mode === "monitor") {
+      const t = setTimeout(() => setOsReady(true), 950);
+      return () => clearTimeout(t);
+    }
+    setOsReady(false);
   }, [mode]);
 
   // React to hash changes (allows linking between tabs without reload)
@@ -118,7 +135,7 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
       <HUD mode={mode} onExitMonitor={exitMonitor} />
       <BingranOS
         data={data}
-        visible={mode === "monitor"}
+        visible={mode === "monitor" && osReady}
         initialTab={osTab}
         onClose={exitMonitor}
       />

--- a/personal-site/app/palace/PalaceMount.tsx
+++ b/personal-site/app/palace/PalaceMount.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { PalaceData } from "./palace-data";
+import styles from "./styles.module.css";
+
+const PalaceClient = dynamic(() => import("./PalaceClient"), {
+  ssr: false,
+  loading: () => <PalaceLoading />,
+});
+
+function PalaceLoading() {
+  return (
+    <div className={`palace-intro ${styles.intro}`} aria-hidden>
+      <p className={styles.introCaption}>Booting palace…</p>
+    </div>
+  );
+}
+
+export function PalaceMount({ data }: { data: PalaceData }) {
+  return <PalaceClient data={data} />;
+}

--- a/personal-site/app/palace/SsrLayer.tsx
+++ b/personal-site/app/palace/SsrLayer.tsx
@@ -1,0 +1,131 @@
+import Link from "next/link";
+import type { PalaceData } from "./palace-data";
+import styles from "./styles.module.css";
+
+export function SsrLayer({ data }: { data: PalaceData }) {
+  const { projects, papers, education, about, contact, blogPosts, socialPosts } = data;
+  const aiProjects = projects.filter((p) => p.track === "ai");
+  const ionProjects = projects.filter((p) => p.track === "ion");
+  const aiPapers = papers.filter((p) => p.track === "ai");
+  const ionPapers = papers.filter((p) => p.track === "ion");
+
+  return (
+    <div className={`palace-fallback ${styles.fallback}`} aria-label="Memory Palace — text index">
+      <h1>Bingran You — Memory Palace</h1>
+      <p>
+        This is the text index of the 3D memory palace at /palace. The same
+        content is also available at the regular site pages linked below. The 3D
+        scene is rendered with WebGL; this text layer exists for search
+        engines, AI agents, JavaScript-free browsers, and assistive tech.
+      </p>
+
+      <h2>About</h2>
+      {about.facts.map((fact) => (
+        <p key={fact}>{fact}</p>
+      ))}
+
+      <h2>Focus</h2>
+      {about.focus.map((area) => (
+        <section key={area.label}>
+          <h3>{area.label}</h3>
+          <ul>
+            {area.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+      ))}
+
+      <h2>Pages</h2>
+      <ul>
+        <li><Link href="/">Home</Link></li>
+        <li><Link href="/about">About</Link></li>
+        <li><Link href="/projects">Projects</Link></li>
+        <li><Link href="/papers">Papers</Link></li>
+        <li><Link href="/skills">Skills</Link></li>
+        <li><Link href="/blog">Blog</Link></li>
+        <li><Link href="/posts">Posts</Link></li>
+        <li><Link href="/zero-human-company">Zero-Human Company</Link></li>
+        <li><Link href="/one-person-company">One-Person Company</Link></li>
+      </ul>
+
+      <h2>Projects — Agentic Builder</h2>
+      <ul>
+        {aiProjects.map((p) => (
+          <li key={p.href}>
+            <a href={p.href}>{p.name}</a> — {p.description}
+          </li>
+        ))}
+      </ul>
+      <h2>Projects — Ion Trapper</h2>
+      <ul>
+        {ionProjects.map((p) => (
+          <li key={p.href}>
+            <a href={p.href}>{p.name}</a> — {p.description}
+          </li>
+        ))}
+      </ul>
+
+      <h2>Papers — Agentic Builder</h2>
+      <ul>
+        {aiPapers.map((p) => (
+          <li key={p.href}>
+            <a href={p.href}>{p.title}</a> ({p.venue})
+            {p.blurb ? ` — ${p.blurb}` : ""}
+          </li>
+        ))}
+      </ul>
+      <h2>Papers — Ion Trapper</h2>
+      <ul>
+        {ionPapers.map((p) => (
+          <li key={p.href}>
+            <a href={p.href}>{p.title}</a> ({p.venue})
+            {p.blurb ? ` — ${p.blurb}` : ""}
+          </li>
+        ))}
+      </ul>
+
+      <h2>Education</h2>
+      <ul>
+        {education.map((e) => (
+          <li key={`${e.institution}-${e.period}`}>
+            <strong>{e.institution}</strong> — {e.degree} ({e.period},{" "}
+            {e.location}). {e.summary}
+            {e.metrics && e.metrics.length ? ` · ${e.metrics.join(" · ")}` : ""}
+          </li>
+        ))}
+      </ul>
+
+      <h2>Blog</h2>
+      <ul>
+        {blogPosts.map((p) => (
+          <li key={p.slug}>
+            <Link href={`/blog/${p.slug}`}>{p.title}</Link> ({p.date})
+            {p.description ? ` — ${p.description}` : ""}
+          </li>
+        ))}
+      </ul>
+
+      <h2>Recent posts</h2>
+      <ul>
+        {socialPosts.map((p) => (
+          <li key={p.id}>
+            <a href={p.url}>
+              {p.title || p.description || `${p.platformLabel} post`}
+            </a>{" "}
+            ({p.platformLabel} · {p.date})
+          </li>
+        ))}
+      </ul>
+
+      <h2>Contact</h2>
+      <ul>
+        {contact.map((c) => (
+          <li key={c.href}>
+            {c.label}: <a href={c.href}>{c.display}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/personal-site/app/palace/page.tsx
+++ b/personal-site/app/palace/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { jsonLdScriptContent, profilePageJsonLd, SITE_URL } from "@/lib/jsonld";
+import { getPalaceData } from "./palace-data";
+import { SsrLayer } from "./SsrLayer";
+import { PalaceMount } from "./PalaceMount";
+import styles from "./styles.module.css";
+
+const PALACE_DESCRIPTION =
+  "A 3D memory palace for bingran.ai — Bingran You's interactive room with a desk, a CRT monitor, and the projects, papers and writing of an AI agent builder and trapped-ion physicist at UC Berkeley.";
+
+export const metadata: Metadata = {
+  title: "Memory Palace",
+  description: PALACE_DESCRIPTION,
+  alternates: { canonical: "/palace" },
+  openGraph: {
+    title: "Bingran You — Memory Palace",
+    description: PALACE_DESCRIPTION,
+    url: `${SITE_URL}/palace`,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Bingran You — Memory Palace",
+    description: PALACE_DESCRIPTION,
+  },
+};
+
+export default async function PalacePage() {
+  const data = await getPalaceData();
+  return (
+    <div className={styles.shell}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLdScriptContent(profilePageJsonLd("/")),
+        }}
+      />
+      {/* Noscript / JS-disabled fallback: reveal the text index, hide canvas. */}
+      <noscript>
+        <style>{`
+          .palace-fallback { position: static !important; width: auto !important; height: auto !important; padding: 2rem !important; margin: 0 auto !important; clip: auto !important; overflow: visible !important; white-space: normal !important; max-width: 56rem; color: #ece4d4; font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; }
+          .palace-canvas { display: none !important; }
+          .palace-intro { display: none !important; }
+          .palace-hud { display: none !important; }
+        `}</style>
+      </noscript>
+      <SsrLayer data={data} />
+      <PalaceMount data={data} />
+    </div>
+  );
+}

--- a/personal-site/app/palace/palace-data.ts
+++ b/personal-site/app/palace/palace-data.ts
@@ -1,0 +1,93 @@
+import { education, papers, projects } from "@/lib/content";
+import { getAllPostsMetadata } from "@/lib/posts";
+import { getAllSocialPosts, PLATFORM_LABEL } from "@/lib/social-posts";
+
+export const ABOUT_FACTS = [
+  "I am Bingran You (Chinese: 尤炳然), a PhD candidate in Applied Science & Technology at UC Berkeley, advised in the Haeffner Lab.",
+  "I build reliable AI systems — agent infrastructure, evaluation harnesses, and applied AI products that need to behave under noisy real-world conditions.",
+  "I run trapped-ion experiments in atomic, molecular and optical physics — integrated photonics for individual ion addressing, ion-photon interfaces, and 3D-printed micro ion traps for scalable hardware.",
+  "Both tracks share one craft: turning complex, noisy systems into something that behaves on purpose.",
+] as const;
+
+export const FOCUS_AREAS = [
+  {
+    label: "Agentic Builder",
+    items: [
+      "Agent skills and tool use, with an emphasis on evaluation that mirrors real workflows.",
+      "Productivity agents that triage notifications, dispatch background work, and stay out of the way.",
+      "Open-source benchmarks for measuring agent capability and safety in simulated workspaces.",
+    ],
+  },
+  {
+    label: "Ion Trapper",
+    items: [
+      "Adjoint-optimized integrated photonic circuits for individual trapped-ion addressing.",
+      "Temporally multiplexed ion-photon interfaces via fast ion-chain transport.",
+      "3D-printed micro ion trap technology for scalable atomic-physics platforms.",
+      "Trapped-ion Ramsey interferometry probing fundamental physics of single-ion vibrational modes.",
+    ],
+  },
+] as const;
+
+export const CONTACT_LINKS = [
+  { label: "Email", href: "mailto:me@bingranyou.com", display: "me@bingranyou.com" },
+  { label: "Lab", href: "https://ions.berkeley.edu/", display: "Haeffner Lab, UC Berkeley" },
+  { label: "GitHub", href: "https://github.com/bingran-you", display: "github.com/bingran-you" },
+  { label: "X / Twitter", href: "https://x.com/bingran_bry", display: "@bingran_bry" },
+  { label: "Google Scholar", href: "https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en", display: "Google Scholar" },
+  { label: "ORCID", href: "https://orcid.org/0000-0002-0316-2115", display: "0000-0002-0316-2115" },
+  { label: "Hugging Face", href: "https://huggingface.co/bingran-you", display: "huggingface.co/bingran-you" },
+  { label: "LinkedIn", href: "https://www.linkedin.com/in/bingran-you-775b4017b/", display: "LinkedIn" },
+  { label: "YouTube", href: "https://www.youtube.com/@BingranBRY", display: "@BingranBRY" },
+  { label: "Bilibili", href: "https://space.bilibili.com/85906410", display: "Bilibili" },
+  { label: "Xiaohongshu", href: "https://xhslink.com/m/gFj0Vwr2Ak", display: "Xiaohongshu" },
+  { label: "Discord", href: "https://discord.gg/jsAnjCep", display: "discord.gg/jsAnjCep" },
+] as const;
+
+export type BlogPostSummary = {
+  slug: string;
+  title: string;
+  description?: string;
+  date: string;
+};
+
+export type SocialPostSummary = {
+  id: string;
+  platform: string;
+  platformLabel: string;
+  url: string;
+  title?: string;
+  description?: string;
+  date: string;
+};
+
+export async function getPalaceData() {
+  const blogPosts = (await getAllPostsMetadata()).map((p) => ({
+    slug: p.slug,
+    title: p.title,
+    description: p.description,
+    date: p.date,
+  })) satisfies BlogPostSummary[];
+
+  const socialPosts = (await getAllSocialPosts()).slice(0, 24).map((p) => ({
+    id: p.id,
+    platform: p.platform,
+    platformLabel: PLATFORM_LABEL[p.platform],
+    url: p.url,
+    title: p.title,
+    description: p.description,
+    date: p.date,
+  })) satisfies SocialPostSummary[];
+
+  return {
+    projects,
+    papers,
+    education,
+    about: { facts: [...ABOUT_FACTS], focus: FOCUS_AREAS.map((f) => ({ label: f.label, items: [...f.items] })) },
+    contact: CONTACT_LINKS.map((c) => ({ ...c })),
+    blogPosts,
+    socialPosts,
+  };
+}
+
+export type PalaceData = Awaited<ReturnType<typeof getPalaceData>>;

--- a/personal-site/app/palace/scene/CameraRig.tsx
+++ b/personal-site/app/palace/scene/CameraRig.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { RefObject } from "react";
+import { useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import { PerspectiveCamera } from "@react-three/drei";
+import * as THREE from "three";
+import type { PalaceMode } from "../PalaceClient";
+
+type Vec3 = [number, number, number];
+
+const CAM: Record<
+  PalaceMode,
+  { pos: Vec3; look: Vec3; fov: number }
+> = {
+  intro: { pos: [3.2, 2.4, 4.8], look: [0, 1.05, -0.9], fov: 38 },
+  idle: { pos: [0, 1.65, 2.1], look: [0, 1.2, -1.0], fov: 34 },
+  monitor: { pos: [0, 1.52, 0.55], look: [0, 1.52, -0.85], fov: 22 },
+};
+
+/**
+ * Three.js cameras specify FOV vertically. On portrait viewports the
+ * horizontal coverage shrinks to nothing and the room reads as a smear.
+ * Boost FOV when aspect drops below 16:9 so phones still see the desk.
+ */
+function fovForAspect(baseFov: number, aspect: number) {
+  const target = 16 / 9;
+  if (aspect >= target) return baseFov;
+  // Convert base vertical FOV to horizontal FOV at the target aspect, then back
+  // out a new vertical FOV that preserves that horizontal coverage.
+  const halfH = Math.atan(Math.tan((baseFov * Math.PI) / 360) * target);
+  const newVertical = Math.atan(Math.tan(halfH) / aspect) * 2 * (180 / Math.PI);
+  return Math.min(80, newVertical);
+}
+
+export function CameraRig({
+  mode,
+  mouseRef,
+}: {
+  mode: PalaceMode;
+  mouseRef: RefObject<[number, number]>;
+}) {
+  const camRef = useRef<THREE.PerspectiveCamera>(null);
+  const targetPos = useRef(new THREE.Vector3(...CAM.intro.pos));
+  const lookAt = useRef(new THREE.Vector3(...CAM.intro.look));
+  const size = useThree((s) => s.size);
+
+  useFrame((_, delta) => {
+    const cam = camRef.current;
+    if (!cam) return;
+    const cfg = CAM[mode];
+
+    targetPos.current.set(...cfg.pos);
+    lookAt.current.set(...cfg.look);
+
+    if (mode === "idle") {
+      const [mx, my] = mouseRef.current;
+      targetPos.current.x += mx * 0.35;
+      targetPos.current.y += -my * 0.12;
+      lookAt.current.x += mx * 0.08;
+    } else if (mode === "intro") {
+      targetPos.current.x += Math.sin(performance.now() / 4000) * 0.18;
+    }
+
+    const lerpAmt = Math.min(
+      1,
+      delta * (mode === "intro" ? 1.4 : mode === "monitor" ? 3.0 : 2.4),
+    );
+    cam.position.lerp(targetPos.current, lerpAmt);
+
+    const aspect = size.width / Math.max(1, size.height);
+    const targetFov = fovForAspect(cfg.fov, aspect);
+    const fovDiff = targetFov - cam.fov;
+    if (Math.abs(fovDiff) > 0.01) {
+      cam.fov += fovDiff * lerpAmt;
+      cam.updateProjectionMatrix();
+    }
+
+    cam.lookAt(lookAt.current);
+  });
+
+  return (
+    <PerspectiveCamera
+      ref={camRef}
+      makeDefault
+      position={CAM.intro.pos}
+      fov={CAM.intro.fov}
+      near={0.05}
+      far={60}
+    />
+  );
+}

--- a/personal-site/app/palace/scene/CameraRig.tsx
+++ b/personal-site/app/palace/scene/CameraRig.tsx
@@ -2,7 +2,7 @@
 
 import type { RefObject } from "react";
 import { useRef } from "react";
-import { useFrame, useThree } from "@react-three/fiber";
+import { useFrame } from "@react-three/fiber";
 import { PerspectiveCamera } from "@react-three/drei";
 import * as THREE from "three";
 import type { PalaceMode } from "../PalaceClient";
@@ -43,9 +43,8 @@ export function CameraRig({
   const camRef = useRef<THREE.PerspectiveCamera>(null);
   const targetPos = useRef(new THREE.Vector3(...CAM.intro.pos));
   const lookAt = useRef(new THREE.Vector3(...CAM.intro.look));
-  const size = useThree((s) => s.size);
 
-  useFrame((_, delta) => {
+  useFrame((state, delta) => {
     const cam = camRef.current;
     if (!cam) return;
     const cfg = CAM[mode];
@@ -68,7 +67,7 @@ export function CameraRig({
     );
     cam.position.lerp(targetPos.current, lerpAmt);
 
-    const aspect = size.width / Math.max(1, size.height);
+    const aspect = state.size.width / Math.max(1, state.size.height);
     const targetFov = fovForAspect(cfg.fov, aspect);
     const fovDiff = targetFov - cam.fov;
     if (Math.abs(fovDiff) > 0.01) {

--- a/personal-site/app/palace/scene/CameraRig.tsx
+++ b/personal-site/app/palace/scene/CameraRig.tsx
@@ -11,26 +11,40 @@ type Vec3 = [number, number, number];
 
 const CAM: Record<
   PalaceMode,
-  { pos: Vec3; look: Vec3; fov: number }
+  { pos: Vec3; look: Vec3; fov: number; duration: number }
 > = {
-  intro: { pos: [3.2, 2.4, 4.8], look: [0, 1.05, -0.9], fov: 38 },
-  idle: { pos: [0, 1.65, 2.1], look: [0, 1.2, -1.0], fov: 34 },
-  monitor: { pos: [0, 1.52, 0.55], look: [0, 1.52, -0.85], fov: 22 },
+  intro: {
+    pos: [3.0, 2.4, 4.6],
+    look: [0, 1.3, -0.85],
+    fov: 42,
+    duration: 2.1,
+  },
+  idle: {
+    pos: [0.4, 1.95, 2.9],
+    look: [0, 1.55, -0.85],
+    fov: 36,
+    duration: 1.45,
+  },
+  monitor: {
+    pos: [0, 1.86, 0.8],
+    look: [0, 1.86, -0.85],
+    fov: 22,
+    duration: 1.2,
+  },
 };
 
-/**
- * Three.js cameras specify FOV vertically. On portrait viewports the
- * horizontal coverage shrinks to nothing and the room reads as a smear.
- * Boost FOV when aspect drops below 16:9 so phones still see the desk.
- */
 function fovForAspect(baseFov: number, aspect: number) {
   const target = 16 / 9;
   if (aspect >= target) return baseFov;
-  // Convert base vertical FOV to horizontal FOV at the target aspect, then back
-  // out a new vertical FOV that preserves that horizontal coverage.
   const halfH = Math.atan(Math.tan((baseFov * Math.PI) / 360) * target);
   const newVertical = Math.atan(Math.tan(halfH) / aspect) * 2 * (180 / Math.PI);
   return Math.min(80, newVertical);
+}
+
+// Cubic ease-in-out — the canonical "buttery" curve. Henry Heffernan's site
+// uses a similar shape: slow start, accelerate, slow finish.
+function cubicInOut(t: number) {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 }
 
 export function CameraRig({
@@ -41,41 +55,84 @@ export function CameraRig({
   mouseRef: RefObject<[number, number]>;
 }) {
   const camRef = useRef<THREE.PerspectiveCamera>(null);
-  const targetPos = useRef(new THREE.Vector3(...CAM.intro.pos));
-  const lookAt = useRef(new THREE.Vector3(...CAM.intro.look));
+  // Current "logical" lookAt point so we can interpolate orientation alongside
+  // the camera position.
+  const currentLook = useRef(new THREE.Vector3(...CAM.intro.look));
+  // Snapshots captured at the moment a mode change is detected.
+  const fromPos = useRef(new THREE.Vector3(...CAM.intro.pos));
+  const fromLook = useRef(new THREE.Vector3(...CAM.intro.look));
+  const fromFov = useRef(CAM.intro.fov);
+  const transStart = useRef(0);
+  const prevMode = useRef<PalaceMode | null>(null);
+  const initialized = useRef(false);
 
   useFrame((state, delta) => {
     const cam = camRef.current;
     if (!cam) return;
+    const tNow = state.clock.elapsedTime;
     const cfg = CAM[mode];
-
-    targetPos.current.set(...cfg.pos);
-    lookAt.current.set(...cfg.look);
-
-    if (mode === "idle") {
-      const [mx, my] = mouseRef.current;
-      targetPos.current.x += mx * 0.35;
-      targetPos.current.y += -my * 0.12;
-      lookAt.current.x += mx * 0.08;
-    } else if (mode === "intro") {
-      targetPos.current.x += Math.sin(performance.now() / 4000) * 0.18;
-    }
-
-    const lerpAmt = Math.min(
-      1,
-      delta * (mode === "intro" ? 1.4 : mode === "monitor" ? 3.0 : 2.4),
-    );
-    cam.position.lerp(targetPos.current, lerpAmt);
-
     const aspect = state.size.width / Math.max(1, state.size.height);
-    const targetFov = fovForAspect(cfg.fov, aspect);
-    const fovDiff = targetFov - cam.fov;
-    if (Math.abs(fovDiff) > 0.01) {
-      cam.fov += fovDiff * lerpAmt;
+    const targetFovAdj = fovForAspect(cfg.fov, aspect);
+
+    // First frame: snap to the configured pose and call it baseline.
+    if (!initialized.current) {
+      cam.position.set(...cfg.pos);
+      currentLook.current.set(...cfg.look);
+      cam.fov = targetFovAdj;
       cam.updateProjectionMatrix();
+      cam.lookAt(currentLook.current);
+      fromPos.current.copy(cam.position);
+      fromLook.current.copy(currentLook.current);
+      fromFov.current = cam.fov;
+      transStart.current = tNow;
+      prevMode.current = mode;
+      initialized.current = true;
+      return;
     }
 
-    cam.lookAt(lookAt.current);
+    // Mode changed → start a brand-new transition from wherever the camera is.
+    if (prevMode.current !== mode) {
+      fromPos.current.copy(cam.position);
+      fromLook.current.copy(currentLook.current);
+      fromFov.current = cam.fov;
+      transStart.current = tNow;
+      prevMode.current = mode;
+    }
+
+    const elapsed = tNow - transStart.current;
+    const linearT = Math.min(1, elapsed / cfg.duration);
+
+    const baseTargetPos = new THREE.Vector3(...cfg.pos);
+    const baseTargetLook = new THREE.Vector3(...cfg.look);
+
+    if (linearT < 1) {
+      // Mid-transition: pure time-based ease, no parallax interference.
+      const eased = cubicInOut(linearT);
+      cam.position.lerpVectors(fromPos.current, baseTargetPos, eased);
+      currentLook.current.lerpVectors(fromLook.current, baseTargetLook, eased);
+      cam.fov = THREE.MathUtils.lerp(fromFov.current, targetFovAdj, eased);
+      cam.updateProjectionMatrix();
+    } else {
+      // Settled. Layer mouse parallax (idle only) or gentle intro drift, then
+      // chase smoothly so parallax never snaps.
+      if (mode === "idle") {
+        const [mx, my] = mouseRef.current;
+        baseTargetPos.x += mx * 0.35;
+        baseTargetPos.y += -my * 0.12;
+        baseTargetLook.x += mx * 0.08;
+      } else if (mode === "intro") {
+        baseTargetPos.x += Math.sin(tNow / 4) * 0.18;
+      }
+      const chase = Math.min(1, delta * 3.5);
+      cam.position.lerp(baseTargetPos, chase);
+      currentLook.current.lerp(baseTargetLook, chase);
+      if (Math.abs(targetFovAdj - cam.fov) > 0.01) {
+        cam.fov += (targetFovAdj - cam.fov) * chase;
+        cam.updateProjectionMatrix();
+      }
+    }
+
+    cam.lookAt(currentLook.current);
   });
 
   return (

--- a/personal-site/app/palace/scene/Computer.tsx
+++ b/personal-site/app/palace/scene/Computer.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+export function Computer({
+  onScreenClick,
+  screenActive,
+}: {
+  onScreenClick: () => void;
+  screenActive: boolean;
+}) {
+  const [hover, setHover] = useState(false);
+  const screenMatRef = useRef<THREE.MeshStandardMaterial>(null);
+
+  useFrame((state) => {
+    if (!screenMatRef.current) return;
+    const t = state.clock.elapsedTime;
+    const base = screenActive ? 0.95 : hover ? 0.78 : 0.55;
+    const flicker =
+      Math.sin(t * 5.3) * 0.02 + Math.sin(t * 11.2) * 0.012;
+    screenMatRef.current.emissiveIntensity = base + flicker;
+  });
+
+  // Anchor everything to the desktop top at y=0.99, z=-0.85 (just inside back of desk)
+  return (
+    <group position={[0, 0.99, -0.85]}>
+      {/* Monitor stand base — disc */}
+      <mesh position={[0, 0.012, 0]} castShadow>
+        <cylinderGeometry args={[0.18, 0.22, 0.025, 24]} />
+        <meshStandardMaterial color="#15110b" roughness={0.4} metalness={0.6} />
+      </mesh>
+      {/* Stand pillar */}
+      <mesh position={[0, 0.18, 0.04]} castShadow>
+        <boxGeometry args={[0.08, 0.32, 0.05]} />
+        <meshStandardMaterial color="#15110b" roughness={0.4} metalness={0.6} />
+      </mesh>
+      {/* Monitor bezel */}
+      <mesh position={[0, 0.52, 0.05]} castShadow>
+        <boxGeometry args={[1.45, 0.92, 0.07]} />
+        <meshStandardMaterial color="#0d0a06" roughness={0.45} metalness={0.4} />
+      </mesh>
+      {/* Screen (clickable) */}
+      <mesh
+        position={[0, 0.52, 0.088]}
+        onClick={(e) => {
+          e.stopPropagation();
+          onScreenClick();
+        }}
+        onPointerOver={(e) => {
+          e.stopPropagation();
+          setHover(true);
+          if (typeof document !== "undefined")
+            document.body.style.cursor = "pointer";
+        }}
+        onPointerOut={(e) => {
+          e.stopPropagation();
+          setHover(false);
+          if (typeof document !== "undefined")
+            document.body.style.cursor = "auto";
+        }}
+      >
+        <planeGeometry args={[1.36, 0.83]} />
+        <meshStandardMaterial
+          ref={screenMatRef}
+          color="#0a1220"
+          emissive={hover ? "#9ec5ed" : "#3a6080"}
+          emissiveIntensity={0.6}
+          roughness={0.35}
+          metalness={0.0}
+        />
+      </mesh>
+      {/* Faint screen text "bingranyou.com" rendered as emissive plane */}
+      <mesh position={[0, 0.45, 0.0885]}>
+        <planeGeometry args={[0.55, 0.05]} />
+        <meshBasicMaterial
+          color={hover || screenActive ? "#f0b687" : "#a8431c"}
+          transparent
+          opacity={hover || screenActive ? 0.85 : 0.55}
+        />
+      </mesh>
+      <mesh position={[0, 0.62, 0.0885]}>
+        <planeGeometry args={[0.85, 0.12]} />
+        <meshBasicMaterial color="#fbeacc" transparent opacity={0.18} />
+      </mesh>
+      {/* Power LED */}
+      <mesh position={[0.65, 0.07, 0.09]}>
+        <sphereGeometry args={[0.008, 8, 8]} />
+        <meshStandardMaterial
+          emissive="#e89968"
+          emissiveIntensity={1.2}
+          color="#3a1a08"
+        />
+      </mesh>
+
+      {/* Keyboard (forward toward the user) */}
+      <group position={[0, 0.0, 0.62]}>
+        <mesh castShadow receiveShadow>
+          <boxGeometry args={[0.95, 0.025, 0.34]} />
+          <meshStandardMaterial color="#1f1a14" roughness={0.65} />
+        </mesh>
+        <mesh position={[0, 0.018, 0]}>
+          <boxGeometry args={[0.9, 0.005, 0.3]} />
+          <meshStandardMaterial color="#3a3026" roughness={0.7} />
+        </mesh>
+        {/* Subtle key-row hint lines via stretched boxes */}
+        {[-0.1, -0.04, 0.02, 0.08].map((z, i) => (
+          <mesh key={i} position={[0, 0.022, z]}>
+            <boxGeometry args={[0.86, 0.001, 0.03]} />
+            <meshBasicMaterial color="#0a0805" transparent opacity={0.4} />
+          </mesh>
+        ))}
+      </group>
+      {/* Mouse */}
+      <mesh position={[0.62, 0.013, 0.62]} castShadow>
+        <boxGeometry args={[0.1, 0.025, 0.16]} />
+        <meshStandardMaterial color="#1f1a14" roughness={0.65} />
+      </mesh>
+      {/* Mouse cable hint */}
+      <mesh position={[0.62, 0.018, 0.44]}>
+        <boxGeometry args={[0.008, 0.008, 0.18]} />
+        <meshStandardMaterial color="#0a0805" />
+      </mesh>
+    </group>
+  );
+}

--- a/personal-site/app/palace/scene/Computer.tsx
+++ b/personal-site/app/palace/scene/Computer.tsx
@@ -4,6 +4,10 @@ import { useRef, useState } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
+// Classic 1984/SE-era Macintosh: beige boxy body, small CRT recessed into a
+// black bezel, "Macintosh" plate underneath, single floppy slot on the lower
+// right, small Apple-logo dot up top, and a green power LED. Sits on a flat
+// base on the desk.
 export function Computer({
   onScreenClick,
   screenActive,
@@ -13,37 +17,79 @@ export function Computer({
 }) {
   const [hover, setHover] = useState(false);
   const screenMatRef = useRef<THREE.MeshStandardMaterial>(null);
+  const cursorMatRef = useRef<THREE.MeshBasicMaterial>(null);
 
   useFrame((state) => {
-    if (!screenMatRef.current) return;
     const t = state.clock.elapsedTime;
-    const base = screenActive ? 0.95 : hover ? 0.78 : 0.55;
-    const flicker =
-      Math.sin(t * 5.3) * 0.02 + Math.sin(t * 11.2) * 0.012;
-    screenMatRef.current.emissiveIntensity = base + flicker;
+    if (screenMatRef.current) {
+      const base = screenActive ? 0.95 : hover ? 0.78 : 0.55;
+      const flicker = Math.sin(t * 5.3) * 0.018 + Math.sin(t * 11.2) * 0.012;
+      screenMatRef.current.emissiveIntensity = base + flicker;
+    }
+    if (cursorMatRef.current) {
+      // Classic blink: 1 Hz with hard step
+      cursorMatRef.current.opacity = Math.floor(t * 2) % 2 === 0 ? 0.9 : 0.0;
+    }
   });
 
-  // Anchor everything to the desktop top at y=0.99, z=-0.85 (just inside back of desk)
+  const setCursor = (on: boolean) => {
+    if (typeof document !== "undefined") {
+      document.body.style.cursor = on ? "pointer" : "auto";
+    }
+  };
+
+  // Anchor group on the desktop, lined up with the back of the desk
   return (
     <group position={[0, 0.99, -0.85]}>
-      {/* Monitor stand base — disc */}
-      <mesh position={[0, 0.012, 0]} castShadow>
-        <cylinderGeometry args={[0.18, 0.22, 0.025, 24]} />
-        <meshStandardMaterial color="#15110b" roughness={0.4} metalness={0.6} />
+      {/* Pedestal base */}
+      <mesh position={[0, 0.008, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.9, 0.016, 0.98]} />
+        <meshStandardMaterial color="#9c8a68" roughness={0.7} />
       </mesh>
-      {/* Stand pillar */}
-      <mesh position={[0, 0.18, 0.04]} castShadow>
-        <boxGeometry args={[0.08, 0.32, 0.05]} />
-        <meshStandardMaterial color="#15110b" roughness={0.4} metalness={0.6} />
+
+      {/* Main body (beige plastic) */}
+      <mesh position={[0, 0.64, 0]} castShadow receiveShadow>
+        <boxGeometry args={[0.86, 1.22, 0.92]} />
+        <meshStandardMaterial color="#d4c4a0" roughness={0.78} />
       </mesh>
-      {/* Monitor bezel */}
-      <mesh position={[0, 0.52, 0.05]} castShadow>
-        <boxGeometry args={[1.45, 0.92, 0.07]} />
-        <meshStandardMaterial color="#0d0a06" roughness={0.45} metalness={0.4} />
+
+      {/* Body side highlights to fake a slight chamfer */}
+      <mesh position={[0, 1.245, 0]} castShadow>
+        <boxGeometry args={[0.78, 0.025, 0.84]} />
+        <meshStandardMaterial color="#c0ae87" roughness={0.78} />
       </mesh>
-      {/* Screen (clickable) */}
+      {/* Subtle back-tilt strip near the top so the silhouette reads as "boxy
+          with a small slope," not a flat slab */}
+      <mesh position={[0, 1.18, -0.43]} rotation={[0.18, 0, 0]} castShadow>
+        <boxGeometry args={[0.82, 0.16, 0.04]} />
+        <meshStandardMaterial color="#c8b893" roughness={0.78} />
+      </mesh>
+
+      {/* Apple-logo placeholder (a small terracotta dot on the body top-front) */}
+      <mesh position={[-0.32, 1.155, 0.461]}>
+        <circleGeometry args={[0.024, 16]} />
+        <meshStandardMaterial
+          color="#a8431c"
+          emissive="#a8431c"
+          emissiveIntensity={0.25}
+          roughness={0.6}
+        />
+      </mesh>
+
+      {/* Recessed black screen bezel */}
+      <mesh position={[0, 0.86, 0.461]}>
+        <planeGeometry args={[0.66, 0.52]} />
+        <meshStandardMaterial color="#15110b" roughness={0.5} />
+      </mesh>
+      {/* Inner black border (illusion of CRT bezel) */}
+      <mesh position={[0, 0.86, 0.4615]}>
+        <planeGeometry args={[0.58, 0.44]} />
+        <meshStandardMaterial color="#0a0805" roughness={0.45} />
+      </mesh>
+
+      {/* Screen — clickable mesh */}
       <mesh
-        position={[0, 0.52, 0.088]}
+        position={[0, 0.86, 0.462]}
         onClick={(e) => {
           e.stopPropagation();
           onScreenClick();
@@ -51,76 +97,111 @@ export function Computer({
         onPointerOver={(e) => {
           e.stopPropagation();
           setHover(true);
-          if (typeof document !== "undefined")
-            document.body.style.cursor = "pointer";
+          setCursor(true);
         }}
         onPointerOut={(e) => {
           e.stopPropagation();
           setHover(false);
-          if (typeof document !== "undefined")
-            document.body.style.cursor = "auto";
+          setCursor(false);
         }}
       >
-        <planeGeometry args={[1.36, 0.83]} />
+        <planeGeometry args={[0.52, 0.4]} />
         <meshStandardMaterial
           ref={screenMatRef}
           color="#0a1220"
-          emissive={hover ? "#9ec5ed" : "#3a6080"}
+          emissive={hover ? "#a4c8ed" : "#3a6080"}
           emissiveIntensity={0.6}
           roughness={0.35}
           metalness={0.0}
         />
       </mesh>
-      {/* Faint screen text "bingranyou.com" rendered as emissive plane */}
-      <mesh position={[0, 0.45, 0.0885]}>
-        <planeGeometry args={[0.55, 0.05]} />
-        <meshBasicMaterial
-          color={hover || screenActive ? "#f0b687" : "#a8431c"}
-          transparent
-          opacity={hover || screenActive ? 0.85 : 0.55}
-        />
+
+      {/* Faux Mac menu bar at the top of the screen */}
+      <mesh position={[0, 1.038, 0.4625]}>
+        <planeGeometry args={[0.51, 0.022]} />
+        <meshBasicMaterial color="#e8d6b0" />
       </mesh>
-      <mesh position={[0, 0.62, 0.0885]}>
-        <planeGeometry args={[0.85, 0.12]} />
-        <meshBasicMaterial color="#fbeacc" transparent opacity={0.18} />
+      {/* Apple emoji slot in the menu bar (left) */}
+      <mesh position={[-0.232, 1.038, 0.463]}>
+        <circleGeometry args={[0.006, 12]} />
+        <meshBasicMaterial color="#1f1a14" />
       </mesh>
-      {/* Power LED */}
-      <mesh position={[0.65, 0.07, 0.09]}>
-        <sphereGeometry args={[0.008, 8, 8]} />
+
+      {/* "Welcome to Bingranyou" text stand-in — single bar */}
+      <mesh position={[0, 0.91, 0.4625]}>
+        <planeGeometry args={[0.32, 0.018]} />
+        <meshBasicMaterial color="#e8d6b0" transparent opacity={0.85} />
+      </mesh>
+      {/* Blinking cursor */}
+      <mesh position={[0.135, 0.91, 0.463]}>
+        <planeGeometry args={[0.008, 0.018]} />
+        <meshBasicMaterial ref={cursorMatRef} color="#e8d6b0" transparent opacity={0.9} />
+      </mesh>
+      {/* "Click to enter" hint */}
+      <mesh position={[0, 0.7, 0.4625]}>
+        <planeGeometry args={[0.22, 0.018]} />
+        <meshBasicMaterial color={hover ? "#f0b687" : "#a8431c"} transparent opacity={hover || screenActive ? 0.95 : 0.7} />
+      </mesh>
+
+      {/* "Macintosh" name plate under the screen */}
+      <mesh position={[0, 0.55, 0.4612]}>
+        <planeGeometry args={[0.34, 0.03]} />
         <meshStandardMaterial
-          emissive="#e89968"
-          emissiveIntensity={1.2}
-          color="#3a1a08"
+          color="#1f1a14"
+          emissive="#1f1a14"
+          emissiveIntensity={0.05}
+          roughness={0.55}
         />
       </mesh>
 
-      {/* Keyboard (forward toward the user) */}
+      {/* Floppy disk slot — thin dark line on the lower right */}
+      <mesh position={[0.16, 0.28, 0.4615]}>
+        <boxGeometry args={[0.34, 0.018, 0.006]} />
+        <meshStandardMaterial color="#0a0805" roughness={0.6} />
+      </mesh>
+      {/* Tiny disk eject indicator dot to the right of the slot */}
+      <mesh position={[0.355, 0.28, 0.4615]}>
+        <circleGeometry args={[0.005, 12]} />
+        <meshStandardMaterial color="#1f1a14" roughness={0.6} />
+      </mesh>
+
+      {/* Power LED (green pinhole on the lower left of the front) */}
+      <mesh position={[-0.32, 0.36, 0.462]}>
+        <sphereGeometry args={[0.008, 8, 8]} />
+        <meshStandardMaterial
+          emissive="#6a8d4a"
+          emissiveIntensity={1.4}
+          color="#1a1208"
+        />
+      </mesh>
+
+      {/* Keyboard (slim wedge in front, smaller than before to match the
+          smaller monitor footprint) */}
       <group position={[0, 0.0, 0.62]}>
         <mesh castShadow receiveShadow>
-          <boxGeometry args={[0.95, 0.025, 0.34]} />
-          <meshStandardMaterial color="#1f1a14" roughness={0.65} />
+          <boxGeometry args={[0.78, 0.025, 0.28]} />
+          <meshStandardMaterial color="#d4c4a0" roughness={0.75} />
         </mesh>
         <mesh position={[0, 0.018, 0]}>
-          <boxGeometry args={[0.9, 0.005, 0.3]} />
-          <meshStandardMaterial color="#3a3026" roughness={0.7} />
+          <boxGeometry args={[0.74, 0.005, 0.24]} />
+          <meshStandardMaterial color="#a89878" roughness={0.7} />
         </mesh>
-        {/* Subtle key-row hint lines via stretched boxes */}
-        {[-0.1, -0.04, 0.02, 0.08].map((z, i) => (
+        {[-0.08, -0.02, 0.04, 0.1].map((z, i) => (
           <mesh key={i} position={[0, 0.022, z]}>
-            <boxGeometry args={[0.86, 0.001, 0.03]} />
-            <meshBasicMaterial color="#0a0805" transparent opacity={0.4} />
+            <boxGeometry args={[0.7, 0.001, 0.02]} />
+            <meshBasicMaterial color="#1f1a14" transparent opacity={0.32} />
           </mesh>
         ))}
       </group>
-      {/* Mouse */}
-      <mesh position={[0.62, 0.013, 0.62]} castShadow>
-        <boxGeometry args={[0.1, 0.025, 0.16]} />
-        <meshStandardMaterial color="#1f1a14" roughness={0.65} />
+
+      {/* "Lisa-style" boxy mouse */}
+      <mesh position={[0.48, 0.013, 0.62]} castShadow>
+        <boxGeometry args={[0.1, 0.025, 0.13]} />
+        <meshStandardMaterial color="#d4c4a0" roughness={0.75} />
       </mesh>
-      {/* Mouse cable hint */}
-      <mesh position={[0.62, 0.018, 0.44]}>
-        <boxGeometry args={[0.008, 0.008, 0.18]} />
-        <meshStandardMaterial color="#0a0805" />
+      <mesh position={[0.48, 0.018, 0.45]}>
+        <boxGeometry args={[0.006, 0.006, 0.17]} />
+        <meshStandardMaterial color="#9c8a68" />
       </mesh>
     </group>
   );

--- a/personal-site/app/palace/scene/Decor.tsx
+++ b/personal-site/app/palace/scene/Decor.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+export function Decor() {
+  const bulbMat = useRef<THREE.MeshStandardMaterial>(null);
+  useFrame((state) => {
+    if (!bulbMat.current) return;
+    const t = state.clock.elapsedTime;
+    bulbMat.current.emissiveIntensity = 1.4 + Math.sin(t * 3.3) * 0.05;
+  });
+
+  return (
+    <>
+      {/* Desk lamp — right side of desk */}
+      <group position={[1.0, 0.99, -0.95]}>
+        <mesh position={[0, 0.04, 0]} castShadow>
+          <cylinderGeometry args={[0.08, 0.1, 0.04, 16]} />
+          <meshStandardMaterial color="#2c2014" roughness={0.6} metalness={0.3} />
+        </mesh>
+        <mesh position={[0, 0.38, 0]} castShadow>
+          <cylinderGeometry args={[0.015, 0.015, 0.68, 8]} />
+          <meshStandardMaterial color="#2c2014" roughness={0.6} metalness={0.3} />
+        </mesh>
+        {/* Arm */}
+        <mesh position={[-0.13, 0.72, 0.06]} rotation={[0, 0, Math.PI / 4]}>
+          <cylinderGeometry args={[0.013, 0.013, 0.3, 8]} />
+          <meshStandardMaterial color="#2c2014" roughness={0.6} metalness={0.3} />
+        </mesh>
+        {/* Shade */}
+        <mesh position={[-0.22, 0.8, 0.12]} rotation={[0.15, 0, Math.PI / 5]} castShadow>
+          <coneGeometry args={[0.15, 0.22, 18, 1, true]} />
+          <meshStandardMaterial
+            color="#f4ead7"
+            roughness={0.85}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+        {/* Bulb */}
+        <mesh position={[-0.22, 0.74, 0.12]}>
+          <sphereGeometry args={[0.05, 16, 16]} />
+          <meshStandardMaterial
+            ref={bulbMat}
+            color="#f0b687"
+            emissive="#f0b687"
+            emissiveIntensity={1.4}
+          />
+        </mesh>
+      </group>
+
+      {/* Stack of books on left of desk + figurine */}
+      <group position={[-1.05, 0.99, -1.05]}>
+        <mesh position={[0, 0.025, 0]} castShadow>
+          <boxGeometry args={[0.42, 0.05, 0.3]} />
+          <meshStandardMaterial color="#7d2e10" roughness={0.85} />
+        </mesh>
+        <mesh position={[0.01, 0.072, 0]} castShadow>
+          <boxGeometry args={[0.4, 0.045, 0.29]} />
+          <meshStandardMaterial color="#2a3a5c" roughness={0.85} />
+        </mesh>
+        <mesh position={[-0.01, 0.115, 0.005]} rotation={[0, 0.05, 0]} castShadow>
+          <boxGeometry args={[0.42, 0.04, 0.3]} />
+          <meshStandardMaterial color="#e8d6b0" roughness={0.85} />
+        </mesh>
+        {/* Pyramid bookmark */}
+        <mesh position={[0.06, 0.18, 0]} castShadow>
+          <coneGeometry args={[0.05, 0.1, 16]} />
+          <meshStandardMaterial color="#a8431c" roughness={0.6} />
+        </mesh>
+      </group>
+
+      {/* Coffee cup right of monitor */}
+      <group position={[0.95, 1.0, -0.35]}>
+        <mesh castShadow>
+          <cylinderGeometry args={[0.055, 0.045, 0.1, 24]} />
+          <meshStandardMaterial color="#f4ead7" roughness={0.8} />
+        </mesh>
+        <mesh position={[0, 0.052, 0]}>
+          <cylinderGeometry args={[0.05, 0.05, 0.002, 24]} />
+          <meshStandardMaterial color="#3a1f0a" roughness={0.5} />
+        </mesh>
+        {/* Handle */}
+        <mesh position={[0.06, 0, 0]} rotation={[0, 0, Math.PI / 2]}>
+          <torusGeometry args={[0.035, 0.008, 8, 14, Math.PI]} />
+          <meshStandardMaterial color="#f4ead7" roughness={0.8} />
+        </mesh>
+      </group>
+
+      {/* Notebook + papers to the left of the keyboard */}
+      <group position={[-0.7, 0.99, -0.05]}>
+        <mesh castShadow receiveShadow>
+          <boxGeometry args={[0.28, 0.015, 0.36]} />
+          <meshStandardMaterial color="#ece1c3" roughness={0.95} />
+        </mesh>
+        <mesh position={[0, 0.009, 0.1]}>
+          <boxGeometry args={[0.22, 0.001, 0.18]} />
+          <meshStandardMaterial color="#a8431c" roughness={0.95} />
+        </mesh>
+        {/* Pen */}
+        <mesh position={[0.12, 0.012, -0.08]} rotation={[0, 0.4, 0]}>
+          <cylinderGeometry args={[0.005, 0.005, 0.18, 8]} />
+          <meshStandardMaterial color="#1a1208" roughness={0.5} metalness={0.3} />
+        </mesh>
+      </group>
+
+      {/* Picture frame on back wall — left */}
+      <group position={[-1.4, 1.95, -2.57]}>
+        <mesh>
+          <boxGeometry args={[0.62, 0.46, 0.02]} />
+          <meshStandardMaterial color="#2c2014" roughness={0.55} />
+        </mesh>
+        <mesh position={[0, 0, 0.012]}>
+          <planeGeometry args={[0.56, 0.4]} />
+          <meshStandardMaterial
+            color="#e8d6b0"
+            emissive="#a8431c"
+            emissiveIntensity={0.05}
+            roughness={0.8}
+          />
+        </mesh>
+      </group>
+
+      {/* Wall shelf with folders */}
+      <group position={[1.3, 2.1, -2.57]}>
+        <mesh castShadow>
+          <boxGeometry args={[1.4, 0.03, 0.22]} />
+          <meshStandardMaterial color="#3a2918" roughness={0.6} />
+        </mesh>
+        <mesh position={[-0.45, 0.13, 0]} castShadow>
+          <boxGeometry args={[0.22, 0.22, 0.18]} />
+          <meshStandardMaterial color="#7d2e10" roughness={0.85} />
+        </mesh>
+        <mesh position={[-0.2, 0.13, 0]} castShadow>
+          <boxGeometry args={[0.22, 0.22, 0.18]} />
+          <meshStandardMaterial color="#2a3a5c" roughness={0.85} />
+        </mesh>
+        <mesh position={[0.05, 0.13, 0]} castShadow>
+          <boxGeometry args={[0.22, 0.22, 0.18]} />
+          <meshStandardMaterial color="#ece1c3" roughness={0.85} />
+        </mesh>
+        <mesh position={[0.4, 0.13, 0]} castShadow>
+          <boxGeometry args={[0.22, 0.22, 0.18]} />
+          <meshStandardMaterial color="#3a2918" roughness={0.85} />
+        </mesh>
+      </group>
+
+      {/* Small plant in pot (right back corner of desk) */}
+      <group position={[1.25, 0.99, -1.0]}>
+        <mesh position={[0, 0.07, 0]} castShadow>
+          <cylinderGeometry args={[0.085, 0.07, 0.14, 16]} />
+          <meshStandardMaterial color="#7d2e10" roughness={0.85} />
+        </mesh>
+        <mesh position={[0, 0.22, 0]} castShadow>
+          <sphereGeometry args={[0.13, 14, 14]} />
+          <meshStandardMaterial color="#3a6b3a" roughness={0.95} />
+        </mesh>
+        <mesh position={[-0.05, 0.3, 0.02]} castShadow>
+          <sphereGeometry args={[0.08, 12, 12]} />
+          <meshStandardMaterial color="#4a7b4a" roughness={0.95} />
+        </mesh>
+      </group>
+    </>
+  );
+}

--- a/personal-site/app/palace/scene/Desk.tsx
+++ b/personal-site/app/palace/scene/Desk.tsx
@@ -1,0 +1,68 @@
+export function Desk() {
+  const legPositions: [number, number, number][] = [
+    [-1.22, 0.48, -0.42 - 0.6],
+    [1.22, 0.48, -0.42 - 0.6],
+    [-1.22, 0.48, 0.42 - 0.6],
+    [1.22, 0.48, 0.42 - 0.6],
+  ];
+
+  return (
+    <group>
+      {/* Desktop */}
+      <mesh position={[0, 0.96, -0.6]} castShadow receiveShadow>
+        <boxGeometry args={[2.6, 0.06, 1.0]} />
+        <meshStandardMaterial
+          color="#3a2918"
+          roughness={0.6}
+          metalness={0.05}
+        />
+      </mesh>
+      {/* Desk legs */}
+      {legPositions.map((p, i) => (
+        <mesh key={i} position={p} castShadow>
+          <boxGeometry args={[0.07, 0.94, 0.07]} />
+          <meshStandardMaterial color="#2a1d10" roughness={0.7} />
+        </mesh>
+      ))}
+      {/* Modesty panel along the back of the desk */}
+      <mesh position={[0, 0.6, -1.04]}>
+        <boxGeometry args={[2.46, 0.55, 0.03]} />
+        <meshStandardMaterial color="#332314" roughness={0.7} />
+      </mesh>
+
+      {/* Office chair, pushed to the side so it frames the desk without
+          blocking the camera's view of the monitor. */}
+      <group position={[-1.7, 0, 0.3]} rotation={[0, 0.6, 0]}>
+        <mesh position={[0, 1.0, 0]} castShadow>
+          <boxGeometry args={[0.78, 0.62, 0.06]} />
+          <meshStandardMaterial color="#3b1605" roughness={0.7} />
+        </mesh>
+        <mesh position={[0, 0.58, 0.3]} castShadow>
+          <boxGeometry args={[0.84, 0.08, 0.74]} />
+          <meshStandardMaterial color="#7d2e10" roughness={0.7} />
+        </mesh>
+        <mesh position={[0, 0.3, 0.3]}>
+          <cylinderGeometry args={[0.04, 0.05, 0.5, 12]} />
+          <meshStandardMaterial color="#1a1208" metalness={0.5} roughness={0.4} />
+        </mesh>
+        <mesh position={[0, 0.06, 0.3]}>
+          <cylinderGeometry args={[0.3, 0.32, 0.06, 16]} />
+          <meshStandardMaterial color="#1a1208" metalness={0.5} roughness={0.4} />
+        </mesh>
+        {[0, 1, 2, 3, 4].map((i) => {
+          const a = (i * Math.PI * 2) / 5;
+          return (
+            <mesh
+              key={i}
+              position={[Math.cos(a) * 0.28, 0.04, Math.sin(a) * 0.28 + 0.3]}
+              rotation={[0, -a, 0]}
+            >
+              <boxGeometry args={[0.34, 0.04, 0.06]} />
+              <meshStandardMaterial color="#15110b" metalness={0.5} roughness={0.4} />
+            </mesh>
+          );
+        })}
+      </group>
+    </group>
+  );
+}

--- a/personal-site/app/palace/scene/Lighting.tsx
+++ b/personal-site/app/palace/scene/Lighting.tsx
@@ -1,0 +1,47 @@
+export function Lighting() {
+  return (
+    <>
+      <ambientLight intensity={0.22} color="#fff1d6" />
+      <hemisphereLight args={["#fff1d6", "#1a1208", 0.18]} />
+      <directionalLight
+        position={[-3, 4.6, 3.2]}
+        intensity={1.05}
+        color="#fde2ba"
+        castShadow
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={0.5}
+        shadow-camera-far={14}
+        shadow-camera-left={-5}
+        shadow-camera-right={5}
+        shadow-camera-top={5}
+        shadow-camera-bottom={-5}
+        shadow-bias={-0.0008}
+      />
+      {/* Desk-lamp glow (no shadow — cheaper, and we already have key light) */}
+      <pointLight
+        position={[1.05, 1.95, -0.93]}
+        intensity={1.8}
+        distance={3.6}
+        decay={2.0}
+        color="#f0b687"
+      />
+      {/* Monitor screen glow — cool counterweight to the warm lamp */}
+      <pointLight
+        position={[0, 1.65, -0.55]}
+        intensity={0.55}
+        distance={2.2}
+        decay={2.0}
+        color="#7faedf"
+      />
+      {/* Window key — soft directional fill from window opening */}
+      <pointLight
+        position={[2.6, 2.0, -0.6]}
+        intensity={0.7}
+        distance={4.5}
+        decay={2.0}
+        color="#f6e1be"
+      />
+    </>
+  );
+}

--- a/personal-site/app/palace/scene/Room.tsx
+++ b/personal-site/app/palace/scene/Room.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from "react";
+import * as THREE from "three";
+
+export function Room() {
+  const floorMat = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: "#4a3826",
+        roughness: 0.85,
+        metalness: 0.02,
+      }),
+    [],
+  );
+  const wallMat = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: "#d8c8a4",
+        roughness: 1.0,
+        metalness: 0,
+      }),
+    [],
+  );
+  const backWallMat = useMemo(
+    () =>
+      new THREE.MeshStandardMaterial({
+        color: "#cab68f",
+        roughness: 1.0,
+        metalness: 0,
+      }),
+    [],
+  );
+
+  return (
+    <group>
+      {/* Floor */}
+      <mesh
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0, 0]}
+        receiveShadow
+        material={floorMat}
+      >
+        <planeGeometry args={[14, 14]} />
+      </mesh>
+      {/* Floorboards — repeating darker strips for texture without a texture file */}
+      {Array.from({ length: 7 }, (_, i) => (
+        <mesh
+          key={`board-${i}`}
+          rotation={[-Math.PI / 2, 0, 0]}
+          position={[0, 0.001, -2.5 + i * 0.85]}
+        >
+          <planeGeometry args={[14, 0.006]} />
+          <meshBasicMaterial color="#2c2014" transparent opacity={0.55} />
+        </mesh>
+      ))}
+
+      {/* Back wall */}
+      <mesh position={[0, 1.8, -2.6]} receiveShadow material={backWallMat}>
+        <planeGeometry args={[14, 3.6]} />
+      </mesh>
+      {/* Left wall */}
+      <mesh
+        position={[-3, 1.8, 0]}
+        rotation={[0, Math.PI / 2, 0]}
+        receiveShadow
+        material={wallMat}
+      >
+        <planeGeometry args={[5.2, 3.6]} />
+      </mesh>
+      {/* Right wall */}
+      <mesh
+        position={[3, 1.8, 0]}
+        rotation={[0, -Math.PI / 2, 0]}
+        receiveShadow
+        material={wallMat}
+      >
+        <planeGeometry args={[5.2, 3.6]} />
+      </mesh>
+
+      {/* Window opening on right wall (emissive sky behind glass) */}
+      <mesh position={[2.985, 1.85, -0.6]} rotation={[0, -Math.PI / 2, 0]}>
+        <planeGeometry args={[1.6, 1.2]} />
+        <meshStandardMaterial
+          color="#f6e1be"
+          emissive="#f6e1be"
+          emissiveIntensity={0.15}
+        />
+      </mesh>
+      {/* Window mullion frame: vertical */}
+      <mesh position={[2.978, 1.85, -0.6]} rotation={[0, -Math.PI / 2, 0]}>
+        <boxGeometry args={[0.02, 1.2, 0.02]} />
+        <meshStandardMaterial color="#2c2014" />
+      </mesh>
+      {/* Window mullion frame: horizontal */}
+      <mesh position={[2.978, 1.85, -0.6]} rotation={[0, -Math.PI / 2, 0]}>
+        <boxGeometry args={[1.6, 0.02, 0.02]} />
+        <meshStandardMaterial color="#2c2014" />
+      </mesh>
+      {/* Window outer frame */}
+      <mesh position={[2.97, 1.85, -0.6]} rotation={[0, -Math.PI / 2, 0]}>
+        <ringGeometry args={[0.84, 0.92, 4, 1]} />
+        <meshStandardMaterial color="#2c2014" side={THREE.DoubleSide} />
+      </mesh>
+
+      {/* Baseboard */}
+      <mesh position={[0, 0.07, -2.59]}>
+        <boxGeometry args={[14, 0.14, 0.03]} />
+        <meshStandardMaterial color="#2c2014" />
+      </mesh>
+      <mesh position={[-2.99, 0.07, 0]} rotation={[0, Math.PI / 2, 0]}>
+        <boxGeometry args={[5.2, 0.14, 0.03]} />
+        <meshStandardMaterial color="#2c2014" />
+      </mesh>
+      <mesh position={[2.99, 0.07, 0]} rotation={[0, -Math.PI / 2, 0]}>
+        <boxGeometry args={[5.2, 0.14, 0.03]} />
+        <meshStandardMaterial color="#2c2014" />
+      </mesh>
+
+      {/* Floor rug under desk */}
+      <mesh
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0.005, 0.1]}
+        receiveShadow
+      >
+        <planeGeometry args={[3.4, 2.2]} />
+        <meshStandardMaterial color="#7d2e10" roughness={0.95} />
+      </mesh>
+      <mesh
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0.006, 0.1]}
+        receiveShadow
+      >
+        <planeGeometry args={[3.0, 1.85]} />
+        <meshStandardMaterial color="#a8431c" roughness={0.95} />
+      </mesh>
+    </group>
+  );
+}

--- a/personal-site/app/palace/styles.module.css
+++ b/personal-site/app/palace/styles.module.css
@@ -614,6 +614,159 @@
   padding: 0.1rem 0.35rem;
 }
 
+/* Games — Tetris + Snake live in BingranOS tabs */
+.gameLayout {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(120px, 200px);
+  gap: 1.2rem;
+  align-items: start;
+  justify-content: center;
+}
+
+@media (max-width: 720px) {
+  .gameLayout {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+  }
+}
+
+.gameBoard {
+  position: relative;
+  background: rgba(31, 26, 20, 0.04);
+  border: 1px solid rgba(31, 26, 20, 0.18);
+  border-radius: 6px;
+  padding: 6px;
+  box-shadow: inset 0 0 18px rgba(31, 26, 20, 0.08);
+}
+
+.tetrisGrid {
+  display: grid;
+  width: clamp(180px, 36vh, 280px);
+  aspect-ratio: 10 / 20;
+  gap: 0;
+}
+
+.snakeGrid {
+  display: grid;
+  width: clamp(240px, 50vh, 380px);
+  aspect-ratio: 1 / 1;
+  gap: 0;
+}
+
+.nextGrid {
+  display: grid;
+  width: 76px;
+  aspect-ratio: 1 / 1;
+  gap: 1px;
+  margin-top: 4px;
+}
+
+.cell {
+  border: 1px solid rgba(31, 26, 20, 0.06);
+  box-sizing: border-box;
+}
+
+.gameOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  text-align: center;
+  background: rgba(244, 234, 215, 0.92);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  border-radius: 6px;
+  padding: 1.4rem;
+}
+
+.gameOverlayTitle {
+  font-family: var(--font-newsreader), serif;
+  font-size: 1.6rem;
+  letter-spacing: -0.01em;
+  font-weight: 500;
+  margin: 0;
+  color: #1f1a14;
+}
+
+.gameOverlayMeta {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.6);
+  margin: 0;
+  max-width: 24ch;
+  line-height: 1.5;
+}
+
+.gameStartBtn {
+  margin-top: 0.4rem;
+  background: #a8431c;
+  color: #fbf3e1;
+  border: none;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.gameStartBtn:hover {
+  background: #7d2e10;
+}
+
+.gameStartBtn:active {
+  transform: scale(0.97);
+}
+
+.gameSide {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-width: 0;
+}
+
+.gameStat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.gameStatLabel {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.55);
+}
+
+.gameStatValue {
+  font-family: var(--font-newsreader), serif;
+  font-size: 1.7rem;
+  letter-spacing: -0.01em;
+  color: #1f1a14;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.gameHelp {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.55);
+  line-height: 1.7;
+  margin: 0;
+  padding-top: 0.4rem;
+  border-top: 1px solid rgba(31, 26, 20, 0.1);
+}
+
 /* Reveal SSR text when JS is disabled */
 .noscriptStyles {
   display: block;

--- a/personal-site/app/palace/styles.module.css
+++ b/personal-site/app/palace/styles.module.css
@@ -1,0 +1,620 @@
+/* Palette is taken from the site's main globals.css so the room reads as
+   "same person, more pixels": warm-paper background, terracotta accent. */
+
+.shell {
+  position: relative;
+  width: 100vw;
+  height: 100dvh;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% 40%, #2a221a 0%, #110d08 70%, #0a0805 100%);
+  color: #ece4d4;
+  font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB", sans-serif;
+}
+
+.canvasWrap {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.canvasWrap canvas {
+  display: block;
+  touch-action: none;
+}
+
+.fallback {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.fallback :where(h1, h2, h3, h4, p, ul, ol, li, a) {
+  all: revert;
+}
+
+.intro {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  pointer-events: none;
+  background: radial-gradient(ellipse at 50% 40%, rgba(20, 16, 10, 0) 30%, rgba(8, 6, 3, 0.9) 100%);
+  opacity: 1;
+  transition: opacity 0.9s ease 0.1s;
+  text-align: center;
+  padding: 2rem;
+}
+
+.intro.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.introTitle {
+  font-family: var(--font-newsreader), serif;
+  font-size: clamp(2.4rem, 6vw, 4.2rem);
+  letter-spacing: -0.035em;
+  line-height: 1.02;
+  color: #f0e5cf;
+  font-weight: 500;
+  text-shadow: 0 1px 30px rgba(0, 0, 0, 0.6);
+}
+
+.introSubtitle {
+  font-family: var(--font-newsreader), var(--font-noto-serif-sc), serif;
+  font-size: clamp(1.4rem, 3.4vw, 2.1rem);
+  color: rgba(240, 229, 207, 0.75);
+  letter-spacing: 0.04em;
+  font-weight: 400;
+}
+
+.introCaption {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(232, 153, 104, 0.85);
+  margin-top: 0.5rem;
+}
+
+.introCta {
+  margin-top: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1.2rem;
+  border: 1px solid rgba(240, 182, 135, 0.6);
+  color: #f0b687;
+  background: rgba(40, 30, 20, 0.4);
+  border-radius: 999px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  pointer-events: auto;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border 0.2s;
+}
+
+.introCta:hover {
+  background: rgba(240, 182, 135, 0.18);
+  color: #f5cba0;
+}
+
+.hud {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: clamp(1rem, 2vw, 1.5rem) clamp(1rem, 3vw, 2rem);
+  color: rgba(236, 228, 212, 0.78);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.hudTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hudBottom {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hudBrand {
+  pointer-events: auto;
+  color: rgba(236, 228, 212, 0.92);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(236, 228, 212, 0.2);
+  padding-bottom: 2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.hudBrand:hover {
+  color: #f0b687;
+  border-color: #f0b687;
+}
+
+.hudExit {
+  pointer-events: auto;
+  background: transparent;
+  border: 1px solid rgba(236, 228, 212, 0.25);
+  color: rgba(236, 228, 212, 0.85);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font: inherit;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.hudExit:hover {
+  background: rgba(240, 182, 135, 0.12);
+  color: #f0b687;
+  border-color: rgba(240, 182, 135, 0.6);
+}
+
+.hudHint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  background: rgba(20, 16, 10, 0.45);
+  border: 1px solid rgba(236, 228, 212, 0.12);
+  border-radius: 8px;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.hudHint kbd {
+  font-family: var(--font-geist-mono), monospace;
+  background: rgba(236, 228, 212, 0.12);
+  border: 1px solid rgba(236, 228, 212, 0.18);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  color: rgba(236, 228, 212, 0.95);
+  font-size: 0.65rem;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #f0b687;
+  box-shadow: 0 0 8px rgba(240, 182, 135, 0.7);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.7; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.15); }
+}
+
+/* BingranOS — appears when the user "enters" the monitor */
+.osLayer {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 4vw, 3rem);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  background: radial-gradient(ellipse at 50% 50%, rgba(0, 0, 0, 0) 30%, rgba(0, 0, 0, 0.55) 100%);
+}
+
+.osLayer.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.osFrame {
+  position: relative;
+  width: min(1100px, 96vw);
+  height: min(720px, 86vh);
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(145deg, #fbf3e1 0%, #f4ead7 60%, #ece1c3 100%);
+  color: #1f1a14;
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.6),
+    0 0 0 8px #15110b,
+    0 0 0 10px rgba(240, 182, 135, 0.18),
+    inset 0 0 40px rgba(255, 230, 200, 0.5);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+}
+
+.osFrame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.03) 0px,
+      rgba(0, 0, 0, 0.03) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+  pointer-events: none;
+  z-index: 2;
+}
+
+.osBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.55rem 1rem;
+  background: linear-gradient(180deg, #1f1a14 0%, #2c241a 100%);
+  color: #ece4d4;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border-bottom: 1px solid rgba(240, 182, 135, 0.3);
+}
+
+.osBarLeft {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.osBarDots {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.osBarDots span {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  background: rgba(236, 228, 212, 0.2);
+  border: 1px solid rgba(236, 228, 212, 0.25);
+}
+
+.osBarDots span:nth-child(1) { background: #e0664e; border-color: #c1543e; }
+.osBarDots span:nth-child(2) { background: #e8b758; border-color: #c19945; }
+.osBarDots span:nth-child(3) { background: #6ab07a; border-color: #4f8c5e; }
+
+.osBarBrand {
+  font-weight: 500;
+}
+
+.osBarClose {
+  background: transparent;
+  border: 1px solid rgba(236, 228, 212, 0.3);
+  color: rgba(236, 228, 212, 0.85);
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  cursor: pointer;
+}
+
+.osBarClose:hover {
+  background: rgba(232, 153, 104, 0.15);
+  color: #f0b687;
+  border-color: #f0b687;
+}
+
+.osBody {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  min-height: 0;
+}
+
+@media (max-width: 720px) {
+  .osBody { grid-template-columns: 110px 1fr; }
+}
+
+.osSide {
+  background: rgba(31, 26, 20, 0.04);
+  border-right: 1px solid rgba(31, 26, 20, 0.12);
+  padding: 0.85rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  overflow-y: auto;
+}
+
+.osIcon {
+  appearance: none;
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  color: #1f1a14;
+  font: inherit;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  cursor: pointer;
+  position: relative;
+  transition: background 0.15s, color 0.15s;
+}
+
+.osIcon:hover {
+  background: rgba(168, 67, 28, 0.1);
+  color: #7d2e10;
+}
+
+.osIcon.active {
+  background: rgba(168, 67, 28, 0.16);
+  color: #7d2e10;
+  font-weight: 500;
+}
+
+.osIcon.active::before {
+  content: "";
+  position: absolute;
+  inset: 6px auto 6px 0;
+  width: 3px;
+  background: #a8431c;
+  border-radius: 2px;
+}
+
+.osIcon .glyph {
+  width: 18px;
+  text-align: center;
+  font-family: var(--font-geist-mono), monospace;
+  color: rgba(31, 26, 20, 0.55);
+}
+
+.osWindow {
+  position: relative;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.osWindowBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: rgba(31, 26, 20, 0.06);
+  border-bottom: 1px solid rgba(31, 26, 20, 0.1);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.65);
+}
+
+.osContent {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: clamp(1rem, 2.6vw, 1.8rem) clamp(1rem, 3vw, 2.2rem);
+  scroll-behavior: smooth;
+}
+
+.osContent h1 {
+  font-family: var(--font-newsreader), serif;
+  font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+  letter-spacing: -0.02em;
+  margin-bottom: 0.6rem;
+  font-weight: 500;
+}
+
+.osContent h2 {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.55);
+  margin: 1.8rem 0 0.8rem;
+}
+
+.osContent p {
+  margin: 0 0 0.9rem;
+  line-height: 1.6;
+  color: rgba(31, 26, 20, 0.85);
+  max-width: 60ch;
+}
+
+.osList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-top: 1px solid rgba(31, 26, 20, 0.12);
+}
+
+.osList li {
+  border-bottom: 1px solid rgba(31, 26, 20, 0.12);
+  padding: 0.85rem 0;
+}
+
+.osList a {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.osList a:hover .osListTitle {
+  color: #7d2e10;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.osListMeta {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.55);
+}
+
+.osListTitle {
+  font-size: 0.98rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.osListBlurb {
+  font-size: 0.86rem;
+  color: rgba(31, 26, 20, 0.7);
+  line-height: 1.5;
+}
+
+.osTwoCol {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.4rem;
+}
+
+.contactList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  gap: 0.3rem 1.2rem;
+  font-size: 0.92rem;
+}
+
+.contactList dt,
+.contactList .dt {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.55);
+  align-self: center;
+}
+
+.contactList a {
+  color: #a8431c;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+.contactList a:hover {
+  color: #7d2e10;
+}
+
+.linkOut {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #a8431c;
+  text-decoration: none;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.linkOut:hover { color: #7d2e10; text-decoration: underline; text-underline-offset: 4px; }
+
+.postsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.9rem;
+}
+
+.postCard {
+  display: block;
+  border: 1px solid rgba(31, 26, 20, 0.12);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  text-decoration: none;
+  color: inherit;
+  background: rgba(255, 248, 230, 0.4);
+  transition: background 0.15s, transform 0.15s, border-color 0.15s;
+}
+
+.postCard:hover {
+  background: rgba(255, 248, 230, 0.85);
+  border-color: rgba(168, 67, 28, 0.4);
+  transform: translateY(-1px);
+}
+
+.postCardTitle {
+  font-size: 0.92rem;
+  line-height: 1.35;
+  font-weight: 500;
+}
+
+.eduList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.eduList li {
+  display: grid;
+  grid-template-columns: 9rem 1fr;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-top: 1px solid rgba(31, 26, 20, 0.12);
+}
+
+.eduList li:last-child {
+  border-bottom: 1px solid rgba(31, 26, 20, 0.12);
+}
+
+@media (max-width: 720px) {
+  .eduList li { grid-template-columns: 1fr; gap: 0.3rem; }
+  .contactList { grid-template-columns: 1fr; }
+}
+
+.kbdHint {
+  position: absolute;
+  bottom: 0.7rem;
+  right: 1rem;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(31, 26, 20, 0.4);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.kbdHint kbd {
+  background: rgba(31, 26, 20, 0.06);
+  border: 1px solid rgba(31, 26, 20, 0.15);
+  border-radius: 3px;
+  padding: 0.1rem 0.35rem;
+}
+
+/* Reveal SSR text when JS is disabled */
+.noscriptStyles {
+  display: block;
+}

--- a/personal-site/app/palace/styles.module.css
+++ b/personal-site/app/palace/styles.module.css
@@ -235,15 +235,16 @@
   position: relative;
   width: min(1100px, 96vw);
   height: min(720px, 86vh);
-  border-radius: 14px;
+  border-radius: 0;
   overflow: hidden;
-  background: linear-gradient(145deg, #fbf3e1 0%, #f4ead7 60%, #ece1c3 100%);
+  background: #fbf3e1;
   color: #1f1a14;
+  /* Classic Mac chrome: thin black outline + a small "shadow" beneath that
+     reads as a window dropped onto the screen. */
   box-shadow:
-    0 30px 80px rgba(0, 0, 0, 0.6),
-    0 0 0 8px #15110b,
-    0 0 0 10px rgba(240, 182, 135, 0.18),
-    inset 0 0 40px rgba(255, 230, 200, 0.5);
+    0 0 0 1px #1f1a14,
+    4px 4px 0 0 rgba(31, 26, 20, 0.85),
+    0 22px 60px rgba(0, 0, 0, 0.55);
   display: flex;
   flex-direction: column;
   font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
@@ -256,8 +257,8 @@
   background:
     repeating-linear-gradient(
       0deg,
-      rgba(0, 0, 0, 0.03) 0px,
-      rgba(0, 0, 0, 0.03) 1px,
+      rgba(0, 0, 0, 0.022) 0px,
+      rgba(0, 0, 0, 0.022) 1px,
       transparent 1px,
       transparent 3px
     );
@@ -265,63 +266,67 @@
   z-index: 2;
 }
 
+/* Classic Mac title bar: cream background + black drag stripes flanking a
+   centred title pill, with a hollow close box on the left. */
 .osBar {
+  position: relative;
+  height: 38px;
+  background: #fbf3e1;
+  border-bottom: 2px solid #1f1a14;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.55rem 1rem;
-  background: linear-gradient(180deg, #1f1a14 0%, #2c241a 100%);
-  color: #ece4d4;
+  padding: 0 12px;
   font-family: var(--font-geist-mono), monospace;
   font-size: 0.72rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  border-bottom: 1px solid rgba(240, 182, 135, 0.3);
-}
-
-.osBarLeft {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-}
-
-.osBarDots {
-  display: inline-flex;
-  gap: 6px;
-}
-
-.osBarDots span {
-  width: 11px;
-  height: 11px;
-  border-radius: 999px;
-  background: rgba(236, 228, 212, 0.2);
-  border: 1px solid rgba(236, 228, 212, 0.25);
-}
-
-.osBarDots span:nth-child(1) { background: #e0664e; border-color: #c1543e; }
-.osBarDots span:nth-child(2) { background: #e8b758; border-color: #c19945; }
-.osBarDots span:nth-child(3) { background: #6ab07a; border-color: #4f8c5e; }
-
-.osBarBrand {
+  letter-spacing: 0.16em;
+  color: #1f1a14;
   font-weight: 500;
+  flex-shrink: 0;
+  text-transform: uppercase;
+}
+
+.osBar::before {
+  content: "";
+  position: absolute;
+  left: 42px;
+  right: 16px;
+  top: 7px;
+  bottom: 9px;
+  background-image: repeating-linear-gradient(
+    180deg,
+    #1f1a14 0 1.4px,
+    transparent 1.4px 5px
+  );
+  pointer-events: none;
+  z-index: 1;
 }
 
 .osBarClose {
-  background: transparent;
-  border: 1px solid rgba(236, 228, 212, 0.3);
-  color: rgba(236, 228, 212, 0.85);
-  padding: 0.25rem 0.7rem;
-  border-radius: 999px;
-  font: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
+  position: relative;
+  z-index: 2;
+  width: 16px;
+  height: 16px;
+  background: #fbf3e1;
+  border: 2px solid #1f1a14;
   cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background 0.15s;
 }
 
 .osBarClose:hover {
-  background: rgba(232, 153, 104, 0.15);
-  color: #f0b687;
-  border-color: #f0b687;
+  background: #1f1a14;
+}
+
+.osBarTitle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  background: #fbf3e1;
+  padding: 0 12px;
+  white-space: nowrap;
 }
 
 .osBody {

--- a/personal-site/app/palace/ui/BingranOS.tsx
+++ b/personal-site/app/palace/ui/BingranOS.tsx
@@ -77,24 +77,15 @@ export function BingranOS({
         aria-modal="true"
       >
         <div className={styles.osBar}>
-          <div className={styles.osBarLeft}>
-            <span className={styles.osBarDots}>
-              <span />
-              <span />
-              <span />
-            </span>
-            <span className={styles.osBarBrand}>
-              BingranOS · bingranyou.com
-            </span>
-          </div>
           <button
             type="button"
             className={styles.osBarClose}
             onClick={onClose}
             aria-label="Close BingranOS and return to room"
-          >
-            Close
-          </button>
+          />
+          <div className={styles.osBarTitle}>
+            BingranOS — bingranyou.com
+          </div>
         </div>
 
         <div className={styles.osBody}>

--- a/personal-site/app/palace/ui/BingranOS.tsx
+++ b/personal-site/app/palace/ui/BingranOS.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import Link from "next/link";
+import { Fragment, useEffect, useState } from "react";
+import type { PalaceData } from "../palace-data";
+import styles from "../styles.module.css";
+
+type TabId =
+  | "about"
+  | "projects"
+  | "papers"
+  | "blog"
+  | "posts"
+  | "skills"
+  | "contact";
+
+const TABS: { id: TabId; label: string; glyph: string }[] = [
+  { id: "about", label: "About.txt", glyph: "i" },
+  { id: "projects", label: "Projects", glyph: "▣" },
+  { id: "papers", label: "Papers", glyph: "▤" },
+  { id: "blog", label: "Blog", glyph: "❖" },
+  { id: "posts", label: "Posts", glyph: "◉" },
+  { id: "skills", label: "Skills", glyph: "✦" },
+  { id: "contact", label: "Contact", glyph: "@" },
+];
+
+export function BingranOS({
+  data,
+  visible,
+  onClose,
+}: {
+  data: PalaceData;
+  visible: boolean;
+  onClose: () => void;
+}) {
+  const [tab, setTab] = useState<TabId>("about");
+
+  useEffect(() => {
+    if (visible) setTab("about");
+  }, [visible]);
+
+  return (
+    <div
+      className={`${styles.osLayer} ${visible ? styles.visible : ""}`}
+      aria-hidden={!visible}
+    >
+      <div
+        className={styles.osFrame}
+        role="dialog"
+        aria-label="BingranOS — bingranyou.com on the monitor"
+        aria-modal="true"
+      >
+        <div className={styles.osBar}>
+          <div className={styles.osBarLeft}>
+            <span className={styles.osBarDots}>
+              <span />
+              <span />
+              <span />
+            </span>
+            <span className={styles.osBarBrand}>
+              BingranOS · bingranyou.com
+            </span>
+          </div>
+          <button
+            type="button"
+            className={styles.osBarClose}
+            onClick={onClose}
+            aria-label="Close BingranOS and return to room"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className={styles.osBody}>
+          <nav className={styles.osSide} aria-label="BingranOS sections">
+            {TABS.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                className={`${styles.osIcon} ${tab === t.id ? styles.active : ""}`}
+                onClick={() => setTab(t.id)}
+                aria-current={tab === t.id ? "page" : undefined}
+              >
+                <span className={styles.glyph} aria-hidden>
+                  {t.glyph}
+                </span>
+                {t.label}
+              </button>
+            ))}
+          </nav>
+
+          <section className={styles.osWindow}>
+            <header className={styles.osWindowBar}>
+              <span>{TABS.find((t) => t.id === tab)?.label} — open</span>
+              <span aria-hidden>↑ ↓ scroll · esc close</span>
+            </header>
+            <div className={styles.osContent}>
+              {tab === "about" && <AboutTab data={data} />}
+              {tab === "projects" && <ProjectsTab data={data} />}
+              {tab === "papers" && <PapersTab data={data} />}
+              {tab === "blog" && <BlogTab data={data} />}
+              {tab === "posts" && <PostsTab data={data} />}
+              {tab === "skills" && <SkillsTab />}
+              {tab === "contact" && <ContactTab data={data} />}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AboutTab({ data }: { data: PalaceData }) {
+  return (
+    <article>
+      <h1>About</h1>
+      <p
+        lang="zh-Hans"
+        style={{
+          fontFamily: "var(--font-newsreader), serif",
+          fontSize: "1.1rem",
+          letterSpacing: "0.04em",
+          color: "rgba(31, 26, 20, 0.95)",
+        }}
+      >
+        尤炳然 · Bingran You
+      </p>
+      {data.about.facts.map((f) => (
+        <p key={f}>{f}</p>
+      ))}
+
+      <h2>Focus</h2>
+      {data.about.focus.map((area) => (
+        <div key={area.label} style={{ marginBottom: "1.4rem" }}>
+          <p
+            style={{
+              fontFamily: "var(--font-geist-mono), monospace",
+              fontSize: "0.7rem",
+              letterSpacing: "0.24em",
+              textTransform: "uppercase",
+              color: "rgba(31, 26, 20, 0.6)",
+              margin: "0 0 0.5rem 0",
+            }}
+          >
+            {area.label}
+          </p>
+          <ul className={styles.osList} style={{ borderTop: "1px solid rgba(31,26,20,0.12)" }}>
+            {area.items.map((item) => (
+              <li key={item} style={{ padding: "0.7rem 0" }}>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+
+      <h2>Education</h2>
+      <ul className={styles.eduList}>
+        {data.education.map((e) => (
+          <li key={e.institution}>
+            <div>
+              <span className={styles.osListMeta}>{e.period}</span>
+            </div>
+            <div>
+              <div className={styles.osListTitle}>{e.institution}</div>
+              <div className={styles.osListBlurb}>
+                {e.degree} · {e.location}
+              </div>
+              {e.metrics?.length ? (
+                <div
+                  className={styles.osListMeta}
+                  style={{ marginTop: 4 }}
+                >
+                  {e.metrics.join(" · ")}
+                </div>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <p style={{ marginTop: "1.8rem" }}>
+        <Link href="/about" className={styles.linkOut}>
+          Full about page →
+        </Link>
+      </p>
+    </article>
+  );
+}
+
+function ProjectsTab({ data }: { data: PalaceData }) {
+  const ai = data.projects.filter((p) => p.track === "ai");
+  const ion = data.projects.filter((p) => p.track === "ion");
+  return (
+    <article>
+      <h1>Projects</h1>
+      <p>Open source and applied AI work, plus the trapped-ion stack.</p>
+
+      <h2>Agentic Builder</h2>
+      <ul className={styles.osList}>
+        {ai.map((p) => (
+          <li key={p.href}>
+            <a href={p.href} target="_blank" rel="noopener noreferrer">
+              <span className={styles.osListTitle}>
+                {p.emoji} {p.name}
+              </span>
+              <span className={styles.osListBlurb}>{p.description}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <h2>Ion Trapper</h2>
+      <ul className={styles.osList}>
+        {ion.map((p) => (
+          <li key={p.href}>
+            <a href={p.href} target="_blank" rel="noopener noreferrer">
+              <span className={styles.osListTitle}>
+                {p.emoji} {p.name}
+              </span>
+              <span className={styles.osListBlurb}>{p.description}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <p style={{ marginTop: "1.5rem" }}>
+        <Link href="/projects" className={styles.linkOut}>
+          All projects →
+        </Link>
+      </p>
+    </article>
+  );
+}
+
+function PapersTab({ data }: { data: PalaceData }) {
+  const ai = data.papers.filter((p) => p.track === "ai");
+  const ion = data.papers.filter((p) => p.track === "ion");
+  return (
+    <article>
+      <h1>Papers</h1>
+      <p>
+        Selected publications. See{" "}
+        <a
+          href="https://scholar.google.com/citations?user=ZJdz2UkAAAAJ&hl=en"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: "#a8431c", textUnderlineOffset: "4px" }}
+        >
+          Google Scholar
+        </a>{" "}
+        for the full list.
+      </p>
+
+      <h2>Agentic Builder</h2>
+      <ul className={styles.osList}>
+        {ai.map((p) => (
+          <li key={p.href}>
+            <a href={p.href} target="_blank" rel="noopener noreferrer">
+              <span className={styles.osListMeta}>{p.venue}</span>
+              <span className={styles.osListTitle}>{p.title}</span>
+              {p.blurb ? (
+                <span className={styles.osListBlurb}>{p.blurb}</span>
+              ) : null}
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <h2>Ion Trapper</h2>
+      <ul className={styles.osList}>
+        {ion.map((p) => (
+          <li key={p.href}>
+            <a href={p.href} target="_blank" rel="noopener noreferrer">
+              <span className={styles.osListMeta}>{p.venue}</span>
+              <span className={styles.osListTitle}>{p.title}</span>
+              {p.blurb ? (
+                <span className={styles.osListBlurb}>{p.blurb}</span>
+              ) : null}
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <p style={{ marginTop: "1.5rem" }}>
+        <Link href="/papers" className={styles.linkOut}>
+          All papers →
+        </Link>
+      </p>
+    </article>
+  );
+}
+
+function BlogTab({ data }: { data: PalaceData }) {
+  return (
+    <article>
+      <h1>Blog</h1>
+      <p>
+        Short notes — on agents, ions, and the craft of making complex things
+        dependable.
+      </p>
+      <ul className={styles.osList}>
+        {data.blogPosts.map((p) => (
+          <li key={p.slug}>
+            <Link href={`/blog/${p.slug}`}>
+              <span className={styles.osListMeta}>{p.date}</span>
+              <span className={styles.osListTitle}>{p.title}</span>
+              {p.description ? (
+                <span className={styles.osListBlurb}>{p.description}</span>
+              ) : null}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <p style={{ marginTop: "1.5rem" }}>
+        <Link href="/blog" className={styles.linkOut}>
+          All posts →
+        </Link>
+      </p>
+    </article>
+  );
+}
+
+function PostsTab({ data }: { data: PalaceData }) {
+  return (
+    <article>
+      <h1>Recent posts</h1>
+      <p>
+        Videos and notes I&apos;ve posted across YouTube, X, Xiaohongshu,
+        Bilibili and elsewhere — newest first.
+      </p>
+      <div className={styles.postsGrid}>
+        {data.socialPosts.map((p) => (
+          <a
+            key={p.id}
+            href={p.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.postCard}
+          >
+            <span className={styles.osListMeta}>
+              {p.platformLabel} · {p.date}
+            </span>
+            <span className={styles.postCardTitle}>
+              {p.title || p.description || `${p.platformLabel} post`}
+            </span>
+          </a>
+        ))}
+      </div>
+      <p style={{ marginTop: "1.5rem" }}>
+        <Link href="/posts" className={styles.linkOut}>
+          All posts →
+        </Link>
+      </p>
+    </article>
+  );
+}
+
+function SkillsTab() {
+  return (
+    <article>
+      <h1>Skills</h1>
+      <p>
+        The curated skills catalog — full skill bodies plus browse-friendly
+        metadata — lives on its own page.
+      </p>
+      <p style={{ marginTop: "1rem" }}>
+        <Link href="/skills" className={styles.linkOut}>
+          Open /skills →
+        </Link>
+      </p>
+    </article>
+  );
+}
+
+function ContactTab({ data }: { data: PalaceData }) {
+  return (
+    <article>
+      <h1>Contact</h1>
+      <p>The usual suspects.</p>
+      <div
+        className={styles.contactList}
+        role="list"
+        aria-label="Contact links"
+      >
+        {data.contact.map((c) => (
+          <Fragment key={c.href}>
+            <div className="dt">{c.label}</div>
+            <div>
+              <a
+                href={c.href}
+                target={c.href.startsWith("mailto") ? undefined : "_blank"}
+                rel="noopener noreferrer"
+              >
+                {c.display}
+              </a>
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/personal-site/app/palace/ui/BingranOS.tsx
+++ b/personal-site/app/palace/ui/BingranOS.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import type { PalaceData } from "../palace-data";
 import styles from "../styles.module.css";
+import { Tetris } from "./games/Tetris";
+import { Snake } from "./games/Snake";
 
 type TabId =
   | "about"
@@ -12,6 +14,8 @@ type TabId =
   | "blog"
   | "posts"
   | "skills"
+  | "tetris"
+  | "snake"
   | "contact";
 
 const TABS: { id: TabId; label: string; glyph: string }[] = [
@@ -21,6 +25,8 @@ const TABS: { id: TabId; label: string; glyph: string }[] = [
   { id: "blog", label: "Blog", glyph: "❖" },
   { id: "posts", label: "Posts", glyph: "◉" },
   { id: "skills", label: "Skills", glyph: "✦" },
+  { id: "tetris", label: "Tetris", glyph: "▢" },
+  { id: "snake", label: "Snake", glyph: "▷" },
   { id: "contact", label: "Contact", glyph: "@" },
 ];
 
@@ -28,16 +34,36 @@ export function BingranOS({
   data,
   visible,
   onClose,
+  initialTab,
 }: {
   data: PalaceData;
   visible: boolean;
   onClose: () => void;
+  initialTab?: string | null;
 }) {
-  const [tab, setTab] = useState<TabId>("about");
+  const [tab, setTab] = useState<TabId>(() => {
+    const requested = initialTab as TabId | null | undefined;
+    return requested && TABS.some((t) => t.id === requested) ? requested : "about";
+  });
+  const lastVisibleRef = useRef(visible);
+  const lastInitialTabRef = useRef(initialTab);
 
+  // Reset tab when the OS opens, honouring an `initialTab` hint if present.
+  // We compare against refs so the deps array stays a fixed shape — passing
+  // props in as deps triggers a React DEV warning when their reference types
+  // shift across renders.
   useEffect(() => {
-    if (visible) setTab("about");
-  }, [visible]);
+    const justOpened = visible && !lastVisibleRef.current;
+    const initialTabChanged = initialTab !== lastInitialTabRef.current;
+    lastVisibleRef.current = visible;
+    lastInitialTabRef.current = initialTab;
+    if (!visible) return;
+    if (justOpened || initialTabChanged) {
+      const requested = initialTab as TabId | null | undefined;
+      if (requested && TABS.some((t) => t.id === requested)) setTab(requested);
+      else if (justOpened) setTab("about");
+    }
+  });
 
   return (
     <div
@@ -101,6 +127,8 @@ export function BingranOS({
               {tab === "blog" && <BlogTab data={data} />}
               {tab === "posts" && <PostsTab data={data} />}
               {tab === "skills" && <SkillsTab />}
+              {tab === "tetris" && <Tetris active={visible && tab === "tetris"} />}
+              {tab === "snake" && <Snake active={visible && tab === "snake"} />}
               {tab === "contact" && <ContactTab data={data} />}
             </div>
           </section>

--- a/personal-site/app/palace/ui/HUD.tsx
+++ b/personal-site/app/palace/ui/HUD.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import styles from "../styles.module.css";
+import type { PalaceMode } from "../PalaceClient";
+
+export function HUD({
+  mode,
+  onExitMonitor,
+}: {
+  mode: PalaceMode;
+  onExitMonitor: () => void;
+}) {
+  return (
+    <div className={`palace-hud ${styles.hud}`}>
+      <div className={styles.hudTop}>
+        <Link href="/" className={styles.hudBrand}>
+          ← bingran.you
+        </Link>
+        <span className={styles.hudHint}>
+          <span className={styles.dot} />
+          Memory Palace · v1
+        </span>
+      </div>
+      <div className={styles.hudBottom}>
+        <span className={styles.hudHint}>
+          {mode === "idle" ? (
+            <>Move mouse to look · Click the monitor to enter</>
+          ) : mode === "monitor" ? (
+            <>
+              Press <kbd>ESC</kbd> to step back
+            </>
+          ) : (
+            <>Booting…</>
+          )}
+        </span>
+        {mode === "monitor" ? (
+          <button
+            type="button"
+            className={styles.hudExit}
+            onClick={onExitMonitor}
+          >
+            Exit screen
+          </button>
+        ) : (
+          <Link href="/" className={styles.hudExit}>
+            Plain text site →
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/personal-site/app/palace/ui/IntroOverlay.tsx
+++ b/personal-site/app/palace/ui/IntroOverlay.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import styles from "../styles.module.css";
+
+export function IntroOverlay({
+  visible,
+  onEnter,
+}: {
+  visible: boolean;
+  onEnter: () => void;
+}) {
+  return (
+    <div
+      className={`palace-intro ${styles.intro} ${visible ? "" : styles.hidden}`}
+      aria-hidden={!visible}
+    >
+      <p className={styles.introCaption}>bingranyou.com · memory palace · v1</p>
+      <h2 className={styles.introTitle}>Bingran You</h2>
+      <p className={styles.introSubtitle} lang="zh-Hans">
+        尤炳然
+      </p>
+      <button type="button" className={styles.introCta} onClick={onEnter}>
+        Enter the room →
+      </button>
+    </div>
+  );
+}

--- a/personal-site/app/palace/ui/games/Snake.tsx
+++ b/personal-site/app/palace/ui/games/Snake.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import styles from "../../styles.module.css";
+
+const SIZE = 20;
+const START_TICK_MS = 140;
+
+type Vec = [number, number];
+type Dir = "up" | "down" | "left" | "right";
+
+const DIRS: Record<Dir, Vec> = {
+  up: [0, -1],
+  down: [0, 1],
+  left: [-1, 0],
+  right: [1, 0],
+};
+
+const OPPOSITE: Record<Dir, Dir> = {
+  up: "down",
+  down: "up",
+  left: "right",
+  right: "left",
+};
+
+type State = {
+  snake: Vec[];
+  dir: Dir;
+  queuedDir: Dir;
+  food: Vec;
+  score: number;
+  best: number;
+  gameOver: boolean;
+  started: boolean;
+};
+
+function spawnFood(snake: Vec[]): Vec {
+  while (true) {
+    const f: Vec = [
+      Math.floor(Math.random() * SIZE),
+      Math.floor(Math.random() * SIZE),
+    ];
+    if (!snake.some(([x, y]) => x === f[0] && y === f[1])) return f;
+  }
+}
+
+function freshState(best: number): State {
+  const snake: Vec[] = [
+    [10, 10],
+    [9, 10],
+    [8, 10],
+  ];
+  return {
+    snake,
+    dir: "right",
+    queuedDir: "right",
+    food: spawnFood(snake),
+    score: 0,
+    best,
+    gameOver: false,
+    started: true,
+  };
+}
+
+type Action =
+  | { type: "start" }
+  | { type: "tick" }
+  | { type: "turn"; dir: Dir }
+  | { type: "reset" };
+
+function reducer(state: State, action: Action): State {
+  if (action.type === "start" || action.type === "reset") {
+    return freshState(state.best);
+  }
+  if (!state.started || state.gameOver) return state;
+  if (action.type === "turn") {
+    if (action.dir === OPPOSITE[state.dir]) return state;
+    return { ...state, queuedDir: action.dir };
+  }
+  if (action.type === "tick") {
+    const dir = state.queuedDir;
+    const [hx, hy] = state.snake[0];
+    const [dx, dy] = DIRS[dir];
+    const next: Vec = [hx + dx, hy + dy];
+    // Wall collision
+    if (next[0] < 0 || next[0] >= SIZE || next[1] < 0 || next[1] >= SIZE) {
+      return { ...state, gameOver: true, best: Math.max(state.best, state.score) };
+    }
+    // Self collision (skip tail tip if it will move)
+    const willGrow =
+      next[0] === state.food[0] && next[1] === state.food[1];
+    const bodyToCheck = willGrow ? state.snake : state.snake.slice(0, -1);
+    if (bodyToCheck.some(([x, y]) => x === next[0] && y === next[1])) {
+      return { ...state, gameOver: true, best: Math.max(state.best, state.score) };
+    }
+    const snake = willGrow
+      ? [next, ...state.snake]
+      : [next, ...state.snake.slice(0, -1)];
+    const food = willGrow ? spawnFood(snake) : state.food;
+    const score = willGrow ? state.score + 1 : state.score;
+    return { ...state, snake, dir, food, score };
+  }
+  return state;
+}
+
+function initial(): State {
+  return {
+    snake: [],
+    dir: "right",
+    queuedDir: "right",
+    food: [0, 0],
+    score: 0,
+    best: 0,
+    gameOver: false,
+    started: false,
+  };
+}
+
+export function Snake({ active }: { active: boolean }) {
+  const [state, dispatch] = useReducer(reducer, undefined, initial);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Tick interval scales mildly with score
+  const tickMs = useMemo(() => {
+    return Math.max(70, START_TICK_MS - state.score * 2);
+  }, [state.score]);
+
+  useEffect(() => {
+    if (!active || !state.started || state.gameOver) return;
+    const id = setInterval(() => dispatch({ type: "tick" }), tickMs);
+    return () => clearInterval(id);
+  }, [active, state.started, state.gameOver, tickMs]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      const k = e.key;
+      if (!state.started || state.gameOver) {
+        if (
+          k === "Enter" ||
+          k === " " ||
+          k === "r" ||
+          k === "R" ||
+          k.startsWith("Arrow")
+        ) {
+          e.preventDefault();
+          dispatch({ type: "reset" });
+        }
+        return;
+      }
+      if (k === "ArrowUp" || k === "w" || k === "W") {
+        e.preventDefault();
+        dispatch({ type: "turn", dir: "up" });
+      } else if (k === "ArrowDown" || k === "s" || k === "S") {
+        e.preventDefault();
+        dispatch({ type: "turn", dir: "down" });
+      } else if (k === "ArrowLeft" || k === "a" || k === "A") {
+        e.preventDefault();
+        dispatch({ type: "turn", dir: "left" });
+      } else if (k === "ArrowRight" || k === "d" || k === "D") {
+        e.preventDefault();
+        dispatch({ type: "turn", dir: "right" });
+      } else if (k === "r" || k === "R") {
+        e.preventDefault();
+        dispatch({ type: "reset" });
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, state.started, state.gameOver]);
+
+  // Render grid
+  const cells = useMemo(() => {
+    const map: Array<"empty" | "head" | "body" | "food"> = Array(
+      SIZE * SIZE,
+    ).fill("empty");
+    state.snake.forEach(([x, y], i) => {
+      map[y * SIZE + x] = i === 0 ? "head" : "body";
+    });
+    const [fx, fy] = state.food;
+    if (state.snake.length) map[fy * SIZE + fx] = "food";
+    return map;
+  }, [state.snake, state.food]);
+
+  const start = useCallback(() => dispatch({ type: "reset" }), []);
+
+  return (
+    <div className={styles.gameLayout} ref={containerRef}>
+      <div className={styles.gameBoard}>
+        <div
+          className={styles.snakeGrid}
+          style={{
+            gridTemplateColumns: `repeat(${SIZE}, 1fr)`,
+            gridTemplateRows: `repeat(${SIZE}, 1fr)`,
+          }}
+        >
+          {cells.map((c, i) => (
+            <div
+              key={i}
+              className={styles.cell}
+              style={{
+                background:
+                  c === "head"
+                    ? "#7d2e10"
+                    : c === "body"
+                      ? "#a8431c"
+                      : c === "food"
+                        ? "#6a8d4a"
+                        : "transparent",
+                borderColor:
+                  c === "empty" ? "rgba(31,26,20,0.04)" : "rgba(0,0,0,0.2)",
+                borderRadius: c === "food" ? "50%" : 0,
+              }}
+            />
+          ))}
+        </div>
+        {(!state.started || state.gameOver) && (
+          <div className={styles.gameOverlay}>
+            <p className={styles.gameOverlayTitle}>
+              {state.gameOver ? "Game over" : "Snake"}
+            </p>
+            <p className={styles.gameOverlayMeta}>
+              {state.gameOver
+                ? `Score ${state.score} · Best ${state.best}`
+                : "Arrow keys / WASD · R to reset"}
+            </p>
+            <button
+              type="button"
+              className={styles.gameStartBtn}
+              onClick={start}
+            >
+              {state.gameOver ? "Play again" : "Start"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      <aside className={styles.gameSide}>
+        <div className={styles.gameStat}>
+          <span className={styles.gameStatLabel}>Score</span>
+          <span className={styles.gameStatValue}>{state.score}</span>
+        </div>
+        <div className={styles.gameStat}>
+          <span className={styles.gameStatLabel}>Best</span>
+          <span className={styles.gameStatValue}>{state.best}</span>
+        </div>
+        <p className={styles.gameHelp}>
+          ↑ ↓ ← →  /  W A S D
+          <br />R reset
+        </p>
+      </aside>
+    </div>
+  );
+}

--- a/personal-site/app/palace/ui/games/Tetris.tsx
+++ b/personal-site/app/palace/ui/games/Tetris.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import styles from "../../styles.module.css";
+
+const ROWS = 20;
+const COLS = 10;
+const TICK_MS = 600;
+
+type ShapeId = "I" | "O" | "T" | "S" | "Z" | "L" | "J";
+
+const SHAPES: Record<ShapeId, number[][]> = {
+  I: [[1, 1, 1, 1]],
+  O: [
+    [1, 1],
+    [1, 1],
+  ],
+  T: [
+    [0, 1, 0],
+    [1, 1, 1],
+  ],
+  S: [
+    [0, 1, 1],
+    [1, 1, 0],
+  ],
+  Z: [
+    [1, 1, 0],
+    [0, 1, 1],
+  ],
+  L: [
+    [1, 0],
+    [1, 0],
+    [1, 1],
+  ],
+  J: [
+    [0, 1],
+    [0, 1],
+    [1, 1],
+  ],
+};
+
+const COLORS: Record<ShapeId, string> = {
+  I: "#4d8fb0",
+  O: "#d4b153",
+  T: "#a8431c",
+  S: "#6a8d4a",
+  Z: "#a83e3e",
+  L: "#c47a3a",
+  J: "#5a6aa8",
+};
+
+const SHAPE_IDS = Object.keys(SHAPES) as ShapeId[];
+
+type Piece = {
+  id: ShapeId;
+  shape: number[][];
+  x: number;
+  y: number;
+};
+
+type Grid = (ShapeId | 0)[][];
+
+type State = {
+  grid: Grid;
+  piece: Piece | null;
+  next: ShapeId;
+  score: number;
+  lines: number;
+  gameOver: boolean;
+  started: boolean;
+};
+
+function emptyGrid(): Grid {
+  return Array.from({ length: ROWS }, () => Array(COLS).fill(0) as (ShapeId | 0)[]);
+}
+
+function randomShape(): ShapeId {
+  return SHAPE_IDS[Math.floor(Math.random() * SHAPE_IDS.length)];
+}
+
+function spawnPiece(id: ShapeId): Piece {
+  const shape = SHAPES[id].map((row) => [...row]);
+  return {
+    id,
+    shape,
+    x: Math.floor((COLS - shape[0].length) / 2),
+    y: 0,
+  };
+}
+
+function rotate(shape: number[][]): number[][] {
+  const rows = shape.length;
+  const cols = shape[0].length;
+  const out = Array.from({ length: cols }, () => Array(rows).fill(0));
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      out[x][rows - 1 - y] = shape[y][x];
+    }
+  }
+  return out;
+}
+
+function collides(grid: Grid, piece: Piece): boolean {
+  for (let y = 0; y < piece.shape.length; y++) {
+    for (let x = 0; x < piece.shape[y].length; x++) {
+      if (!piece.shape[y][x]) continue;
+      const gx = piece.x + x;
+      const gy = piece.y + y;
+      if (gx < 0 || gx >= COLS || gy >= ROWS) return true;
+      if (gy >= 0 && grid[gy][gx]) return true;
+    }
+  }
+  return false;
+}
+
+function lockPiece(grid: Grid, piece: Piece): Grid {
+  const out = grid.map((row) => [...row]) as Grid;
+  for (let y = 0; y < piece.shape.length; y++) {
+    for (let x = 0; x < piece.shape[y].length; x++) {
+      if (piece.shape[y][x] && piece.y + y >= 0) {
+        out[piece.y + y][piece.x + x] = piece.id;
+      }
+    }
+  }
+  return out;
+}
+
+function clearLines(grid: Grid): { grid: Grid; cleared: number } {
+  const keep = grid.filter((row) => row.some((c) => !c));
+  const cleared = ROWS - keep.length;
+  const filled: Grid = Array.from({ length: cleared }, () =>
+    Array(COLS).fill(0) as (ShapeId | 0)[],
+  );
+  return { grid: [...filled, ...keep], cleared };
+}
+
+type Action =
+  | { type: "start" }
+  | { type: "tick" }
+  | { type: "move"; dx: number }
+  | { type: "soft" }
+  | { type: "hard" }
+  | { type: "rotate" }
+  | { type: "reset" };
+
+function reducer(state: State, action: Action): State {
+  if (action.type === "reset" || action.type === "start") {
+    const first = randomShape();
+    const second = randomShape();
+    return {
+      grid: emptyGrid(),
+      piece: spawnPiece(first),
+      next: second,
+      score: 0,
+      lines: 0,
+      gameOver: false,
+      started: true,
+    };
+  }
+
+  if (!state.started || state.gameOver || !state.piece) return state;
+
+  if (action.type === "tick" || action.type === "soft") {
+    const moved = { ...state.piece, y: state.piece.y + 1 };
+    if (!collides(state.grid, moved)) {
+      return {
+        ...state,
+        piece: moved,
+        score: action.type === "soft" ? state.score + 1 : state.score,
+      };
+    }
+    // Lock + clear
+    const locked = lockPiece(state.grid, state.piece);
+    const { grid: cleared, cleared: rows } = clearLines(locked);
+    const nextPiece = spawnPiece(state.next);
+    const lineScore = [0, 40, 100, 300, 1200][rows] ?? 0;
+    if (collides(cleared, nextPiece)) {
+      return {
+        ...state,
+        grid: cleared,
+        piece: null,
+        score: state.score + lineScore,
+        lines: state.lines + rows,
+        gameOver: true,
+      };
+    }
+    return {
+      ...state,
+      grid: cleared,
+      piece: nextPiece,
+      next: randomShape(),
+      score: state.score + lineScore,
+      lines: state.lines + rows,
+    };
+  }
+
+  if (action.type === "move") {
+    const moved = { ...state.piece, x: state.piece.x + action.dx };
+    if (!collides(state.grid, moved)) return { ...state, piece: moved };
+    return state;
+  }
+
+  if (action.type === "rotate") {
+    const rotated = { ...state.piece, shape: rotate(state.piece.shape) };
+    // Try wall kicks
+    for (const dx of [0, -1, 1, -2, 2]) {
+      const candidate = { ...rotated, x: rotated.x + dx };
+      if (!collides(state.grid, candidate)) return { ...state, piece: candidate };
+    }
+    return state;
+  }
+
+  if (action.type === "hard") {
+    let piece = state.piece;
+    let drop = 0;
+    while (!collides(state.grid, { ...piece, y: piece.y + 1 })) {
+      piece = { ...piece, y: piece.y + 1 };
+      drop++;
+    }
+    const locked = lockPiece(state.grid, piece);
+    const { grid: cleared, cleared: rows } = clearLines(locked);
+    const nextPiece = spawnPiece(state.next);
+    const lineScore = [0, 40, 100, 300, 1200][rows] ?? 0;
+    if (collides(cleared, nextPiece)) {
+      return {
+        ...state,
+        grid: cleared,
+        piece: null,
+        score: state.score + lineScore + drop * 2,
+        lines: state.lines + rows,
+        gameOver: true,
+      };
+    }
+    return {
+      ...state,
+      grid: cleared,
+      piece: nextPiece,
+      next: randomShape(),
+      score: state.score + lineScore + drop * 2,
+      lines: state.lines + rows,
+    };
+  }
+
+  return state;
+}
+
+function initialState(): State {
+  return {
+    grid: emptyGrid(),
+    piece: null,
+    next: randomShape(),
+    score: 0,
+    lines: 0,
+    gameOver: false,
+    started: false,
+  };
+}
+
+export function Tetris({ active }: { active: boolean }) {
+  const [state, dispatch] = useReducer(reducer, undefined, initialState);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Drop tick — speeds up by 25ms per 10 lines, floor 90ms
+  const tickMs = useMemo(() => {
+    return Math.max(90, TICK_MS - Math.floor(state.lines / 10) * 80);
+  }, [state.lines]);
+
+  useEffect(() => {
+    if (!active || !state.started || state.gameOver) return;
+    const id = setInterval(() => dispatch({ type: "tick" }), tickMs);
+    return () => clearInterval(id);
+  }, [active, state.started, state.gameOver, tickMs]);
+
+  // Keyboard
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      const k = e.key;
+      if (!state.started || state.gameOver) {
+        if (k === "Enter" || k === " " || k === "r" || k === "R") {
+          e.preventDefault();
+          dispatch({ type: "reset" });
+        }
+        return;
+      }
+      if (k === "ArrowLeft") {
+        e.preventDefault();
+        dispatch({ type: "move", dx: -1 });
+      } else if (k === "ArrowRight") {
+        e.preventDefault();
+        dispatch({ type: "move", dx: 1 });
+      } else if (k === "ArrowDown") {
+        e.preventDefault();
+        dispatch({ type: "soft" });
+      } else if (k === "ArrowUp" || k === "x" || k === "X") {
+        e.preventDefault();
+        dispatch({ type: "rotate" });
+      } else if (k === " ") {
+        e.preventDefault();
+        dispatch({ type: "hard" });
+      } else if (k === "r" || k === "R") {
+        e.preventDefault();
+        dispatch({ type: "reset" });
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, state.started, state.gameOver]);
+
+  // Compose displayed grid (locked + falling)
+  const display = useMemo<Grid>(() => {
+    const out: Grid = state.grid.map((row) => [...row]);
+    if (state.piece) {
+      for (let y = 0; y < state.piece.shape.length; y++) {
+        for (let x = 0; x < state.piece.shape[y].length; x++) {
+          if (state.piece.shape[y][x] && state.piece.y + y >= 0) {
+            out[state.piece.y + y][state.piece.x + x] = state.piece.id;
+          }
+        }
+      }
+    }
+    return out;
+  }, [state.grid, state.piece]);
+
+  // Next piece preview
+  const nextShape = SHAPES[state.next];
+  const nextRows = nextShape.length;
+  const nextCols = nextShape[0].length;
+
+  const start = useCallback(() => dispatch({ type: "reset" }), []);
+
+  return (
+    <div className={styles.gameLayout} ref={containerRef}>
+      <div className={styles.gameBoard}>
+        <div
+          className={styles.tetrisGrid}
+          style={{
+            gridTemplateColumns: `repeat(${COLS}, 1fr)`,
+            gridTemplateRows: `repeat(${ROWS}, 1fr)`,
+          }}
+        >
+          {display.flatMap((row, y) =>
+            row.map((cell, x) => (
+              <div
+                key={`${x}-${y}`}
+                className={styles.cell}
+                style={{
+                  background: cell ? COLORS[cell] : "transparent",
+                  borderColor: cell ? "rgba(0,0,0,0.18)" : "rgba(31,26,20,0.06)",
+                }}
+              />
+            )),
+          )}
+        </div>
+        {(!state.started || state.gameOver) && (
+          <div className={styles.gameOverlay}>
+            <p className={styles.gameOverlayTitle}>
+              {state.gameOver ? "Game over" : "Tetris"}
+            </p>
+            {state.gameOver ? (
+              <p className={styles.gameOverlayMeta}>
+                Score {state.score} · Lines {state.lines}
+              </p>
+            ) : (
+              <p className={styles.gameOverlayMeta}>
+                ←→ move · ↑ rotate · ↓ soft drop · space hard drop · R reset
+              </p>
+            )}
+            <button
+              type="button"
+              className={styles.gameStartBtn}
+              onClick={start}
+            >
+              {state.gameOver ? "Play again" : "Start"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      <aside className={styles.gameSide}>
+        <div className={styles.gameStat}>
+          <span className={styles.gameStatLabel}>Score</span>
+          <span className={styles.gameStatValue}>{state.score}</span>
+        </div>
+        <div className={styles.gameStat}>
+          <span className={styles.gameStatLabel}>Lines</span>
+          <span className={styles.gameStatValue}>{state.lines}</span>
+        </div>
+        <div className={styles.gameStat}>
+          <span className={styles.gameStatLabel}>Next</span>
+          <div
+            className={styles.nextGrid}
+            style={{
+              gridTemplateColumns: `repeat(${nextCols}, 1fr)`,
+              gridTemplateRows: `repeat(${nextRows}, 1fr)`,
+            }}
+          >
+            {nextShape.flatMap((row, y) =>
+              row.map((cell, x) => (
+                <div
+                  key={`${x}-${y}`}
+                  className={styles.cell}
+                  style={{
+                    background: cell ? COLORS[state.next] : "transparent",
+                    borderColor: cell
+                      ? "rgba(0,0,0,0.18)"
+                      : "transparent",
+                  }}
+                />
+              )),
+            )}
+          </div>
+        </div>
+        <p className={styles.gameHelp}>
+          ← → move<br />↑ / X rotate<br />↓ soft drop<br />space hard drop<br />R reset
+        </p>
+      </aside>
+    </div>
+  );
+}

--- a/personal-site/app/sitemap.ts
+++ b/personal-site/app/sitemap.ts
@@ -119,6 +119,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly",
       priority: 0.9,
     },
+    {
+      url: `${SITE_URL}/palace`,
+      lastModified: await getLatestLastModified([
+        "app/palace/page.tsx",
+        "app/palace/PalaceClient.tsx",
+        "app/palace/palace-data.ts",
+      ]),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
   ];
 
   const skillEntries: MetadataRoute.Sitemap = getAllSkills().map((skill) => ({

--- a/personal-site/components/site-nav.tsx
+++ b/personal-site/components/site-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 const nav = [
+  { href: "/palace", label: "Palace" },
   { href: "/projects", label: "Projects" },
   { href: "/papers", label: "Papers" },
   { href: "/skills", label: "Skills" },

--- a/personal-site/package-lock.json
+++ b/personal-site/package-lock.json
@@ -11,6 +11,8 @@
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.2.4",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "@tailwindcss/typography": "^0.5.19",
         "@types/mdx": "^2.0.13",
         "gray-matter": "^4.0.3",
@@ -20,13 +22,15 @@
         "react-tweet": "^3.3.0",
         "rehype-pretty-code": "^0.14.3",
         "remark-gfm": "^4.0.1",
-        "shiki": "^4.0.2"
+        "shiki": "^4.0.2",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/three": "^0.184.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "marked": "^18.0.3",
@@ -240,6 +244,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -287,6 +300,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -1123,6 +1142,24 @@
         "react": ">=16"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1357,6 +1394,94 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2048,6 +2173,12 @@
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2084,6 +2215,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2155,6 +2292,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2174,10 +2317,45 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2750,6 +2928,24 @@
         "win32"
       ]
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -3183,6 +3379,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.25",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
@@ -3193,6 +3409,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -3253,6 +3478,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -3311,6 +3560,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3479,11 +3741,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3655,6 +3934,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3690,6 +3978,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4584,6 +4878,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4852,6 +5152,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -5193,6 +5499,12 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -5203,6 +5515,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5212,6 +5544,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -5596,6 +5934,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5752,7 +6096,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -5771,6 +6114,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jiti": {
@@ -5917,6 +6272,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -6234,6 +6598,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
       }
     },
     "node_modules/magic-string": {
@@ -6599,6 +6973,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -7797,7 +8186,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7888,6 +8276,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7896,6 +8290,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -7992,6 +8396,21 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/recma-build-jsx": {
@@ -8257,6 +8676,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -8567,7 +8995,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8580,7 +9007,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8734,6 +9160,32 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/std-env": {
@@ -8983,6 +9435,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/swr": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
@@ -9015,6 +9476,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -9114,6 +9613,36 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -9168,6 +9697,43 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9515,6 +10081,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -9761,11 +10336,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9934,6 +10519,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/personal-site/package.json
+++ b/personal-site/package.json
@@ -17,6 +17,8 @@
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^16.2.4",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@tailwindcss/typography": "^0.5.19",
     "@types/mdx": "^2.0.13",
     "gray-matter": "^4.0.3",
@@ -26,13 +28,15 @@
     "react-tweet": "^3.3.0",
     "rehype-pretty-code": "^0.14.3",
     "remark-gfm": "^4.0.1",
-    "shiki": "^4.0.2"
+    "shiki": "^4.0.2",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.184.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "marked": "^18.0.3",


### PR DESCRIPTION
## Summary

- Adds `/palace`, a Henry Heffernan-style 3D room (desk, CRT-style monitor, lamp, books, plant, shelf, picture frame, floor rug) rendered with React Three Fiber. Click the monitor → camera dollies in and a paper-warm **BingranOS** overlay fades up with windows for About / Projects / Papers / Blog / Posts / Skills / Contact.
- Content is sourced *strictly* from existing data (`lib/content.ts`, `content/posts/*.mdx`, `content/social/posts.json`, `lib/jsonld.ts`) — nothing is rewritten or duplicated.
- The route ships a visually-hidden, fully-populated text index (~80KB) so search engines, LLM agents, and JS-disabled clients still see every project, paper, blog post, social post, education entry, and contact link. `<noscript>` flips the index to visible and hides the canvas.
- New top-level `Palace` nav entry, pulsing "Enter the Memory Palace" CTA on the home hero, `/palace` added to `sitemap.ts` and `llms.txt`.

## What changed

- `personal-site/app/palace/` — new route, 16 files
  - `page.tsx` (server) + `PalaceMount.tsx` (client wrapper, `dynamic({ ssr: false })`)
  - `PalaceClient.tsx` — state machine: `intro` → `idle` → `monitor`, auto-skip intro at 5s, ESC closes monitor
  - `palace-data.ts` — assembles data once at build time
  - `SsrLayer.tsx` — sr-only HTML index for agents + crawlers
  - `scene/{Room,Desk,Computer,Decor,Lighting,CameraRig}.tsx` — primitive-mesh room geometry, aspect-aware FOV so phones still see the desk
  - `ui/{IntroOverlay,HUD,BingranOS}.tsx` — title card, corner hints + brand link, full OS overlay
  - `styles.module.css`
- `app/(personal)/page.tsx` — Memory Palace CTA pill on home hero
- `components/site-nav.tsx` — `Palace` nav entry
- `app/sitemap.ts`, `app/llms.txt/route.ts` — register `/palace`
- `personal-site/.gitignore` — ignore local `.claude/` preview config
- `package.json` — `three@^0.184`, `@react-three/fiber@^9.6`, `@react-three/drei@^10.7`, `@types/three`

## Test plan

- [x] `npm run build` — green, `/palace` prerendered as static HTML
- [x] Static HTML carries content for crawlers (`Bingran You`×42, `尤炳然`×18, `SkillsBench`, `DoWhiz`, `first-tree`, `Haeffner`, `trapped-ion`, `me@bingranyou` all present, JSON-LD ProfilePage in `<head>`)
- [x] `npm run dev` → `/palace` renders the room; clicking the monitor opens BingranOS About; switching to Projects/Posts swaps content sourced from existing site data; ESC returns to the room
- [x] Home page shows the pulsing CTA and links to `/palace`
- [x] Console: no errors, only three.js deprecation warnings (Clock, PCFSoftShadowMap) from drei internals — non-actionable

## Notes / follow-ups (not in this PR)

- The screen currently shows abstract bars + a "bingranyou.com" hint; a canvas-texture mock desktop would feel more "Henry-like" but adds complexity. Defer.
- Aspect-aware FOV scales for portrait; on very tall phones, room still reads but composition could use a separate mobile camera preset.
- Three.js deprecation warnings will disappear when `@react-three/fiber` updates internals.