### PR TITLE
memory: log 2026-05-12 disk cleanup + CARGO_TARGET_DIR note

### DIFF
--- a/memory/2026-05-12.md
+++ b/memory/2026-05-12.md
@@ -1,0 +1,47 @@
+# 2026-05-12
+
+## Disk cleanup — freed 90 GB from worktrees
+
+Mac was at 889 GB / 931 GB used (99% full, 14 GB free). Bingran noticed "莫名其妙几天多了上百 GB". Diagnosed and cleaned in three steps; ended at 799 GB / 931 GB used (89%, 104 GB free).
+
+### Root cause
+
+DoWhiz is a Rust project. **Every Claude Code / Codex worktree compiles its own `DoWhiz_service/target/` → ~9 GB each.** There were 81 DoWhiz worktrees alive (68 under `~/Downloads/Claude-Code-Worktree/DoWhiz/`, 13 under `~/.codex/worktrees/`), plus 19 bingran-you worktrees with their own `personal-site/.next` + `node_modules` × multiple submodules.
+
+So the rate of growth is roughly: **+5–9 GB per new DoWhiz worktree** the first time `cargo build` runs in it. A week of heavy worktree use ≈ +100 GB silently.
+
+### Three-step cleanup (executed)
+
+1. **Step A — delete build artifacts in worktrees** (53 GB):
+   - 20 × `target/` under `Claude-Code-Worktree/DoWhiz/*/DoWhiz_service/`
+   - 3 × `.next/` + 12 × `node_modules/` under `Claude-Code-Worktree/bingran-you/*/personal-site/`
+   - Pure rebuild artifacts, no git state touched.
+2. **Step B — remove merged worktrees** (14 GB): 42 worktrees on branches already merged into `dev` (DoWhiz, 35) or `main` (bingran-you, 7) → `git worktree remove`. 3 DoWhiz worktrees needed `--force` (only `.claude/settings.local.json` + `.claude/scheduled_tasks.lock` were dirty — Claude Code runtime crumbs). 5 bingran-you worktrees refused because git won't remove worktrees containing submodules — used `rm -rf` + `git worktree prune`.
+3. **Step C — drop all of `~/.codex/worktrees/`** (23 GB): 13 DoWhiz + 1 bingran-you detached-HEAD ad-hoc worktrees, plus orphan dirs git no longer tracked. Checked `lsof +D` first (empty). Codex desktop Electron app keeps running fine — it doesn't lock worktree files.
+
+### Future preventive measure — `CARGO_TARGET_DIR`
+
+Each new DoWhiz worktree currently rebuilds 9 GB of Rust artifacts from scratch. Setting a shared target directory would collapse all worktrees onto one shared `target/`:
+
+```sh
+# in ~/.zshrc or per-project .envrc
+export CARGO_TARGET_DIR="$HOME/.cargo/shared-target"
+```
+
+Trade-off: builds across worktrees share the same artifact cache, so concurrent builds in two worktrees may rebuild each other's invalidations. For DoWhiz's normal usage (one or two active worktrees at a time) the disk savings are massive. Worth setting up next time we touch DoWhiz tooling.
+
+Also worth doing eventually:
+
+- Use `git worktree add -b ... --detach` discipline + a "delete the branch when worktree is removed" alias.
+- Periodic `git worktree prune` is harmless and should be in a weekly task.
+- 35 still-unmerged worktrees remain (28 DoWhiz, 7 bingran-you). Re-run Step B after future merges.
+
+### Inventory of other reclaimable caches (not yet touched, ~12 GB more)
+
+- `~/.cache/uv` — 3.8 GB
+- `~/.cache/huggingface` — 2.2 GB
+- `~/.npm/_cacache` — 5.2 GB
+- `~/Library/Caches/Homebrew` — 2.1 GB
+- `~/Library/Caches/pip` — 1.9 GB
+
+All safe to clear; tools will repopulate on next use.


### PR DESCRIPTION
## Summary

- Logs today's three-step worktree cleanup that freed ~90 GB (889 GB → 799 GB used; 14 GB → 104 GB free).
- Documents the root cause: each Claude Code / Codex worktree of DoWhiz compiles its own ~9 GB Rust \`target/\`, so a week of worktree-heavy use silently piles on 100+ GB.
- Captures the \`CARGO_TARGET_DIR\` mitigation to share build artifacts across worktrees next time we touch DoWhiz tooling.

## Test plan

- [x] Memory file follows the daily-log format used by recent entries (e.g. memory/2026-05-10.md).
- [x] No source code or skill artifacts touched — pure docs, no \`make sync\` needed.