### PR TITLE
personal-site: /palace — disable HTML caching so future header changes can't get stuck

### DIFF
--- a/personal-site/vercel.json
+++ b/personal-site/vercel.json
@@ -37,6 +37,18 @@
       "headers": [
         { "key": "Cross-Origin-Opener-Policy", "value": "unsafe-none" }
       ]
+    },
+    {
+      "source": "/palace",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/palace/os",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, must-revalidate" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Belt-and-suspenders fix for the stale-header iframe issue. Add `Cache-Control: no-store, must-revalidate` to the two HTML entry points (`/palace` and `/palace/os`) so returning visitors always get fresh response headers. Hashed assets under `/palace/*` keep their default long-cache behaviour.