### PR TITLE
personal-site: /palace — fix h1 fallback (Alfa Slab One)

### DIFF
--- a/personal-site/palace-inner/public/index.html
+++ b/personal-site/palace-inner/public/index.html
@@ -7,7 +7,11 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="BingranOS — the inner Windows-98-style desktop served inside the /palace memory palace." />
   <base target="_parent">
-  <link rel="stylesheet" href="https://use.typekit.net/llo2eru.css" />
+  <!-- Display serif for h1 (chunky retro). Replaces upstream Henry's
+       Typekit kit (llo2eru) which is domain-locked to his own sites. -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&display=swap" />
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <title>BingranOS</title>

--- a/personal-site/palace-inner/src/index.css
+++ b/personal-site/palace-inner/src/index.css
@@ -79,8 +79,13 @@ p b {
 }
 
 h1 {
-    font-family: gastromond, sans-serif;
+    /* Chunky retro display serif. Upstream used Henry's Typekit "gastromond"
+       which is locked to his own domains — falls back to system sans-serif
+       elsewhere. Alfa Slab One (Google Fonts, OFL) is the nearest free
+       look-alike. */
+    font-family: 'Alfa Slab One', Georgia, 'Times New Roman', serif;
     font-size: 64px;
+    letter-spacing: 0.5px;
 }
 
 h2 {


### PR DESCRIPTION
## Summary

Follow-up to #187. Henry's upstream index.html loaded his Adobe Typekit kit (`llo2eru.css`) for the gastromond h1 display font, but Typekit kits are tied to the publisher's own domains — loading from bingran.ai returns a 200 but doesn't register the family, so every h1 fell back to system sans-serif on production.

Swap the kit for [Alfa Slab One](https://fonts.google.com/specimen/Alfa+Slab+One) from Google Fonts (OFL, no domain lock) — closest free look-alike to gastromond's chunky display slab — and update the h1 font-family stack.

## Verified

- Local: build green, `/palace/os` and `/palace/os/about` show the new chunky slab on "Bingran You" / "Hi, I'm Bingran" / "Experience" / "Projects".
- Production failure mode confirmed: `document.fonts` reported `hasGastromond: false` on bingran.ai/about even though the Typekit link 200'd.