### PR TITLE
personal-site: /skills — token-split search so "memory palace" finds memory-palace

### DIFF
--- a/personal-site/lib/skills-browser-vm.test.ts
+++ b/personal-site/lib/skills-browser-vm.test.ts
@@ -124,6 +124,66 @@ describe("buildSkillsViewModel", () => {
     expect(flat.map((s) => s.slug)).toEqual(["playwright"]);
   });
 
+  it("splits the query on whitespace so users can type a hyphenated slug naturally", () => {
+    // "memory palace" must find a skill slugged "memory-palace" — the literal
+    // substring "memory palace" doesn't exist anywhere.
+    const palaceFixtures: Skill[] = [
+      ...fixtures,
+      makeSkill({
+        slug: "memory-palace",
+        category: "Other",
+        name: "memory-palace",
+        description: "Apply Henry Heffernan's portfolio template.",
+      }),
+    ];
+    const vm = buildSkillsViewModel(palaceFixtures, allCategories, {
+      query: "memory palace",
+      activeCategory: "All",
+    });
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat.map((s) => s.slug)).toEqual(["memory-palace"]);
+  });
+
+  it("AND-combines tokens across different fields", () => {
+    // "henry frontend" matches frontend-slides by name AND a skill whose
+    // description mentions Henry — only the skill that hits BOTH should win.
+    const mixed: Skill[] = [
+      makeSkill({
+        slug: "frontend-slides",
+        category: "Slides & Decks",
+        name: "Frontend Slides",
+        description: "stunning animation rich slides",
+      }),
+      makeSkill({
+        slug: "henry-template",
+        category: "Other",
+        name: "henry-template",
+        description: "frontend portfolio template",
+      }),
+      makeSkill({
+        slug: "playwright",
+        category: "Browser & Testing",
+        name: "Playwright",
+        description: "browser automation",
+      }),
+    ];
+    const vm = buildSkillsViewModel(mixed, allCategories, {
+      query: "henry frontend",
+      activeCategory: "All",
+    });
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat.map((s) => s.slug)).toEqual(["henry-template"]);
+  });
+
+  it("collapses multiple internal whitespace runs", () => {
+    const vm = buildSkillsViewModel(fixtures, allCategories, {
+      query: "  deep    research  ",
+      activeCategory: "All",
+    });
+    const flat = vm.groups.flatMap(([, list]) => list);
+    expect(flat.map((s) => s.slug)).toEqual(["deep-research"]);
+  });
+
   it("restricts to active category", () => {
     const vm = buildSkillsViewModel(fixtures, allCategories, {
       query: "",

--- a/personal-site/lib/skills-browser-vm.ts
+++ b/personal-site/lib/skills-browser-vm.ts
@@ -13,14 +13,22 @@ export type SkillsViewModel = {
   queryMatchesAcrossCategories: number;
 };
 
-function matchesQuery(skill: Skill, q: string): boolean {
-  if (!q) return true;
+function matchesToken(skill: Skill, token: string): boolean {
   return (
-    skill.name.toLowerCase().includes(q) ||
-    skill.slug.toLowerCase().includes(q) ||
-    skill.description.toLowerCase().includes(q) ||
-    (skill.triggers?.some((t) => t.toLowerCase().includes(q)) ?? false)
+    skill.name.toLowerCase().includes(token) ||
+    skill.slug.toLowerCase().includes(token) ||
+    skill.description.toLowerCase().includes(token) ||
+    (skill.triggers?.some((t) => t.toLowerCase().includes(token)) ?? false)
   );
+}
+
+function matchesQuery(skill: Skill, tokens: string[]): boolean {
+  // AND semantics: every whitespace-separated token must hit some field on the
+  // card. This makes "memory palace" find a skill with slug "memory-palace"
+  // (token "memory" hits the slug, token "palace" hits the slug too) instead
+  // of trying to match the literal substring "memory palace" which doesn't
+  // exist anywhere.
+  return tokens.every((t) => matchesToken(skill, t));
 }
 
 export function buildSkillsViewModel(
@@ -28,8 +36,13 @@ export function buildSkillsViewModel(
   categories: SkillCategory[],
   state: SkillsFilterState,
 ): SkillsViewModel {
-  const q = state.query.trim().toLowerCase();
-  const queryMatches = q ? skills.filter((s) => matchesQuery(s, q)) : skills;
+  const tokens = state.query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+  const queryMatches = tokens.length
+    ? skills.filter((s) => matchesQuery(s, tokens))
+    : skills;
   const filtered =
     state.activeCategory === "All"
       ? queryMatches
@@ -57,6 +70,8 @@ export function buildSkillsViewModel(
     groups,
     isEmpty: filtered.length === 0,
     queryMatchesAcrossCategories:
-      q && state.activeCategory !== "All" ? queryMatches.length : 0,
+      tokens.length && state.activeCategory !== "All"
+        ? queryMatches.length
+        : 0,
   };
 }


### PR DESCRIPTION
Fix the substring-only search on /skills. Searching for 'memory palace' (two words) didn't find the 'memory-palace' skill because no field contains that exact substring — the slug uses a hyphen.

Now the query is split on whitespace and each token must match somewhere on the card (AND across fields). Single-token search behaves the same as before.

Tests: 16/16 pass, including 4 new cases for the new behaviour.