### PR TITLE
tools: document worktree submodule hygiene and disk traps

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -37,6 +37,25 @@ By default, you should always send a PR and squash merge into main and delete th
 
 When I ask you to do reports / deep research / article review / display or explain any content or concept, if the content is worth sharing, by default you can create a blog post in the website in blog section. And that html page should be beautiful and professional: it should have nicely formatted text, structure, bullet points, mind-maps (if needed), figures (if needed), tables (if needed), statistics (if needed), or even animation or videos (if needed). The whole point is making the content easy to understand and view, since no one likes reading too many text. But do not sacrifice the content itself. The content should always be professional and informative. Please avoid unnecessary filler. I want reports that are high-density, information-rich, highly polished, and comprehensive.
 
+## Worktree & disk hygiene
+
+The `bingran-you` repo nests many submodules (`trusted-external-repos/*`, `current-projects/*`, `bingran-you-private`). Most of them are large reference repos that a typical task does **not** touch. Watch out for two failure modes that quietly eat tens of GB:
+
+1. **Submodule init blows up the main repo's `.git/worktrees/`.** When a worktree runs `git submodule update --init --recursive`, each submodule's `.git` data lands in `<main-repo>/.git/worktrees/<branch>/modules/<submodule>/`, not in the worktree itself. 50+ worktrees × all-submodules ≈ 15–20G inside the main `.git/`.
+2. **Removed worktree directories leave `prunable` metadata behind.** Deleting a worktree folder with `rm -rf` doesn't free the `.git/worktrees/<name>/` slot — only `git worktree remove` or `git worktree prune` does.
+
+Rules:
+
+- **Don't `--recursive` init by default.** Only `git submodule update --init <path>` for the submodules the current task actually needs (usually none, sometimes `personal-site/` deps live in `repo-skills/`, occasionally `trusted-external-repos/skills` for a skill edit). If you don't know, ask — don't preemptively pull 16G of submodule history.
+- **Finish a worktree with `git worktree remove <path>`, not `rm -rf`.** That cleans the metadata and submodule `.git` data in one go. If a worktree was already `rm`'d, run `git worktree prune -v` in the main repo to reclaim it.
+- **Periodic hygiene in `~/Downloads/GitHub/bingran-you`:** `git worktree prune -v && git gc --prune=now`. Safe to run anytime; reclaims dead worktree metadata and compacts packs.
+
+Other disk traps to know about on this machine:
+
+- **Docker `buildx` cache never expires.** One pass of `kywch/smolclaws-base` (Claude Code sandbox) left 21G of build cache sitting for 7 weeks. After any sandbox / dev-container work, run `docker builder prune -a -f`. If you genuinely don't use Docker, reset the disk image from Docker Desktop → Settings → Resources.
+- **`~/Library/Application Support/Claude/vm_bundles/claudevm.bundle/` is ~10G.** That's the Claude **desktop app**'s sandbox VM, not the CLI. CLI does not depend on it — safe to delete if Bingran isn't using the desktop sandbox feature.
+- **WeChat (`~/Library/Containers/com.tencent.xinWeChat`) grows ~10–20G/month** from group chat attachments. Cleaned only via the WeChat app's storage panel — never touch the container directly.
+
 ## Task Delivery
 
 You are end-to-end. When Bingran gives you a task:


### PR DESCRIPTION
## Context

Today's disk audit: laptop was at 88% full (106G free of 926G). Root causes turned out to be:

1. **`.git/worktrees/` in `bingran-you` had ballooned to 16G** — 53 dead worktree slots whose working directories had been `rm`'d, each holding a copy of every submodule's `.git` data under `.git/worktrees/<branch>/modules/`.
2. **Docker `buildx` cache held 21G for 7 weeks** — leftover layers from a single `kywch/smolclaws-base` (Claude Code sandbox) build; buildx cache never auto-expires.
3. Worktree working directories themselves were fine (17G total across 13 active worktrees) — not the culprit despite intuition.

Recovered ~59G via `git worktree prune` + `git gc` + `docker builder prune` + brew/pip cache cleanup. None of it touched Claude Code itself (`~/.claude` is 270M).

## Change

Adds a **Worktree & disk hygiene** section to `TOOLS.md` so future agents know:

- Don't `git submodule update --init --recursive` by default — only init what the task needs. (Each unnecessary `--recursive` adds ~300MB to the main repo's `.git/worktrees/`.)
- Tear down worktrees with `git worktree remove <path>`, not `rm -rf` — otherwise the metadata sticks around as `prunable`.
- Periodic `git worktree prune -v && git gc --prune=now` is safe and reclaims dead-worktree storage.
- Three other disk traps on this machine (Docker buildx cache, Claude desktop `vm_bundles/`, WeChat container).

## Test plan

- [x] `git diff` reviewed — single-section addition, no other edits
- [x] No skill source touched → no `make sync` needed