### PR TITLE
Sync .agents/skills and .claude/skills entrypoints (follow-up to #204)

### DIFF
--- a/.agents/skills/agent-browser
+++ b/.agents/skills/agent-browser
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/agent-browser

--- a/.agents/skills/ai-music-album
+++ b/.agents/skills/ai-music-album
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ai-music-album

--- a/.agents/skills/algorithmic-art
+++ b/.agents/skills/algorithmic-art
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/algorithmic-art

--- a/.agents/skills/apple-hig
+++ b/.agents/skills/apple-hig
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/apple-hig

--- a/.agents/skills/artifacts-builder
+++ b/.agents/skills/artifacts-builder
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/artifacts-builder

--- a/.agents/skills/audio-jingle
+++ b/.agents/skills/audio-jingle
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/audio-jingle

--- a/.agents/skills/blog-post
+++ b/.agents/skills/blog-post
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/blog-post

--- a/.agents/skills/brainstorming
+++ b/.agents/skills/brainstorming
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/brainstorming

--- a/.agents/skills/brand-guidelines
+++ b/.agents/skills/brand-guidelines
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/brand-guidelines

--- a/.agents/skills/canvas-design
+++ b/.agents/skills/canvas-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/canvas-design

--- a/.agents/skills/clinical-case-report
+++ b/.agents/skills/clinical-case-report
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/clinical-case-report

--- a/.agents/skills/color-expert
+++ b/.agents/skills/color-expert
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/color-expert

--- a/.agents/skills/competitive-ads-extractor
+++ b/.agents/skills/competitive-ads-extractor
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/competitive-ads-extractor

--- a/.agents/skills/creative-director
+++ b/.agents/skills/creative-director
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/creative-director

--- a/.agents/skills/critique
+++ b/.agents/skills/critique
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/critique

--- a/.agents/skills/d3-visualization
+++ b/.agents/skills/d3-visualization
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/d3-visualization

--- a/.agents/skills/dashboard
+++ b/.agents/skills/dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/dashboard

--- a/.agents/skills/dating-web
+++ b/.agents/skills/dating-web
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/dating-web

--- a/.agents/skills/dcf-valuation
+++ b/.agents/skills/dcf-valuation
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/dcf-valuation

--- a/.agents/skills/design-md
+++ b/.agents/skills/design-md
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/design-md

--- a/.agents/skills/digital-eguide
+++ b/.agents/skills/digital-eguide
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/digital-eguide

--- a/.agents/skills/doc
+++ b/.agents/skills/doc
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/doc

--- a/.agents/skills/docs-page
+++ b/.agents/skills/docs-page
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/docs-page

--- a/.agents/skills/domain-name-brainstormer
+++ b/.agents/skills/domain-name-brainstormer
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/domain-name-brainstormer

--- a/.agents/skills/email-marketing
+++ b/.agents/skills/email-marketing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/email-marketing

--- a/.agents/skills/eng-runbook
+++ b/.agents/skills/eng-runbook
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/eng-runbook

--- a/.agents/skills/enhance-prompt
+++ b/.agents/skills/enhance-prompt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/enhance-prompt

--- a/.agents/skills/fal-3d
+++ b/.agents/skills/fal-3d
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-3d

--- a/.agents/skills/fal-generate
+++ b/.agents/skills/fal-generate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-generate

--- a/.agents/skills/fal-image-edit
+++ b/.agents/skills/fal-image-edit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-image-edit

--- a/.agents/skills/fal-kling-o3
+++ b/.agents/skills/fal-kling-o3
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-kling-o3

--- a/.agents/skills/fal-lip-sync
+++ b/.agents/skills/fal-lip-sync
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-lip-sync

--- a/.agents/skills/fal-realtime
+++ b/.agents/skills/fal-realtime
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-realtime

--- a/.agents/skills/fal-restore
+++ b/.agents/skills/fal-restore
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-restore

--- a/.agents/skills/fal-train
+++ b/.agents/skills/fal-train
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-train

--- a/.agents/skills/fal-tryon
+++ b/.agents/skills/fal-tryon
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-tryon

--- a/.agents/skills/fal-upscale
+++ b/.agents/skills/fal-upscale
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-upscale

--- a/.agents/skills/fal-video-edit
+++ b/.agents/skills/fal-video-edit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-video-edit

--- a/.agents/skills/fal-vision
+++ b/.agents/skills/fal-vision
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-vision

--- a/.agents/skills/figma-code-connect-components
+++ b/.agents/skills/figma-code-connect-components
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-code-connect-components

--- a/.agents/skills/figma-create-design-system-rules
+++ b/.agents/skills/figma-create-design-system-rules
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-create-design-system-rules

--- a/.agents/skills/figma-create-new-file
+++ b/.agents/skills/figma-create-new-file
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-create-new-file

--- a/.agents/skills/figma-generate-design
+++ b/.agents/skills/figma-generate-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-generate-design

--- a/.agents/skills/figma-generate-library
+++ b/.agents/skills/figma-generate-library
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-generate-library

--- a/.agents/skills/figma-implement-design
+++ b/.agents/skills/figma-implement-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-implement-design

--- a/.agents/skills/figma-use
+++ b/.agents/skills/figma-use
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-use

--- a/.agents/skills/finance-report
+++ b/.agents/skills/finance-report
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/finance-report

--- a/.agents/skills/flowai-live-dashboard-template
+++ b/.agents/skills/flowai-live-dashboard-template
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/flowai-live-dashboard-template

--- a/.agents/skills/flutter-animating-apps
+++ b/.agents/skills/flutter-animating-apps
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/flutter-animating-apps

--- a/.agents/skills/frontend-dev
+++ b/.agents/skills/frontend-dev
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/frontend-dev

--- a/.agents/skills/frontend-skill
+++ b/.agents/skills/frontend-skill
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/frontend-skill

--- a/.agents/skills/full-page-screenshot
+++ b/.agents/skills/full-page-screenshot
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/full-page-screenshot

--- a/.agents/skills/gamified-app
+++ b/.agents/skills/gamified-app
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/gamified-app

--- a/.agents/skills/gif-sticker-maker
+++ b/.agents/skills/gif-sticker-maker
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gif-sticker-maker

--- a/.agents/skills/github-dashboard
+++ b/.agents/skills/github-dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/github-dashboard

--- a/.agents/skills/gsap-core
+++ b/.agents/skills/gsap-core
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-core

--- a/.agents/skills/gsap-react
+++ b/.agents/skills/gsap-react
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-react

--- a/.agents/skills/gsap-scrolltrigger
+++ b/.agents/skills/gsap-scrolltrigger
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-scrolltrigger

--- a/.agents/skills/gsap-timeline
+++ b/.agents/skills/gsap-timeline
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-timeline

--- a/.agents/skills/guizang-ppt
+++ b/.agents/skills/guizang-ppt
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/guizang-ppt

--- a/.agents/skills/hand-drawn-diagrams
+++ b/.agents/skills/hand-drawn-diagrams
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/hand-drawn-diagrams

--- a/.agents/skills/hr-onboarding
+++ b/.agents/skills/hr-onboarding
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/hr-onboarding

--- a/.agents/skills/html-ppt
+++ b/.agents/skills/html-ppt
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt

--- a/.agents/skills/html-ppt-course-module
+++ b/.agents/skills/html-ppt-course-module
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-course-module

--- a/.agents/skills/html-ppt-dir-key-nav-minimal
+++ b/.agents/skills/html-ppt-dir-key-nav-minimal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-dir-key-nav-minimal

--- a/.agents/skills/html-ppt-graphify-dark-graph
+++ b/.agents/skills/html-ppt-graphify-dark-graph
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-graphify-dark-graph

--- a/.agents/skills/html-ppt-hermes-cyber-terminal
+++ b/.agents/skills/html-ppt-hermes-cyber-terminal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-hermes-cyber-terminal

--- a/.agents/skills/html-ppt-knowledge-arch-blueprint
+++ b/.agents/skills/html-ppt-knowledge-arch-blueprint
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-knowledge-arch-blueprint

--- a/.agents/skills/html-ppt-obsidian-claude-gradient
+++ b/.agents/skills/html-ppt-obsidian-claude-gradient
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-obsidian-claude-gradient

--- a/.agents/skills/html-ppt-pitch-deck
+++ b/.agents/skills/html-ppt-pitch-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-pitch-deck

--- a/.agents/skills/html-ppt-presenter-mode-reveal
+++ b/.agents/skills/html-ppt-presenter-mode-reveal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-presenter-mode-reveal

--- a/.agents/skills/html-ppt-product-launch
+++ b/.agents/skills/html-ppt-product-launch
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-product-launch

--- a/.agents/skills/html-ppt-taste-brutalist
+++ b/.agents/skills/html-ppt-taste-brutalist
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-taste-brutalist

--- a/.agents/skills/html-ppt-taste-editorial
+++ b/.agents/skills/html-ppt-taste-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-taste-editorial

--- a/.agents/skills/html-ppt-tech-sharing
+++ b/.agents/skills/html-ppt-tech-sharing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-tech-sharing

--- a/.agents/skills/html-ppt-testing-safety-alert
+++ b/.agents/skills/html-ppt-testing-safety-alert
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-testing-safety-alert

--- a/.agents/skills/html-ppt-weekly-report
+++ b/.agents/skills/html-ppt-weekly-report
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-weekly-report

--- a/.agents/skills/html-ppt-xhs-pastel-card
+++ b/.agents/skills/html-ppt-xhs-pastel-card
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-xhs-pastel-card

--- a/.agents/skills/html-ppt-xhs-post
+++ b/.agents/skills/html-ppt-xhs-post
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-xhs-post

--- a/.agents/skills/html-ppt-xhs-white-editorial
+++ b/.agents/skills/html-ppt-xhs-white-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-xhs-white-editorial

--- a/.agents/skills/html-ppt-zhangzara-8-bit-orbit
+++ b/.agents/skills/html-ppt-zhangzara-8-bit-orbit
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-8-bit-orbit

--- a/.agents/skills/html-ppt-zhangzara-biennale-yellow
+++ b/.agents/skills/html-ppt-zhangzara-biennale-yellow
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-biennale-yellow

--- a/.agents/skills/html-ppt-zhangzara-block-frame
+++ b/.agents/skills/html-ppt-zhangzara-block-frame
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-block-frame

--- a/.agents/skills/html-ppt-zhangzara-blue-professional
+++ b/.agents/skills/html-ppt-zhangzara-blue-professional
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-blue-professional

--- a/.agents/skills/html-ppt-zhangzara-bold-poster
+++ b/.agents/skills/html-ppt-zhangzara-bold-poster
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-bold-poster

--- a/.agents/skills/html-ppt-zhangzara-broadside
+++ b/.agents/skills/html-ppt-zhangzara-broadside
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-broadside

--- a/.agents/skills/html-ppt-zhangzara-capsule
+++ b/.agents/skills/html-ppt-zhangzara-capsule
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-capsule

--- a/.agents/skills/html-ppt-zhangzara-cartesian
+++ b/.agents/skills/html-ppt-zhangzara-cartesian
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cartesian

--- a/.agents/skills/html-ppt-zhangzara-cobalt-grid
+++ b/.agents/skills/html-ppt-zhangzara-cobalt-grid
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cobalt-grid

--- a/.agents/skills/html-ppt-zhangzara-coral
+++ b/.agents/skills/html-ppt-zhangzara-coral
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-coral

--- a/.agents/skills/html-ppt-zhangzara-creative-mode
+++ b/.agents/skills/html-ppt-zhangzara-creative-mode
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-creative-mode

--- a/.agents/skills/html-ppt-zhangzara-daisy-days
+++ b/.agents/skills/html-ppt-zhangzara-daisy-days
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-daisy-days

--- a/.agents/skills/html-ppt-zhangzara-editorial-tri-tone
+++ b/.agents/skills/html-ppt-zhangzara-editorial-tri-tone
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-editorial-tri-tone

--- a/.agents/skills/html-ppt-zhangzara-grove
+++ b/.agents/skills/html-ppt-zhangzara-grove
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-grove

--- a/.agents/skills/html-ppt-zhangzara-long-table
+++ b/.agents/skills/html-ppt-zhangzara-long-table
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-long-table

--- a/.agents/skills/html-ppt-zhangzara-mat
+++ b/.agents/skills/html-ppt-zhangzara-mat
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-mat

--- a/.agents/skills/html-ppt-zhangzara-monochrome
+++ b/.agents/skills/html-ppt-zhangzara-monochrome
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-monochrome

--- a/.agents/skills/html-ppt-zhangzara-neo-grid-bold
+++ b/.agents/skills/html-ppt-zhangzara-neo-grid-bold
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-neo-grid-bold

--- a/.agents/skills/html-ppt-zhangzara-peoples-platform
+++ b/.agents/skills/html-ppt-zhangzara-peoples-platform
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-peoples-platform

--- a/.agents/skills/html-ppt-zhangzara-pin-and-paper
+++ b/.agents/skills/html-ppt-zhangzara-pin-and-paper
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pin-and-paper

--- a/.agents/skills/html-ppt-zhangzara-pink-script
+++ b/.agents/skills/html-ppt-zhangzara-pink-script
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pink-script

--- a/.agents/skills/html-ppt-zhangzara-playful
+++ b/.agents/skills/html-ppt-zhangzara-playful
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-playful

--- a/.agents/skills/html-ppt-zhangzara-raw-grid
+++ b/.agents/skills/html-ppt-zhangzara-raw-grid
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-raw-grid

--- a/.agents/skills/html-ppt-zhangzara-retro-windows
+++ b/.agents/skills/html-ppt-zhangzara-retro-windows
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-windows

--- a/.agents/skills/html-ppt-zhangzara-retro-zine
+++ b/.agents/skills/html-ppt-zhangzara-retro-zine
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-zine

--- a/.agents/skills/html-ppt-zhangzara-sakura-chroma
+++ b/.agents/skills/html-ppt-zhangzara-sakura-chroma
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-sakura-chroma

--- a/.agents/skills/html-ppt-zhangzara-scatterbrain
+++ b/.agents/skills/html-ppt-zhangzara-scatterbrain
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-scatterbrain

--- a/.agents/skills/html-ppt-zhangzara-signal
+++ b/.agents/skills/html-ppt-zhangzara-signal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-signal

--- a/.agents/skills/html-ppt-zhangzara-soft-editorial
+++ b/.agents/skills/html-ppt-zhangzara-soft-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-soft-editorial

--- a/.agents/skills/html-ppt-zhangzara-stencil-tablet
+++ b/.agents/skills/html-ppt-zhangzara-stencil-tablet
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-stencil-tablet

--- a/.agents/skills/html-ppt-zhangzara-studio
+++ b/.agents/skills/html-ppt-zhangzara-studio
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-studio

--- a/.agents/skills/html-ppt-zhangzara-vellum
+++ b/.agents/skills/html-ppt-zhangzara-vellum
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-vellum

--- a/.agents/skills/hyperframes
+++ b/.agents/skills/hyperframes
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/hyperframes

--- a/.agents/skills/ib-pitch-book
+++ b/.agents/skills/ib-pitch-book
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/ib-pitch-book

--- a/.agents/skills/image-enhancer
+++ b/.agents/skills/image-enhancer
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/image-enhancer

--- a/.agents/skills/image-poster
+++ b/.agents/skills/image-poster
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/image-poster

--- a/.agents/skills/imagegen
+++ b/.agents/skills/imagegen
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/imagegen

--- a/.agents/skills/imagen
+++ b/.agents/skills/imagen
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/imagen

--- a/.agents/skills/invoice
+++ b/.agents/skills/invoice
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/invoice

--- a/.agents/skills/kami-deck
+++ b/.agents/skills/kami-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/kami-deck

--- a/.agents/skills/kami-landing
+++ b/.agents/skills/kami-landing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/kami-landing

--- a/.agents/skills/kanban-board
+++ b/.agents/skills/kanban-board
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/kanban-board

--- a/.agents/skills/last30days
+++ b/.agents/skills/last30days
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/last30days

--- a/.agents/skills/live-artifact
+++ b/.agents/skills/live-artifact
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/live-artifact

--- a/.agents/skills/live-dashboard
+++ b/.agents/skills/live-dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/live-dashboard

--- a/.agents/skills/magazine-poster
+++ b/.agents/skills/magazine-poster
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/magazine-poster

--- a/.agents/skills/meeting-notes
+++ b/.agents/skills/meeting-notes
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/meeting-notes

--- a/.agents/skills/minimax-docx
+++ b/.agents/skills/minimax-docx
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/minimax-docx

--- a/.agents/skills/minimax-pdf
+++ b/.agents/skills/minimax-pdf
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/minimax-pdf

--- a/.agents/skills/mobile-app
+++ b/.agents/skills/mobile-app
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/mobile-app

--- a/.agents/skills/mobile-onboarding
+++ b/.agents/skills/mobile-onboarding
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/mobile-onboarding

--- a/.agents/skills/motion-frames
+++ b/.agents/skills/motion-frames
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/motion-frames

--- a/.agents/skills/nanobanana-ppt
+++ b/.agents/skills/nanobanana-ppt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/nanobanana-ppt

--- a/.agents/skills/open-design-landing
+++ b/.agents/skills/open-design-landing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/open-design-landing

--- a/.agents/skills/open-design-landing-deck
+++ b/.agents/skills/open-design-landing-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/open-design-landing-deck

--- a/.agents/skills/orbit-general
+++ b/.agents/skills/orbit-general
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-general

--- a/.agents/skills/orbit-github
+++ b/.agents/skills/orbit-github
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-github

--- a/.agents/skills/orbit-gmail
+++ b/.agents/skills/orbit-gmail
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-gmail

--- a/.agents/skills/orbit-linear
+++ b/.agents/skills/orbit-linear
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-linear

--- a/.agents/skills/orbit-notion
+++ b/.agents/skills/orbit-notion
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-notion

--- a/.agents/skills/pixelbin-media
+++ b/.agents/skills/pixelbin-media
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pixelbin-media

--- a/.agents/skills/platform-design
+++ b/.agents/skills/platform-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/platform-design

--- a/.agents/skills/pm-spec
+++ b/.agents/skills/pm-spec
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/pm-spec

--- a/.agents/skills/pptx-generator
+++ b/.agents/skills/pptx-generator
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pptx-generator

--- a/.agents/skills/pricing-page
+++ b/.agents/skills/pricing-page
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/pricing-page

--- a/.agents/skills/remotion
+++ b/.agents/skills/remotion
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/remotion

--- a/.agents/skills/replicate
+++ b/.agents/skills/replicate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/replicate

--- a/.agents/skills/replit-deck
+++ b/.agents/skills/replit-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/replit-deck

--- a/.agents/skills/saas-landing
+++ b/.agents/skills/saas-landing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/saas-landing

--- a/.agents/skills/screenshots-marketing
+++ b/.agents/skills/screenshots-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/screenshots-marketing

--- a/.agents/skills/shadcn-ui
+++ b/.agents/skills/shadcn-ui
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/shadcn-ui

--- a/.agents/skills/shader-dev
+++ b/.agents/skills/shader-dev
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/shader-dev

--- a/.agents/skills/simple-deck
+++ b/.agents/skills/simple-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/simple-deck

--- a/.agents/skills/slack-gif-creator
+++ b/.agents/skills/slack-gif-creator
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/slack-gif-creator

--- a/.agents/skills/slides
+++ b/.agents/skills/slides
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/slides

--- a/.agents/skills/social-carousel
+++ b/.agents/skills/social-carousel
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/social-carousel

--- a/.agents/skills/social-media-dashboard
+++ b/.agents/skills/social-media-dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/social-media-dashboard

--- a/.agents/skills/social-media-matrix-tracker-template
+++ b/.agents/skills/social-media-matrix-tracker-template
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/social-media-matrix-tracker-template

--- a/.agents/skills/sora
+++ b/.agents/skills/sora
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/sora

--- a/.agents/skills/speech
+++ b/.agents/skills/speech
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/speech

--- a/.agents/skills/sprite-animation
+++ b/.agents/skills/sprite-animation
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/sprite-animation

--- a/.agents/skills/stitch-loop
+++ b/.agents/skills/stitch-loop
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/stitch-loop

--- a/.agents/skills/swiftui-design
+++ b/.agents/skills/swiftui-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/swiftui-design

--- a/.agents/skills/taste-skill
+++ b/.agents/skills/taste-skill
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/taste-skill

--- a/.agents/skills/team-okrs
+++ b/.agents/skills/team-okrs
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/team-okrs

--- a/.agents/skills/threejs
+++ b/.agents/skills/threejs
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/threejs

--- a/.agents/skills/trading-analysis-dashboard-template
+++ b/.agents/skills/trading-analysis-dashboard-template
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/trading-analysis-dashboard-template

--- a/.agents/skills/tweaks
+++ b/.agents/skills/tweaks
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/tweaks

--- a/.agents/skills/ui-skills
+++ b/.agents/skills/ui-skills
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ui-skills

--- a/.agents/skills/ui-ux-pro-max
+++ b/.agents/skills/ui-ux-pro-max
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ui-ux-pro-max

--- a/.agents/skills/venice-audio-music
+++ b/.agents/skills/venice-audio-music
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-audio-music

--- a/.agents/skills/venice-audio-speech
+++ b/.agents/skills/venice-audio-speech
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-audio-speech

--- a/.agents/skills/venice-image-edit
+++ b/.agents/skills/venice-image-edit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-image-edit

--- a/.agents/skills/venice-image-generate
+++ b/.agents/skills/venice-image-generate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-image-generate

--- a/.agents/skills/venice-video
+++ b/.agents/skills/venice-video
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-video

--- a/.agents/skills/video-downloader
+++ b/.agents/skills/video-downloader
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/video-downloader

--- a/.agents/skills/video-shortform
+++ b/.agents/skills/video-shortform
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/video-shortform

--- a/.agents/skills/waitlist-page
+++ b/.agents/skills/waitlist-page
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/waitlist-page

--- a/.agents/skills/web-design-guidelines
+++ b/.agents/skills/web-design-guidelines
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/web-design-guidelines

--- a/.agents/skills/web-prototype
+++ b/.agents/skills/web-prototype
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype

--- a/.agents/skills/web-prototype-taste-brutalist
+++ b/.agents/skills/web-prototype-taste-brutalist
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype-taste-brutalist

--- a/.agents/skills/web-prototype-taste-editorial
+++ b/.agents/skills/web-prototype-taste-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype-taste-editorial

--- a/.agents/skills/web-prototype-taste-soft
+++ b/.agents/skills/web-prototype-taste-soft
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype-taste-soft

--- a/.agents/skills/weekly-update
+++ b/.agents/skills/weekly-update
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/weekly-update

--- a/.agents/skills/wireframe-sketch
+++ b/.agents/skills/wireframe-sketch
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/wireframe-sketch

--- a/.agents/skills/wpds
+++ b/.agents/skills/wpds
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/wpds

--- a/.agents/skills/x-research
+++ b/.agents/skills/x-research
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/x-research

--- a/.agents/skills/youtube-clipper
+++ b/.agents/skills/youtube-clipper
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/youtube-clipper

--- a/.claude/skills/agent-browser
+++ b/.claude/skills/agent-browser
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/agent-browser

--- a/.claude/skills/ai-music-album
+++ b/.claude/skills/ai-music-album
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ai-music-album

--- a/.claude/skills/algorithmic-art
+++ b/.claude/skills/algorithmic-art
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/algorithmic-art

--- a/.claude/skills/apple-hig
+++ b/.claude/skills/apple-hig
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/apple-hig

--- a/.claude/skills/artifacts-builder
+++ b/.claude/skills/artifacts-builder
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/artifacts-builder

--- a/.claude/skills/audio-jingle
+++ b/.claude/skills/audio-jingle
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/audio-jingle

--- a/.claude/skills/blog-post
+++ b/.claude/skills/blog-post
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/blog-post

--- a/.claude/skills/brainstorming
+++ b/.claude/skills/brainstorming
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/brainstorming

--- a/.claude/skills/brand-guidelines
+++ b/.claude/skills/brand-guidelines
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/brand-guidelines

--- a/.claude/skills/canvas-design
+++ b/.claude/skills/canvas-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/canvas-design

--- a/.claude/skills/clinical-case-report
+++ b/.claude/skills/clinical-case-report
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/clinical-case-report

--- a/.claude/skills/color-expert
+++ b/.claude/skills/color-expert
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/color-expert

--- a/.claude/skills/competitive-ads-extractor
+++ b/.claude/skills/competitive-ads-extractor
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/competitive-ads-extractor

--- a/.claude/skills/creative-director
+++ b/.claude/skills/creative-director
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/creative-director

--- a/.claude/skills/critique
+++ b/.claude/skills/critique
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/critique

--- a/.claude/skills/d3-visualization
+++ b/.claude/skills/d3-visualization
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/d3-visualization

--- a/.claude/skills/dashboard
+++ b/.claude/skills/dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/dashboard

--- a/.claude/skills/dating-web
+++ b/.claude/skills/dating-web
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/dating-web

--- a/.claude/skills/dcf-valuation
+++ b/.claude/skills/dcf-valuation
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/dcf-valuation

--- a/.claude/skills/design-md
+++ b/.claude/skills/design-md
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/design-md

--- a/.claude/skills/digital-eguide
+++ b/.claude/skills/digital-eguide
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/digital-eguide

--- a/.claude/skills/doc
+++ b/.claude/skills/doc
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/doc

--- a/.claude/skills/docs-page
+++ b/.claude/skills/docs-page
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/docs-page

--- a/.claude/skills/domain-name-brainstormer
+++ b/.claude/skills/domain-name-brainstormer
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/domain-name-brainstormer

--- a/.claude/skills/email-marketing
+++ b/.claude/skills/email-marketing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/email-marketing

--- a/.claude/skills/eng-runbook
+++ b/.claude/skills/eng-runbook
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/eng-runbook

--- a/.claude/skills/enhance-prompt
+++ b/.claude/skills/enhance-prompt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/enhance-prompt

--- a/.claude/skills/fal-3d
+++ b/.claude/skills/fal-3d
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-3d

--- a/.claude/skills/fal-generate
+++ b/.claude/skills/fal-generate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-generate

--- a/.claude/skills/fal-image-edit
+++ b/.claude/skills/fal-image-edit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-image-edit

--- a/.claude/skills/fal-kling-o3
+++ b/.claude/skills/fal-kling-o3
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-kling-o3

--- a/.claude/skills/fal-lip-sync
+++ b/.claude/skills/fal-lip-sync
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-lip-sync

--- a/.claude/skills/fal-realtime
+++ b/.claude/skills/fal-realtime
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-realtime

--- a/.claude/skills/fal-restore
+++ b/.claude/skills/fal-restore
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-restore

--- a/.claude/skills/fal-train
+++ b/.claude/skills/fal-train
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-train

--- a/.claude/skills/fal-tryon
+++ b/.claude/skills/fal-tryon
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-tryon

--- a/.claude/skills/fal-upscale
+++ b/.claude/skills/fal-upscale
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-upscale

--- a/.claude/skills/fal-video-edit
+++ b/.claude/skills/fal-video-edit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-video-edit

--- a/.claude/skills/fal-vision
+++ b/.claude/skills/fal-vision
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/fal-vision

--- a/.claude/skills/figma-code-connect-components
+++ b/.claude/skills/figma-code-connect-components
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-code-connect-components

--- a/.claude/skills/figma-create-design-system-rules
+++ b/.claude/skills/figma-create-design-system-rules
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-create-design-system-rules

--- a/.claude/skills/figma-create-new-file
+++ b/.claude/skills/figma-create-new-file
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-create-new-file

--- a/.claude/skills/figma-generate-design
+++ b/.claude/skills/figma-generate-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-generate-design

--- a/.claude/skills/figma-generate-library
+++ b/.claude/skills/figma-generate-library
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-generate-library

--- a/.claude/skills/figma-implement-design
+++ b/.claude/skills/figma-implement-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-implement-design

--- a/.claude/skills/figma-use
+++ b/.claude/skills/figma-use
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/figma-use

--- a/.claude/skills/finance-report
+++ b/.claude/skills/finance-report
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/finance-report

--- a/.claude/skills/flowai-live-dashboard-template
+++ b/.claude/skills/flowai-live-dashboard-template
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/flowai-live-dashboard-template

--- a/.claude/skills/flutter-animating-apps
+++ b/.claude/skills/flutter-animating-apps
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/flutter-animating-apps

--- a/.claude/skills/frontend-dev
+++ b/.claude/skills/frontend-dev
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/frontend-dev

--- a/.claude/skills/frontend-skill
+++ b/.claude/skills/frontend-skill
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/frontend-skill

--- a/.claude/skills/full-page-screenshot
+++ b/.claude/skills/full-page-screenshot
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/full-page-screenshot

--- a/.claude/skills/gamified-app
+++ b/.claude/skills/gamified-app
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/gamified-app

--- a/.claude/skills/gif-sticker-maker
+++ b/.claude/skills/gif-sticker-maker
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gif-sticker-maker

--- a/.claude/skills/github-dashboard
+++ b/.claude/skills/github-dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/github-dashboard

--- a/.claude/skills/gsap-core
+++ b/.claude/skills/gsap-core
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-core

--- a/.claude/skills/gsap-react
+++ b/.claude/skills/gsap-react
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-react

--- a/.claude/skills/gsap-scrolltrigger
+++ b/.claude/skills/gsap-scrolltrigger
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-scrolltrigger

--- a/.claude/skills/gsap-timeline
+++ b/.claude/skills/gsap-timeline
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/gsap-timeline

--- a/.claude/skills/guizang-ppt
+++ b/.claude/skills/guizang-ppt
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/guizang-ppt

--- a/.claude/skills/hand-drawn-diagrams
+++ b/.claude/skills/hand-drawn-diagrams
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/hand-drawn-diagrams

--- a/.claude/skills/hr-onboarding
+++ b/.claude/skills/hr-onboarding
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/hr-onboarding

--- a/.claude/skills/html-ppt
+++ b/.claude/skills/html-ppt
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt

--- a/.claude/skills/html-ppt-course-module
+++ b/.claude/skills/html-ppt-course-module
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-course-module

--- a/.claude/skills/html-ppt-dir-key-nav-minimal
+++ b/.claude/skills/html-ppt-dir-key-nav-minimal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-dir-key-nav-minimal

--- a/.claude/skills/html-ppt-graphify-dark-graph
+++ b/.claude/skills/html-ppt-graphify-dark-graph
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-graphify-dark-graph

--- a/.claude/skills/html-ppt-hermes-cyber-terminal
+++ b/.claude/skills/html-ppt-hermes-cyber-terminal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-hermes-cyber-terminal

--- a/.claude/skills/html-ppt-knowledge-arch-blueprint
+++ b/.claude/skills/html-ppt-knowledge-arch-blueprint
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-knowledge-arch-blueprint

--- a/.claude/skills/html-ppt-obsidian-claude-gradient
+++ b/.claude/skills/html-ppt-obsidian-claude-gradient
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-obsidian-claude-gradient

--- a/.claude/skills/html-ppt-pitch-deck
+++ b/.claude/skills/html-ppt-pitch-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-pitch-deck

--- a/.claude/skills/html-ppt-presenter-mode-reveal
+++ b/.claude/skills/html-ppt-presenter-mode-reveal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-presenter-mode-reveal

--- a/.claude/skills/html-ppt-product-launch
+++ b/.claude/skills/html-ppt-product-launch
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-product-launch

--- a/.claude/skills/html-ppt-taste-brutalist
+++ b/.claude/skills/html-ppt-taste-brutalist
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-taste-brutalist

--- a/.claude/skills/html-ppt-taste-editorial
+++ b/.claude/skills/html-ppt-taste-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-taste-editorial

--- a/.claude/skills/html-ppt-tech-sharing
+++ b/.claude/skills/html-ppt-tech-sharing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-tech-sharing

--- a/.claude/skills/html-ppt-testing-safety-alert
+++ b/.claude/skills/html-ppt-testing-safety-alert
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-testing-safety-alert

--- a/.claude/skills/html-ppt-weekly-report
+++ b/.claude/skills/html-ppt-weekly-report
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-weekly-report

--- a/.claude/skills/html-ppt-xhs-pastel-card
+++ b/.claude/skills/html-ppt-xhs-pastel-card
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-xhs-pastel-card

--- a/.claude/skills/html-ppt-xhs-post
+++ b/.claude/skills/html-ppt-xhs-post
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-xhs-post

--- a/.claude/skills/html-ppt-xhs-white-editorial
+++ b/.claude/skills/html-ppt-xhs-white-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-xhs-white-editorial

--- a/.claude/skills/html-ppt-zhangzara-8-bit-orbit
+++ b/.claude/skills/html-ppt-zhangzara-8-bit-orbit
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-8-bit-orbit

--- a/.claude/skills/html-ppt-zhangzara-biennale-yellow
+++ b/.claude/skills/html-ppt-zhangzara-biennale-yellow
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-biennale-yellow

--- a/.claude/skills/html-ppt-zhangzara-block-frame
+++ b/.claude/skills/html-ppt-zhangzara-block-frame
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-block-frame

--- a/.claude/skills/html-ppt-zhangzara-blue-professional
+++ b/.claude/skills/html-ppt-zhangzara-blue-professional
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-blue-professional

--- a/.claude/skills/html-ppt-zhangzara-bold-poster
+++ b/.claude/skills/html-ppt-zhangzara-bold-poster
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-bold-poster

--- a/.claude/skills/html-ppt-zhangzara-broadside
+++ b/.claude/skills/html-ppt-zhangzara-broadside
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-broadside

--- a/.claude/skills/html-ppt-zhangzara-capsule
+++ b/.claude/skills/html-ppt-zhangzara-capsule
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-capsule

--- a/.claude/skills/html-ppt-zhangzara-cartesian
+++ b/.claude/skills/html-ppt-zhangzara-cartesian
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cartesian

--- a/.claude/skills/html-ppt-zhangzara-cobalt-grid
+++ b/.claude/skills/html-ppt-zhangzara-cobalt-grid
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-cobalt-grid

--- a/.claude/skills/html-ppt-zhangzara-coral
+++ b/.claude/skills/html-ppt-zhangzara-coral
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-coral

--- a/.claude/skills/html-ppt-zhangzara-creative-mode
+++ b/.claude/skills/html-ppt-zhangzara-creative-mode
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-creative-mode

--- a/.claude/skills/html-ppt-zhangzara-daisy-days
+++ b/.claude/skills/html-ppt-zhangzara-daisy-days
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-daisy-days

--- a/.claude/skills/html-ppt-zhangzara-editorial-tri-tone
+++ b/.claude/skills/html-ppt-zhangzara-editorial-tri-tone
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-editorial-tri-tone

--- a/.claude/skills/html-ppt-zhangzara-grove
+++ b/.claude/skills/html-ppt-zhangzara-grove
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-grove

--- a/.claude/skills/html-ppt-zhangzara-long-table
+++ b/.claude/skills/html-ppt-zhangzara-long-table
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-long-table

--- a/.claude/skills/html-ppt-zhangzara-mat
+++ b/.claude/skills/html-ppt-zhangzara-mat
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-mat

--- a/.claude/skills/html-ppt-zhangzara-monochrome
+++ b/.claude/skills/html-ppt-zhangzara-monochrome
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-monochrome

--- a/.claude/skills/html-ppt-zhangzara-neo-grid-bold
+++ b/.claude/skills/html-ppt-zhangzara-neo-grid-bold
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-neo-grid-bold

--- a/.claude/skills/html-ppt-zhangzara-peoples-platform
+++ b/.claude/skills/html-ppt-zhangzara-peoples-platform
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-peoples-platform

--- a/.claude/skills/html-ppt-zhangzara-pin-and-paper
+++ b/.claude/skills/html-ppt-zhangzara-pin-and-paper
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pin-and-paper

--- a/.claude/skills/html-ppt-zhangzara-pink-script
+++ b/.claude/skills/html-ppt-zhangzara-pink-script
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-pink-script

--- a/.claude/skills/html-ppt-zhangzara-playful
+++ b/.claude/skills/html-ppt-zhangzara-playful
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-playful

--- a/.claude/skills/html-ppt-zhangzara-raw-grid
+++ b/.claude/skills/html-ppt-zhangzara-raw-grid
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-raw-grid

--- a/.claude/skills/html-ppt-zhangzara-retro-windows
+++ b/.claude/skills/html-ppt-zhangzara-retro-windows
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-windows

--- a/.claude/skills/html-ppt-zhangzara-retro-zine
+++ b/.claude/skills/html-ppt-zhangzara-retro-zine
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-retro-zine

--- a/.claude/skills/html-ppt-zhangzara-sakura-chroma
+++ b/.claude/skills/html-ppt-zhangzara-sakura-chroma
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-sakura-chroma

--- a/.claude/skills/html-ppt-zhangzara-scatterbrain
+++ b/.claude/skills/html-ppt-zhangzara-scatterbrain
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-scatterbrain

--- a/.claude/skills/html-ppt-zhangzara-signal
+++ b/.claude/skills/html-ppt-zhangzara-signal
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-signal

--- a/.claude/skills/html-ppt-zhangzara-soft-editorial
+++ b/.claude/skills/html-ppt-zhangzara-soft-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-soft-editorial

--- a/.claude/skills/html-ppt-zhangzara-stencil-tablet
+++ b/.claude/skills/html-ppt-zhangzara-stencil-tablet
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-stencil-tablet

--- a/.claude/skills/html-ppt-zhangzara-studio
+++ b/.claude/skills/html-ppt-zhangzara-studio
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-studio

--- a/.claude/skills/html-ppt-zhangzara-vellum
+++ b/.claude/skills/html-ppt-zhangzara-vellum
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/html-ppt-zhangzara-vellum

--- a/.claude/skills/hyperframes
+++ b/.claude/skills/hyperframes
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/hyperframes

--- a/.claude/skills/ib-pitch-book
+++ b/.claude/skills/ib-pitch-book
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/ib-pitch-book

--- a/.claude/skills/image-enhancer
+++ b/.claude/skills/image-enhancer
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/image-enhancer

--- a/.claude/skills/image-poster
+++ b/.claude/skills/image-poster
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/image-poster

--- a/.claude/skills/imagegen
+++ b/.claude/skills/imagegen
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/imagegen

--- a/.claude/skills/imagen
+++ b/.claude/skills/imagen
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/imagen

--- a/.claude/skills/invoice
+++ b/.claude/skills/invoice
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/invoice

--- a/.claude/skills/kami-deck
+++ b/.claude/skills/kami-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/kami-deck

--- a/.claude/skills/kami-landing
+++ b/.claude/skills/kami-landing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/kami-landing

--- a/.claude/skills/kanban-board
+++ b/.claude/skills/kanban-board
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/kanban-board

--- a/.claude/skills/last30days
+++ b/.claude/skills/last30days
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/last30days

--- a/.claude/skills/live-artifact
+++ b/.claude/skills/live-artifact
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/live-artifact

--- a/.claude/skills/live-dashboard
+++ b/.claude/skills/live-dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/live-dashboard

--- a/.claude/skills/magazine-poster
+++ b/.claude/skills/magazine-poster
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/magazine-poster

--- a/.claude/skills/meeting-notes
+++ b/.claude/skills/meeting-notes
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/meeting-notes

--- a/.claude/skills/minimax-docx
+++ b/.claude/skills/minimax-docx
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/minimax-docx

--- a/.claude/skills/minimax-pdf
+++ b/.claude/skills/minimax-pdf
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/minimax-pdf

--- a/.claude/skills/mobile-app
+++ b/.claude/skills/mobile-app
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/mobile-app

--- a/.claude/skills/mobile-onboarding
+++ b/.claude/skills/mobile-onboarding
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/mobile-onboarding

--- a/.claude/skills/motion-frames
+++ b/.claude/skills/motion-frames
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/motion-frames

--- a/.claude/skills/nanobanana-ppt
+++ b/.claude/skills/nanobanana-ppt
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/nanobanana-ppt

--- a/.claude/skills/open-design-landing
+++ b/.claude/skills/open-design-landing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/open-design-landing

--- a/.claude/skills/open-design-landing-deck
+++ b/.claude/skills/open-design-landing-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/open-design-landing-deck

--- a/.claude/skills/orbit-general
+++ b/.claude/skills/orbit-general
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-general

--- a/.claude/skills/orbit-github
+++ b/.claude/skills/orbit-github
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-github

--- a/.claude/skills/orbit-gmail
+++ b/.claude/skills/orbit-gmail
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-gmail

--- a/.claude/skills/orbit-linear
+++ b/.claude/skills/orbit-linear
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-linear

--- a/.claude/skills/orbit-notion
+++ b/.claude/skills/orbit-notion
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/orbit-notion

--- a/.claude/skills/pixelbin-media
+++ b/.claude/skills/pixelbin-media
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pixelbin-media

--- a/.claude/skills/platform-design
+++ b/.claude/skills/platform-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/platform-design

--- a/.claude/skills/pm-spec
+++ b/.claude/skills/pm-spec
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/pm-spec

--- a/.claude/skills/pptx-generator
+++ b/.claude/skills/pptx-generator
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/pptx-generator

--- a/.claude/skills/pricing-page
+++ b/.claude/skills/pricing-page
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/pricing-page

--- a/.claude/skills/remotion
+++ b/.claude/skills/remotion
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/remotion

--- a/.claude/skills/replicate
+++ b/.claude/skills/replicate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/replicate

--- a/.claude/skills/replit-deck
+++ b/.claude/skills/replit-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/replit-deck

--- a/.claude/skills/saas-landing
+++ b/.claude/skills/saas-landing
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/saas-landing

--- a/.claude/skills/screenshots-marketing
+++ b/.claude/skills/screenshots-marketing
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/screenshots-marketing

--- a/.claude/skills/shadcn-ui
+++ b/.claude/skills/shadcn-ui
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/shadcn-ui

--- a/.claude/skills/shader-dev
+++ b/.claude/skills/shader-dev
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/shader-dev

--- a/.claude/skills/simple-deck
+++ b/.claude/skills/simple-deck
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/simple-deck

--- a/.claude/skills/slack-gif-creator
+++ b/.claude/skills/slack-gif-creator
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/slack-gif-creator

--- a/.claude/skills/slides
+++ b/.claude/skills/slides
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/slides

--- a/.claude/skills/social-carousel
+++ b/.claude/skills/social-carousel
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/social-carousel

--- a/.claude/skills/social-media-dashboard
+++ b/.claude/skills/social-media-dashboard
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/social-media-dashboard

--- a/.claude/skills/social-media-matrix-tracker-template
+++ b/.claude/skills/social-media-matrix-tracker-template
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/social-media-matrix-tracker-template

--- a/.claude/skills/sora
+++ b/.claude/skills/sora
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/sora

--- a/.claude/skills/speech
+++ b/.claude/skills/speech
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/speech

--- a/.claude/skills/sprite-animation
+++ b/.claude/skills/sprite-animation
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/sprite-animation

--- a/.claude/skills/stitch-loop
+++ b/.claude/skills/stitch-loop
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/stitch-loop

--- a/.claude/skills/swiftui-design
+++ b/.claude/skills/swiftui-design
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/swiftui-design

--- a/.claude/skills/taste-skill
+++ b/.claude/skills/taste-skill
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/taste-skill

--- a/.claude/skills/team-okrs
+++ b/.claude/skills/team-okrs
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/team-okrs

--- a/.claude/skills/threejs
+++ b/.claude/skills/threejs
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/threejs

--- a/.claude/skills/trading-analysis-dashboard-template
+++ b/.claude/skills/trading-analysis-dashboard-template
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/trading-analysis-dashboard-template

--- a/.claude/skills/tweaks
+++ b/.claude/skills/tweaks
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/tweaks

--- a/.claude/skills/ui-skills
+++ b/.claude/skills/ui-skills
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ui-skills

--- a/.claude/skills/ui-ux-pro-max
+++ b/.claude/skills/ui-ux-pro-max
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/ui-ux-pro-max

--- a/.claude/skills/venice-audio-music
+++ b/.claude/skills/venice-audio-music
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-audio-music

--- a/.claude/skills/venice-audio-speech
+++ b/.claude/skills/venice-audio-speech
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-audio-speech

--- a/.claude/skills/venice-image-edit
+++ b/.claude/skills/venice-image-edit
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-image-edit

--- a/.claude/skills/venice-image-generate
+++ b/.claude/skills/venice-image-generate
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-image-generate

--- a/.claude/skills/venice-video
+++ b/.claude/skills/venice-video
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/venice-video

--- a/.claude/skills/video-downloader
+++ b/.claude/skills/video-downloader
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/video-downloader

--- a/.claude/skills/video-shortform
+++ b/.claude/skills/video-shortform
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/video-shortform

--- a/.claude/skills/waitlist-page
+++ b/.claude/skills/waitlist-page
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/waitlist-page

--- a/.claude/skills/web-design-guidelines
+++ b/.claude/skills/web-design-guidelines
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/web-design-guidelines

--- a/.claude/skills/web-prototype
+++ b/.claude/skills/web-prototype
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype

--- a/.claude/skills/web-prototype-taste-brutalist
+++ b/.claude/skills/web-prototype-taste-brutalist
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype-taste-brutalist

--- a/.claude/skills/web-prototype-taste-editorial
+++ b/.claude/skills/web-prototype-taste-editorial
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype-taste-editorial

--- a/.claude/skills/web-prototype-taste-soft
+++ b/.claude/skills/web-prototype-taste-soft
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/web-prototype-taste-soft

--- a/.claude/skills/weekly-update
+++ b/.claude/skills/weekly-update
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/weekly-update

--- a/.claude/skills/wireframe-sketch
+++ b/.claude/skills/wireframe-sketch
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/wireframe-sketch

--- a/.claude/skills/wpds
+++ b/.claude/skills/wpds
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/wpds

--- a/.claude/skills/x-research
+++ b/.claude/skills/x-research
@@ -1,1 +1,0 @@
-../../trusted-external-repos/open-design/skills/x-research

--- a/.claude/skills/youtube-clipper
+++ b/.claude/skills/youtube-clipper
@@ -1,0 +1,1 @@
+../../trusted-external-repos/open-design/skills/youtube-clipper


### PR DESCRIPTION
## Summary

Follow-up to #204. That PR regenerated the downstream skill catalog (`personal-site/lib/skills.generated.json` + `personal-site/public/skill-files/`) but missed the upstream tracked entrypoint directories themselves — `.agents/skills/` and `.claude/skills/`.

`scripts/sync_skills.sh refresh` rebuilds both directories by `rm -rf` then re-creating symlinks. The new symlink set differs from what main had after #204:

- **220 deletions**: symlinks to skill dirs no longer present in any source (most were dangling references into `open-design` after the submodule pin moved, plus the open-design stubs that #204's precedence rule started shadowing).
- **156 additions**: symlinks to skills now present in the source roots but not yet mirrored on main (additions to `open-design` / `gstack` / `repo-skills` since the last refresh).

Net: each entrypoint dir goes from 247 to 215 tracked symlinks, matching the 215-entry `skills.generated.json` shipped in #204.

## Why this matters

Without this PR, the three layers are inconsistent on main:

1. **Source** — `repo-skills/` + `trusted-external-repos/*/skills/` — 215 real skills.
2. **Generator output** (shipped in #204) — 215 skills.
3. **Tracked entrypoints** (this PR) — 247 symlinks, some pointing at skills that no longer exist.

A fresh `git clone` would land with `.claude/skills/` containing broken symlinks, breaking Claude Code / Codex skill discovery on session start.

## Scope

No source skills, no script logic, and no generator output were modified — purely the bookkeeping that #204 omitted.

## Test plan

- [x] `git diff` on every changed entry is either `delete` or `create` of a `120000` symlink (no content drift).
- [x] After merge, `zsh scripts/sync_skills.sh refresh` produces a clean tree.
- [x] After merge, `cd personal-site && npm run skills:generate` produces a clean tree.
- [ ] Spot-check on a fresh clone: `ls .claude/skills/` returns 215 working symlinks, no broken ones.