### PR TITLE
palace: add Text version back-link to InfoOverlay

### DIFF
--- a/personal-site/palace-outer/src/Application/UI/components/BackToTextSite.tsx
+++ b/personal-site/palace-outer/src/Application/UI/components/BackToTextSite.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Easing } from '../Animation';
+
+const LABEL = '← Text version';
+
+type BackToTextSiteProps = {};
+
+const BackToTextSite: React.FC<BackToTextSiteProps> = () => {
+    const [isHovering, setIsHovering] = useState(false);
+    const [isActive, setIsActive] = useState(false);
+
+    const background = isHovering ? '#fff' : '#000';
+    const color = isHovering ? '#000' : '#fff';
+
+    return (
+        <motion.a
+            href="/"
+            id="prevent-click"
+            initial="hidden"
+            animate="visible"
+            variants={vars}
+            onMouseEnter={() => setIsHovering(true)}
+            onMouseLeave={() => {
+                setIsHovering(false);
+                setIsActive(false);
+            }}
+            onMouseDown={() => setIsActive(true)}
+            onMouseUp={() => setIsActive(false)}
+            style={{
+                ...styles.container,
+                background,
+                opacity: isActive ? 0.6 : 1,
+            }}
+        >
+            <p id="prevent-click" style={{ color }}>
+                {LABEL}
+            </p>
+        </motion.a>
+    );
+};
+
+const vars = {
+    hidden: {
+        opacity: 0,
+        x: -8,
+    },
+    visible: {
+        opacity: 1,
+        x: 0,
+        transition: {
+            duration: 0.3,
+            ease: Easing.expOut,
+        },
+    },
+};
+
+const styles: StyleSheetCSS = {
+    container: {
+        background: '#000',
+        padding: 4,
+        paddingLeft: 16,
+        paddingRight: 16,
+        textAlign: 'center',
+        display: 'inline-flex',
+        marginBottom: 4,
+        boxSizing: 'border-box',
+        cursor: 'pointer',
+        textDecoration: 'none',
+        alignSelf: 'flex-start',
+        transition:
+            'background 120ms ease-out, color 120ms ease-out, opacity 120ms ease-out',
+    },
+};
+
+export default BackToTextSite;

--- a/personal-site/palace-outer/src/Application/UI/components/InfoOverlay.tsx
+++ b/personal-site/palace-outer/src/Application/UI/components/InfoOverlay.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import BackToTextSite from './BackToTextSite';
 import FreeCamToggle from './FreeCamToggle';
 import MuteToggle from './MuteToggle';
 
@@ -20,6 +21,7 @@ const InfoOverlay: React.FC<InfoOverlayProps> = ({ visible }) => {
     const [textDone, setTextDone] = useState(false);
     const [volumeVisible, setVolumeVisible] = useState(false);
     const [freeCamVisible, setFreeCamVisible] = useState(false);
+    const [backLinkVisible, setBackLinkVisible] = useState(false);
 
     const typeText = (
         i: number,
@@ -83,6 +85,9 @@ const InfoOverlay: React.FC<InfoOverlayProps> = ({ visible }) => {
                 setVolumeVisible(true);
                 setTimeout(() => {
                     setFreeCamVisible(true);
+                    setTimeout(() => {
+                        setBackLinkVisible(true);
+                    }, 250);
                 }, 250);
             }, 250);
         }
@@ -139,6 +144,7 @@ const InfoOverlay: React.FC<InfoOverlayProps> = ({ visible }) => {
                     )}
                 </div>
             )}
+            {backLinkVisible && <BackToTextSite />}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- `/palace` had no in-page way back to the text site at `/` — only the address bar.
- Adds a new `BackToTextSite` button in the top-left `InfoOverlay`, beneath the time row.
- Fades in after the mute / free-cam icons, sharing the staggered entrance.
- Styling matches the existing rows: black pill, monospace, white text → inverts to black-on-white on hover (BIOS-style, same hover treatment as `.bios-start-button`).
- Uses `<a href="/">` because `/palace` is a static webpack bundle — we need a full navigation back into the Next.js app.
- Carries `id="prevent-click"` so the Camera click handler ([Camera.ts:72](../blob/main/personal-site/palace-outer/src/Application/Camera/Camera.ts#L72)) doesn't treat the click as a 3D scene interaction.

## Test plan
- [x] `npm run palace:build` from `personal-site/` — webpack + CRA build clean, new bundle contains the `Text version` label.
- [ ] Visually verify the button appears beneath the icons after intro animation, hover inverts, click lands on `/`.
- [ ] Mobile breakpoint (<768px) — font scales down to 10px via the existing global rule.