### PR TITLE
personal-site: /palace — relax COOP so the in-monitor iframe works

### DIFF
--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -31,6 +31,12 @@
         { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
         { "key": "Cache-Control", "value": "public, max-age=3600, must-revalidate" }
       ]
+    },
+    {
+      "source": "/palace(/.*)?",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "unsafe-none" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Final fix in the iframe-on-prod saga. Global `Cross-Origin-Opener-Policy: same-origin` was putting parent /palace and child /palace/os into separate agent clusters, so Chrome treated the same-origin iframe as cross-origin and blocked `contentWindow` access. Override COOP to `unsafe-none` for `/palace(/.*)?` so the outer 3D site can read/postMessage with the inner OS. Rest of the site keeps strict global COOP.