### PR TITLE
personal-site: /palace — project BingranOS into monitor via <Html transform>

### DIFF
--- a/personal-site/app/palace/PalaceClient.tsx
+++ b/personal-site/app/palace/PalaceClient.tsx
@@ -9,7 +9,6 @@ import { BakedScene } from "./scene/BakedScene";
 import { CameraRig } from "./scene/CameraRig";
 import { IntroOverlay } from "./ui/IntroOverlay";
 import { HUD } from "./ui/HUD";
-import { BingranOS } from "./ui/BingranOS";
 
 export type PalaceMode = "intro" | "idle" | "monitor";
 
@@ -33,10 +32,6 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
   }, []);
   const [mode, setMode] = useState<PalaceMode>(initialTab ? "monitor" : "intro");
   const [osTab, setOsTab] = useState<string | null>(initialTab);
-  // OS overlay only appears AFTER the dolly-in completes — keeps the
-  // entrance feeling like Henry's where you actually arrive at the screen
-  // before any UI surfaces.
-  const [osReady, setOsReady] = useState(false);
   const mouseRef = useRef<[number, number]>([0, 0]);
 
   const enterRoom = useCallback(() => setMode("idle"), []);
@@ -57,19 +52,6 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
     if (mode !== "intro") return;
     const t = setTimeout(() => setMode("idle"), 5000);
     return () => clearTimeout(t);
-  }, [mode]);
-
-  // Hold the OS overlay back until the camera has nearly arrived at the
-  // monitor pose (camera dolly-in is 1.15s; we wait 0.95s so the OS fades
-  // up over the final 200ms of camera travel + its own 0.45s opacity
-  // transition). On exit, drop it immediately so the panel fades out
-  // while the camera is still close to the screen.
-  useEffect(() => {
-    if (mode === "monitor") {
-      const t = setTimeout(() => setOsReady(true), 950);
-      return () => clearTimeout(t);
-    }
-    setOsReady(false);
   }, [mode]);
 
   // React to hash changes (allows linking between tabs without reload)
@@ -124,7 +106,15 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
         >
           <color attach="background" args={["#0a0805"]} />
           <Suspense fallback={null}>
-            <BakedScene onScreenClick={enterMonitor} />
+            <BakedScene
+              onScreenClick={enterMonitor}
+              os={{
+                data,
+                active: mode === "monitor",
+                initialTab: osTab,
+                onClose: exitMonitor,
+              }}
+            />
           </Suspense>
           <CameraRig mode={mode} mouseRef={mouseRef} />
         </Canvas>
@@ -132,12 +122,6 @@ export default function PalaceClient({ data }: { data: PalaceData }) {
 
       <IntroOverlay visible={mode === "intro"} onEnter={enterRoom} />
       <HUD mode={mode} onExitMonitor={exitMonitor} />
-      <BingranOS
-        data={data}
-        visible={mode === "monitor" && osReady}
-        initialTab={osTab}
-        onClose={exitMonitor}
-      />
     </>
   );
 }

--- a/personal-site/app/palace/scene/BakedScene.tsx
+++ b/personal-site/app/palace/scene/BakedScene.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useTexture } from "@react-three/drei";
+import { Html } from "@react-three/drei";
 import * as THREE from "three";
 import { BakedGLB, preloadBakedAssets } from "./BakedGLB";
+import { BingranOS } from "../ui/BingranOS";
+import type { PalaceData } from "../palace-data";
+import styles from "../styles.module.css";
 
 // preload the three GLB + JPG pairs in module scope so they hit the cache
 // before Canvas mounts. drei's useGLTF.preload is the r3f equivalent of
@@ -21,15 +24,45 @@ export const MODEL_SCALE = 0.15;
 
 // Monitor face world position at MODEL_SCALE=0.15. Used by CameraRig for the
 // "inside the monitor" pose and by the click hitbox below.
-export const MONITOR_POSITION = new THREE.Vector3(0, 0.22, 0.005);
-const MONITOR_WIDTH = 0.27;
-const MONITOR_HEIGHT = 0.2;
+// Calibrated from monitor_base mesh in computer_setup.glb: CRT head (z>0.45 in
+// model space) spans y=[0.35, 1.79], so screen mid-y ≈ 1.07 → 0.16 at scale.
+// Bezel front sits at z=0.59 raw → 0.089 scaled, so place the screen plane at
+// z=0.092 (a hair forward) to sit on the screen glass without z-fighting.
+export const MONITOR_POSITION = new THREE.Vector3(0, 0.165, 0.092);
+const MONITOR_WIDTH = 0.2;
+const MONITOR_HEIGHT = 0.15;
+
+// HTML container size (CSS px) for the projected BingranOS. 1024×768 is 4:3
+// — matches the CRT screen face aspect exactly so the OS fills the monitor
+// glass edge-to-edge with no letterbox bands.
+const MONITOR_HTML_WIDTH = 1024;
+const MONITOR_HTML_HEIGHT = 768;
+// drei's <Html transform> internally divides the object matrix by 40
+// (factor = 1 / ((distanceFactor||10) / 400) = 40 with default props), so
+// the raw scale prop is in units of "world meters per CSS px / 40".
+// We compensate by multiplying our intended world-meters-per-CSS-px ratio
+// by 40 so the projected HTML matches the monitor screen size exactly.
+//   intended scale (m/px) = MONITOR_WIDTH / MONITOR_HTML_WIDTH ≈ 0.000195
+//   drei-compensated      = intended * 40                     ≈ 0.0078125
+// Result: HTML container projects to 0.20m × 0.15m — the exact CRT face.
+const DREI_HTML_TRANSFORM_FACTOR = 40;
+const MONITOR_HTML_SCALE =
+  (MONITOR_WIDTH / MONITOR_HTML_WIDTH) * DREI_HTML_TRANSFORM_FACTOR;
+
+export type OsProps = {
+  data: PalaceData;
+  /** True when the OS owns focus (monitor mode). Drives pointer-events. */
+  active: boolean;
+  initialTab: string | null;
+  onClose: () => void;
+};
 
 type Props = {
   onScreenClick: () => void;
+  os: OsProps;
 };
 
-export function BakedScene({ onScreenClick }: Props) {
+export function BakedScene({ onScreenClick, os }: Props) {
   return (
     <group>
       <BakedGLB
@@ -48,49 +81,63 @@ export function BakedScene({ onScreenClick }: Props) {
         scale={MODEL_SCALE}
       />
 
-      {/* Subtle CRT smudge sheen on the monitor face — gives the phosphor
-          glass a soft physicality even when the screen is dark. */}
-      <ScreenSheen />
+      {/* The BingranOS UI is permanently projected onto the monitor screen
+          plane via drei <Html transform>. In idle the room camera sees a
+          tiny readable copy of the desktop on the CRT; the dolly-in is a
+          pure camera zoom — no fade, no overlay swap. */}
+      <Html
+        transform
+        position={MONITOR_POSITION}
+        rotation={[0, 0, 0]}
+        scale={MONITOR_HTML_SCALE}
+        zIndexRange={[1, 0]}
+        prepend
+        // The CSS3D layer sits above the WebGL canvas; pointer-events on the
+        // wrapper let clicks pass through to the monitor hitbox in idle.
+        style={{ pointerEvents: os.active ? "auto" : "none" }}
+      >
+        <div
+          className={styles.monitorScreen}
+          style={{
+            width: `${MONITOR_HTML_WIDTH}px`,
+            height: `${MONITOR_HTML_HEIGHT}px`,
+          }}
+        >
+          <BingranOS
+            data={os.data}
+            active={os.active}
+            initialTab={os.initialTab}
+            onClose={os.onClose}
+          />
+        </div>
+      </Html>
 
-      <MonitorHitbox onClick={onScreenClick} />
-    </group>
-  );
-}
-
-function ScreenSheen() {
-  const smudge = useTexture("/palace/textures/monitor-smudge.jpg");
-  return (
-    <group position={MONITOR_POSITION}>
-      <mesh position={[0, 0, 0.001]}>
-        <planeGeometry args={[MONITOR_WIDTH, MONITOR_HEIGHT]} />
-        <meshBasicMaterial color="#0d1a1d" />
-      </mesh>
-      <mesh position={[0, 0, 0.003]}>
-        <planeGeometry args={[MONITOR_WIDTH, MONITOR_HEIGHT]} />
-        <meshBasicMaterial
-          map={smudge}
-          transparent
-          opacity={0.12}
-          blending={THREE.AdditiveBlending}
-          depthWrite={false}
-        />
-      </mesh>
+      <MonitorHitbox onClick={onScreenClick} enabled={!os.active} />
     </group>
   );
 }
 
 // Invisible plane in front of the monitor that picks up clicks and routes
-// them up to the parent (which transitions camera + reveals BingranOS).
-function MonitorHitbox({ onClick }: { onClick: () => void }) {
+// them up to the parent (which transitions the camera into monitor mode).
+// Disabled while OS is active so the HTML projection owns interaction.
+function MonitorHitbox({
+  onClick,
+  enabled,
+}: {
+  onClick: () => void;
+  enabled: boolean;
+}) {
   const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
-    document.body.style.cursor = hovered ? "pointer" : "default";
+    document.body.style.cursor = hovered && enabled ? "pointer" : "default";
     return () => {
       document.body.style.cursor = "default";
     };
-  }, [hovered]);
+  }, [hovered, enabled]);
+
+  if (!enabled) return null;
 
   return (
     <mesh

--- a/personal-site/app/palace/scene/CameraRig.tsx
+++ b/personal-site/app/palace/scene/CameraRig.tsx
@@ -10,30 +10,35 @@ import type { PalaceMode } from "../PalaceClient";
 type Vec3 = [number, number, number];
 
 // Poses calibrated to the baked GLB world (MODEL_SCALE = 0.15 in BakedScene).
-// The Mac monitor face sits at world (0, 0.22, 0), so all targets read low
-// compared to the older procedural setup — the scene is roughly desk-on-floor
-// scale rather than room-with-tall-desk scale.
+// Monitor screen plane sits at z=0.092 with width 0.20m / height 0.15m (4:3).
+// The BingranOS HTML container (1024×768, 4:3) projects to exactly that —
+// no letterbox/pillarbox inside the CRT bezel. Monitor-mode framing fits
+// the screen HEIGHT in viewport so 16:9 viewports show the screen with a
+// small pillarbox of CRT bezel + room around the sides (which sells the
+// "looking at a real monitor" feel rather than a fullscreen-app illusion):
+//   d = 0.32 - 0.092 = 0.228
+//   visible_height = 2 * d * tan(fov/2) = 0.15 → fov ≈ 36.4°
 const CAM: Record<
   PalaceMode,
   { pos: Vec3; look: Vec3; fov: number; duration: number }
 > = {
   intro: {
-    pos: [1.4, 0.95, 2.4],
-    look: [0, 0.2, -0.15],
+    pos: [1.4, 0.85, 2.3],
+    look: [0, 0.15, -0.1],
     fov: 44,
     duration: 2.1,
   },
   idle: {
-    pos: [0.3, 0.55, 1.6],
-    look: [0, 0.12, -0.1],
+    pos: [0.22, 0.45, 1.4],
+    look: [0, 0.12, -0.05],
     fov: 36,
-    duration: 1.45,
+    duration: 1.6,
   },
   monitor: {
-    pos: [0, 0.22, 0.45],
-    look: [0, 0.22, 0],
-    fov: 22,
-    duration: 1.2,
+    pos: [0, 0.165, 0.32],
+    look: [0, 0.165, 0.092],
+    fov: 36,
+    duration: 1.6,
   },
 };
 
@@ -45,10 +50,12 @@ function fovForAspect(baseFov: number, aspect: number) {
   return Math.min(80, newVertical);
 }
 
-// Cubic ease-in-out — the canonical "buttery" curve. Henry Heffernan's site
-// uses a similar shape: slow start, accelerate, slow finish.
-function cubicInOut(t: number) {
-  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+// Quintic ease-in-out — flatter tails than cubic. The flat start and finish
+// matter most for the monitor dolly: the camera "lifts off" and "lands"
+// almost imperceptibly so the zoom reads as one continuous motion rather
+// than a snap-zoom.
+function quintInOut(t: number) {
+  return t < 0.5 ? 16 * t * t * t * t * t : 1 - Math.pow(-2 * t + 2, 5) / 2;
 }
 
 export function CameraRig({
@@ -111,7 +118,7 @@ export function CameraRig({
 
     if (linearT < 1) {
       // Mid-transition: pure time-based ease, no parallax interference.
-      const eased = cubicInOut(linearT);
+      const eased = quintInOut(linearT);
       cam.position.lerpVectors(fromPos.current, baseTargetPos, eased);
       currentLook.current.lerpVectors(fromLook.current, baseTargetLook, eased);
       cam.fov = THREE.MathUtils.lerp(fromFov.current, targetFovAdj, eased);

--- a/personal-site/app/palace/styles.module.css
+++ b/personal-site/app/palace/styles.module.css
@@ -211,43 +211,55 @@
   50% { opacity: 1; transform: scale(1.15); }
 }
 
-/* BingranOS — appears when the user "enters" the monitor */
-.osLayer {
-  position: absolute;
-  inset: 0;
-  z-index: 20;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(1rem, 4vw, 3rem);
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.5s ease;
-  background: radial-gradient(ellipse at 50% 50%, rgba(0, 0, 0, 0) 30%, rgba(0, 0, 0, 0.55) 100%);
+/* BingranOS — rendered as an HTML element projected onto the 3D monitor
+   screen plane via drei <Html transform>. There is no fade overlay; the OS
+   is permanently mounted so the dolly-in reads as a single smooth zoom.
+   `.monitorScreen` IS the CRT screen face — a deep warm-dark phosphor
+   coating. The OS frame sits inset inside it so a thin band of phosphor
+   shows around the UI, the way an actual CRT displays an image slightly
+   smaller than the physical face. Aspect ratio 4:3 matches the bezel
+   aperture so the projection has no letterbox bands.
+
+   Subtle inset shadow + radial vignette suggest curved glass — turning the
+   "flat texture sticker" feel into "content lit on phosphor". */
+.monitorScreen {
+  width: 1024px;
+  height: 768px;
+  background:
+    radial-gradient(ellipse at 50% 48%, #1c1308 0%, #0d0904 70%, #050301 100%);
+  position: relative;
+  overflow: hidden;
+  font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+  box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.6);
 }
 
-.osLayer.visible {
-  opacity: 1;
-  pointer-events: auto;
+/* Faint phosphor highlight at the top — old CRTs bloom a little at the
+   top center where the electron beam dwells. Soft, low opacity. */
+.monitorScreen::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(240, 182, 135, 0.08) 0%, transparent 55%);
+  pointer-events: none;
+  z-index: 4;
 }
 
 .osFrame {
-  position: relative;
-  width: min(1100px, 96vw);
-  height: min(720px, 86vh);
-  border-radius: 0;
-  overflow: hidden;
+  position: absolute;
+  /* Inset asymmetrically: a bit more vertical so the OS frame feels like
+     it's centered in the CRT cone rather than glued to the bezel. */
+  top: 4.5%;
+  bottom: 4.5%;
+  left: 3.5%;
+  right: 3.5%;
   background: #fbf3e1;
   color: #1f1a14;
-  /* Classic Mac chrome: thin black outline + a small "shadow" beneath that
-     reads as a window dropped onto the screen. */
-  box-shadow:
-    0 0 0 1px #1f1a14,
-    4px 4px 0 0 rgba(31, 26, 20, 0.85),
-    0 22px 60px rgba(0, 0, 0, 0.55);
   display: flex;
   flex-direction: column;
-  font-family: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, "PingFang SC", sans-serif;
+  /* Tiny inner shadow softens the OS edge against the phosphor — sells the
+     "image projected on the screen" feel instead of "rectangle pasted on". */
+  box-shadow: 0 0 24px rgba(240, 182, 135, 0.12);
 }
 
 .osFrame::before {

--- a/personal-site/app/palace/ui/BingranOS.tsx
+++ b/personal-site/app/palace/ui/BingranOS.tsx
@@ -32,12 +32,16 @@ const TABS: { id: TabId; label: string; glyph: string }[] = [
 
 export function BingranOS({
   data,
-  visible,
+  active,
   onClose,
   initialTab,
 }: {
   data: PalaceData;
-  visible: boolean;
+  /** True when the OS owns user focus (monitor mode). Drives game ticking
+   *  and ARIA modality but does NOT control mounting — the OS is permanently
+   *  rendered onto the 3D monitor screen so the dolly-in reads as a single
+   *  smooth zoom rather than a fade-in. */
+  active: boolean;
   onClose: () => void;
   initialTab?: string | null;
 }) {
@@ -45,85 +49,78 @@ export function BingranOS({
     const requested = initialTab as TabId | null | undefined;
     return requested && TABS.some((t) => t.id === requested) ? requested : "about";
   });
-  const lastVisibleRef = useRef(visible);
+  const lastActiveRef = useRef(active);
   const lastInitialTabRef = useRef(initialTab);
 
-  // Reset tab when the OS opens, honouring an `initialTab` hint if present.
-  // We compare against refs so the deps array stays a fixed shape — passing
-  // props in as deps triggers a React DEV warning when their reference types
-  // shift across renders.
+  // Reset tab when the OS gains focus, honouring an `initialTab` hint if
+  // present. Compare against refs so the deps array stays fixed-shape.
   useEffect(() => {
-    const justOpened = visible && !lastVisibleRef.current;
+    const justFocused = active && !lastActiveRef.current;
     const initialTabChanged = initialTab !== lastInitialTabRef.current;
-    lastVisibleRef.current = visible;
+    lastActiveRef.current = active;
     lastInitialTabRef.current = initialTab;
-    if (!visible) return;
-    if (justOpened || initialTabChanged) {
+    if (!active) return;
+    if (justFocused || initialTabChanged) {
       const requested = initialTab as TabId | null | undefined;
       if (requested && TABS.some((t) => t.id === requested)) setTab(requested);
-      else if (justOpened) setTab("about");
+      else if (justFocused) setTab("about");
     }
   });
 
   return (
     <div
-      className={`${styles.osLayer} ${visible ? styles.visible : ""}`}
-      aria-hidden={!visible}
+      className={styles.osFrame}
+      role="dialog"
+      aria-label="BingranOS — bingranyou.com on the monitor"
+      aria-modal={active}
     >
-      <div
-        className={styles.osFrame}
-        role="dialog"
-        aria-label="BingranOS — bingranyou.com on the monitor"
-        aria-modal="true"
-      >
-        <div className={styles.osBar}>
-          <button
-            type="button"
-            className={styles.osBarClose}
-            onClick={onClose}
-            aria-label="Close BingranOS and return to room"
-          />
-          <div className={styles.osBarTitle}>
-            BingranOS — bingranyou.com
+      <div className={styles.osBar}>
+        <button
+          type="button"
+          className={styles.osBarClose}
+          onClick={onClose}
+          aria-label="Close BingranOS and return to room"
+          tabIndex={active ? 0 : -1}
+        />
+        <div className={styles.osBarTitle}>BingranOS — bingranyou.com</div>
+      </div>
+
+      <div className={styles.osBody}>
+        <nav className={styles.osSide} aria-label="BingranOS sections">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              className={`${styles.osIcon} ${tab === t.id ? styles.active : ""}`}
+              onClick={() => setTab(t.id)}
+              aria-current={tab === t.id ? "page" : undefined}
+              tabIndex={active ? 0 : -1}
+            >
+              <span className={styles.glyph} aria-hidden>
+                {t.glyph}
+              </span>
+              {t.label}
+            </button>
+          ))}
+        </nav>
+
+        <section className={styles.osWindow}>
+          <header className={styles.osWindowBar}>
+            <span>{TABS.find((t) => t.id === tab)?.label} — open</span>
+            <span aria-hidden>↑ ↓ scroll · esc close</span>
+          </header>
+          <div className={styles.osContent}>
+            {tab === "about" && <AboutTab data={data} />}
+            {tab === "projects" && <ProjectsTab data={data} />}
+            {tab === "papers" && <PapersTab data={data} />}
+            {tab === "blog" && <BlogTab data={data} />}
+            {tab === "posts" && <PostsTab data={data} />}
+            {tab === "skills" && <SkillsTab />}
+            {tab === "tetris" && <Tetris active={active && tab === "tetris"} />}
+            {tab === "snake" && <Snake active={active && tab === "snake"} />}
+            {tab === "contact" && <ContactTab data={data} />}
           </div>
-        </div>
-
-        <div className={styles.osBody}>
-          <nav className={styles.osSide} aria-label="BingranOS sections">
-            {TABS.map((t) => (
-              <button
-                key={t.id}
-                type="button"
-                className={`${styles.osIcon} ${tab === t.id ? styles.active : ""}`}
-                onClick={() => setTab(t.id)}
-                aria-current={tab === t.id ? "page" : undefined}
-              >
-                <span className={styles.glyph} aria-hidden>
-                  {t.glyph}
-                </span>
-                {t.label}
-              </button>
-            ))}
-          </nav>
-
-          <section className={styles.osWindow}>
-            <header className={styles.osWindowBar}>
-              <span>{TABS.find((t) => t.id === tab)?.label} — open</span>
-              <span aria-hidden>↑ ↓ scroll · esc close</span>
-            </header>
-            <div className={styles.osContent}>
-              {tab === "about" && <AboutTab data={data} />}
-              {tab === "projects" && <ProjectsTab data={data} />}
-              {tab === "papers" && <PapersTab data={data} />}
-              {tab === "blog" && <BlogTab data={data} />}
-              {tab === "posts" && <PostsTab data={data} />}
-              {tab === "skills" && <SkillsTab />}
-              {tab === "tetris" && <Tetris active={visible && tab === "tetris"} />}
-              {tab === "snake" && <Snake active={visible && tab === "snake"} />}
-              {tab === "contact" && <ContactTab data={data} />}
-            </div>
-          </section>
-        </div>
+        </section>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Replace the post-zoom fade-in CSS overlay with a permanently-mounted drei `<Html transform>` that sits on the CRT screen plane. `idle → monitor` is now a pure camera dolly with no fade or overlay swap, matching the seamless feel of [henryjeff.com](https://henryjeff.com).

## What changed

- **Calibrated coordinates from real GLB data** — `MONITOR_POSITION` and all `CameraRig` poses derived from `computer_setup.glb`'s `monitor_base` mesh vertices (CRT head z>0.45 → screen mid at world `(0, 0.165, 0.092)`, face 0.20m × 0.15m). The old `(0, 0.22, 0.005)` was 6cm too high and 7cm too far back, which is why the camera framed empty space and the screen looked stuck on the wrong plane.
- **HTML projection, not overlay** — `BingranOS` is now mounted inside `<Canvas>` via `<Html transform>` at 1024×768 (4:3). It projects to exactly 0.20m × 0.15m (matching the CRT face) — no letterbox or pillarbox inside the bezel. Compensates drei's internal 1/40 matrix factor with a `* 40` multiplier on the scale prop.
- **Single fluid dolly** — idle `(0.22, 0.45, 1.4)` → monitor `(0, 0.165, 0.32)`, both at fov 36°. No fov change between modes, quintic ease-in-out over 1.6s. Removed the `osReady` 950ms delay and CSS `.osLayer` fade — they were the source of the "切换/淡出" feel.
- **CRT-realistic chrome** — `.monitorScreen` is now a warm-dark phosphor radial gradient with inset shadow; `.osFrame` inset 4.5%/3.5% so a thin phosphor band shows around the cream UI. Adds a faint warm phosphor bloom at the top of the screen.
- **`BingranOS` refactor** — removed the `.osLayer` fade wrapper; renamed `visible` → `active`. The OS is now always mounted; `active` only gates game ticking and ARIA modality.

## Test plan

- [ ] `npm run dev`, open `/palace` — verify in idle the CRT screen shows a tiny readable copy of the OS (cream UI with warm phosphor border)
- [ ] Click the monitor — verify the dolly is one continuous zoom (no fade, no UI swap mid-transition)
- [ ] In monitor mode — verify pillarbox sides show CRT bezel + room, not a flat dark overlay
- [ ] `ESC` — verify smooth reverse dolly to idle
- [ ] `/palace#about`, `/palace#tetris` etc. — verify deep-link still jumps straight into the OS tab