### PR TITLE
personal-site: add X post 2056443020946571738 to /posts

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "x-2056443020946571738",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2056443020946571738",
+    "date": "2026-05-18",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2055929896409448612",
     "platform": "x",
     "url": "https://x.com/xdotli/status/2055929896409448612",


### PR DESCRIPTION
## Summary
- Adds Bingran's X post https://x.com/bingran_bry/status/2056443020946571738 (just posted on 2026-05-18) to `/posts`.
- Minimal entry shape (id + url + date + addedVia) matching every existing X card; `react-tweet` fetches the rest at render time.
- Hand-authored unshift to keep diff at +7/-0 and avoid the `add-post.mjs` resort-on-add reshuffle (skill §3.7).

## Test plan
- [x] `posts.json` parses; entry sits at index 0; array still sorted desc by `date`.
- [x] Diff is +7/-0, no unrelated files touched.
- [ ] Vercel preview renders the new card with embedded tweet content + author + media at the top of `/posts`.