### PR TITLE
personal-site: allow same-origin iframing for /palace → /palace/os

### DIFF
--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -11,7 +11,7 @@
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "X-DNS-Prefetch-Control", "value": "on" },
         {
           "key": "Permissions-Policy",
@@ -21,7 +21,7 @@
         { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:; media-src 'self' https:; frame-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:; media-src 'self' https:; frame-src 'self' https:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
         }
       ]
     },


### PR DESCRIPTION
Fix "bingran.ai refused to connect" inside the 3D monitor. Global vercel.json headers sent `X-Frame-Options: DENY` and CSP `frame-ancestors 'none'`, which forbid all iframing — same-origin included. Relax both to `SAMEORIGIN` / `'self'`. Cross-origin clickjacking surface unchanged.