### PR TITLE
personal-site: fix Download SKILL.md button contrast on /skills/[slug]

### DIFF
--- a/personal-site/app/(personal)/skills/[slug]/page.tsx
+++ b/personal-site/app/(personal)/skills/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function SkillDetailPage({
           <a
             href={skill.downloadUrl}
             download={`${skill.slug}.md`}
-            className="inline-flex items-center gap-1.5 rounded-full border border-foreground bg-foreground px-3.5 py-1.5 text-xs text-[var(--background)] transition hover:opacity-90"
+            className="inline-flex items-center gap-1.5 rounded-full border border-foreground bg-foreground px-3.5 py-1.5 text-xs text-[var(--background)]! no-underline! transition hover:opacity-90"
           >
             <DownloadIcon className="h-3 w-3" />
             Download SKILL.md


### PR DESCRIPTION
## Summary

- The global `a { color: var(--paper-link); text-decoration: underline }` rule in [globals.css:206](personal-site/app/globals.css) is unlayered, so it beats Tailwind utilities on the filled Download button. The button rendered as **Win98 violet `#551a8b` text + underline on near-black `bg-foreground`** — contrast ratio ~1.4:1, fails WCAG entirely.
- Fix: add Tailwind v4 `!` suffix to `text-[var(--background)]!` and `no-underline!` so the intended cream-on-black palette wins. New contrast ~13.7:1 (AAA). Verified the compiled CSS emits `color: var(--background) !important` and `text-decoration-line: none !important`.
- Scope: only the filled primary button. The secondary "View source on GitHub" pill keeps violet+underline — that's the Win98 paper theme on cream and reads fine.

## Test plan

- [x] Render `/skills/memory-palace` locally via `npm run dev` and inspect rendered `class` attribute on the Download anchor.
- [x] Verify compiled CSS bundle contains both `!important` rules.
- [ ] Reviewer: load the deployed preview and confirm the Download pill shows cream text without an underline on every skill detail page.