### PR TITLE
personal-site: emit atom:updated as RFC 3339 in RSS feed

### DIFF
--- a/personal-site/lib/feed.ts
+++ b/personal-site/lib/feed.ts
@@ -57,7 +57,7 @@ export function renderRssFeed(
       <link>${escapeXml(url)}</link>
       <guid isPermaLink="true">${escapeXml(url)}</guid>
       <pubDate>${pubDateOf(item)}</pubDate>
-      <atom:updated>${item.lastModified.toUTCString()}</atom:updated>
+      <atom:updated>${item.lastModified.toISOString()}</atom:updated>
       <description><![CDATA[${escapeCdata(description)}]]></description>${creatorLine}
     </item>`;
     })


### PR DESCRIPTION
## Summary
W3C feed validator (https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fbingran.ai%2Ffeed.xml) flagged a real spec error introduced in #134:

> `atom:updated` must be an RFC-3339 date-time: `Sun, 17 May 2026 21:02:00 GMT` (8 occurrences, first at line 15)

Atom (RFC 4287) timestamps are RFC 3339, not RFC 2822. We were calling `Date.toUTCString()` (which emits the RFC 2822 form `"Sun, 17 May 2026 21:02:00 GMT"`) into `<atom:updated>`.

Fix: switch `<atom:updated>` to `toISOString()` (`2026-05-17T21:05:12.388Z`). Keep `<pubDate>` on `toUTCString()` — `<pubDate>` is RSS 2.0 (channel/item) which *does* use RFC 822/2822, so that one is correct as-is.

## Test plan
- [x] `npx next build` — passes.
- [x] Verified `<pubDate>` stays as `Mon, 11 May 2026 00:00:00 GMT` (RSS 2.0 / RFC 2822).
- [x] Verified `<atom:updated>` becomes `2026-05-17T21:05:12.388Z` (Atom / RFC 3339).
- [ ] After deploy: re-run https://validator.w3.org/feed/ — expect "valid".

---
_Generated by [Claude Code](https://claude.ai/code/session_018T1sofLeokqohJV4pG8eXA)_