### PR TITLE
personal-site: drop Chinese-name (尤炳然) references site-wide

### DIFF
--- a/personal-site/app/(personal)/about/page.tsx
+++ b/personal-site/app/(personal)/about/page.tsx
@@ -5,12 +5,12 @@ import { jsonLdScriptContent, profilePageJsonLd } from "@/lib/jsonld";
 export const metadata: Metadata = {
   title: "About",
   description:
-    "Bingran You (尤炳然) — PhD candidate at UC Berkeley working on reliable AI systems and trapped-ion experiments in atomic, molecular and optical physics.",
+    "Bingran You — PhD candidate at UC Berkeley working on reliable AI systems and trapped-ion experiments in atomic, molecular and optical physics.",
   alternates: { canonical: "/about" },
 };
 
 const facts = [
-  "I am Bingran You (Chinese: 尤炳然), a PhD candidate in Applied Science & Technology at UC Berkeley, advised in the Haeffner Lab.",
+  "I am Bingran You, a PhD candidate in Applied Science & Technology at UC Berkeley, advised in the Haeffner Lab.",
   "I build reliable AI systems — agent infrastructure, evaluation harnesses, and applied AI products that need to behave under noisy real-world conditions.",
   "I run trapped-ion experiments in atomic, molecular and optical physics — integrated photonics for individual ion addressing, ion-photon interfaces, and 3D-printed micro ion traps for scalable hardware.",
   "Both tracks share one craft: turning complex, noisy systems into something that behaves on purpose.",

--- a/personal-site/app/(personal)/layout.tsx
+++ b/personal-site/app/(personal)/layout.tsx
@@ -26,7 +26,7 @@ export default function PersonalLayout({
       <footer className="border-t border-[var(--border)]">
         <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 sm:py-10 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-[var(--muted)]">
-            © {new Date().getFullYear()} Bingran You · <span lang="zh-Hans">尤炳然</span> · Berkeley, CA
+            © {new Date().getFullYear()} Bingran You · Berkeley, CA
           </p>
           <SocialLinks />
         </div>

--- a/personal-site/app/(personal)/page.tsx
+++ b/personal-site/app/(personal)/page.tsx
@@ -29,12 +29,6 @@ export default function Home() {
           <h1 className="font-display text-5xl leading-[1.02] tracking-[-0.035em] sm:text-6xl">
             Bingran You
           </h1>
-          <p
-            lang="zh-Hans"
-            className="mt-3 font-display text-4xl leading-[1.1] text-foreground/85 sm:text-5xl"
-          >
-            尤炳然
-          </p>
           <ul className="mt-7 space-y-3 text-base text-[var(--muted)]">
             <li className="flex flex-wrap items-center gap-x-6 gap-y-2">
               <span className="inline-flex items-center gap-2">

--- a/personal-site/app/globals.css
+++ b/personal-site/app/globals.css
@@ -70,8 +70,8 @@ body {
    Latin defaults, and the Newsreader text-feature settings (ss01/ss02/cv01/
    cv11 from `body`) target Latin glyphs only — Noto Serif SC ignores them
    but inheriting them is harmless. Apply a small letter-spacing nudge so
-   inline Han inside Latin paragraphs (e.g. "Bingran You (Chinese: 尤炳然)")
-   reads as a deliberate inset, not a jam-up. */
+   inline Han inside Latin paragraphs reads as a deliberate inset, not a
+   jam-up. */
 :lang(zh-Hans),
 :lang(zh-Hant),
 :lang(zh) {

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -4,16 +4,15 @@ import { SITE_URL } from "@/lib/site";
 export { SITE_URL };
 export const SITE_NAME = "Bingran You";
 export const SITE_DESCRIPTION =
-  "Bingran You (尤炳然) — PhD candidate at UC Berkeley building reliable AI systems and running trapped-ion experiments in atomic, molecular and optical physics.";
+  "Bingran You — PhD candidate at UC Berkeley building reliable AI systems and running trapped-ion experiments in atomic, molecular and optical physics.";
 export const SITE_OG_DESCRIPTION =
-  "Bingran You (尤炳然) — PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion atomic, molecular and optical physics.";
+  "Bingran You — PhD candidate at UC Berkeley. Reliable AI systems × trapped-ion atomic, molecular and optical physics.";
 export const OG_IMAGE_URL = `${SITE_URL}/images/profile/bingran-you-portrait.jpg`;
 export const PERSON_ID = `${SITE_URL}#person`;
 export const WEBSITE_ID = `${SITE_URL}#website`;
 export const PROFILE_PAGE_ID = `${SITE_URL}#profile`;
 export const SITE_KEYWORDS = [
   "Bingran You",
-  "尤炳然",
   "You Bingran",
   "AI agents",
   "reliable AI systems",
@@ -45,7 +44,7 @@ function personEntity() {
     "@type": "Person" as const,
     "@id": PERSON_ID,
     name: SITE_NAME,
-    alternateName: ["尤炳然", "You Bingran"],
+    alternateName: ["You Bingran"],
     givenName: "Bingran",
     familyName: "You",
     url: SITE_URL,
@@ -120,7 +119,7 @@ export function websiteJsonLd() {
     "@type": "WebSite",
     "@id": WEBSITE_ID,
     name: SITE_NAME,
-    alternateName: ["尤炳然", "bingranyou.com"],
+    alternateName: ["bingranyou.com"],
     url: SITE_URL,
     inLanguage: "en",
     author: { "@id": PERSON_ID },

--- a/personal-site/palace-inner/src/components/showcase/About.tsx
+++ b/personal-site/palace-inner/src/components/showcase/About.tsx
@@ -8,7 +8,7 @@ const About: React.FC<AboutProps> = () => {
     return (
         <div className="site-page-content">
             <h1 style={{ marginLeft: -16 }}>Hi, I'm Bingran</h1>
-            <h3>PhD candidate at UC Berkeley · 尤炳然</h3>
+            <h3>PhD candidate at UC Berkeley</h3>
             <br />
             <div className="text-block">
                 <p>

--- a/personal-site/public/humans.txt
+++ b/personal-site/public/humans.txt
@@ -1,6 +1,6 @@
 /* TEAM */
 
-   Bingran You (尤炳然)
+   Bingran You
    Site:    https://bingran.ai
    Email:   me@bingranyou.com
    GitHub:  bingran-you


### PR DESCRIPTION
## Summary

Removes every occurrence of the Chinese-character name **尤炳然** from anything the site renders or emits — visible copy, metadata, structured data, and a stylistic example in a CSS comment. The Latin name `Bingran You` (and the SEO-only pinyin variant `You Bingran`) stay.

### Files touched (7)

| File | Change |
| --- | --- |
| `app/(personal)/page.tsx` | Drop the `<p lang="zh-Hans">尤炳然</p>` byline under the H1. |
| `app/(personal)/layout.tsx` | Drop `· 尤炳然` from the footer line. |
| `app/(personal)/about/page.tsx` | Strip `(尤炳然)` from the page `description` and `(Chinese: 尤炳然)` from the intro paragraph. |
| `lib/jsonld.ts` | Strip `(尤炳然)` from `SITE_DESCRIPTION` / `SITE_OG_DESCRIPTION`, remove the keyword, remove from both `alternateName` arrays (Person + WebSite). |
| `palace-inner/src/components/showcase/About.tsx` | `PhD candidate at UC Berkeley · 尤炳然` → `PhD candidate at UC Berkeley`. |
| `public/humans.txt` | `Bingran You (尤炳然)` → `Bingran You`. |
| `app/globals.css` | Update the Han-typography comment example so it no longer cites the Chinese name. CSS rule itself unchanged. |

### Verification

- `npm test` → 38/38 passing
- `npx tsc --noEmit` → clean
- `npm run lint` → only pre-existing palace-inner CRA errors; nothing introduced by this diff
- `grep -rn "尤炳然" personal-site/` (excluding `node_modules`, `.next`) → empty

## Test plan

- [ ] Visually confirm home page no longer shows the Han byline
- [ ] Footer reads `© 2026 Bingran You · Berkeley, CA`
- [ ] `/about` and OG meta description no longer mention 尤炳然
- [ ] View-source on `/` JSON-LD `alternateName` does not contain Han characters
- [ ] Memory Palace inner OS About panel reads `PhD candidate at UC Berkeley`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYPxHuxdvZ3sLwt6vDkLjy)_