### PR TITLE
Add overleaf-paper-sync skill

### DIFF
--- a/.agents/skills/overleaf-paper-sync
+++ b/.agents/skills/overleaf-paper-sync
@@ -1,0 +1,1 @@
+../../repo-skills/overleaf-paper-sync

--- a/.claude/skills/overleaf-paper-sync
+++ b/.claude/skills/overleaf-paper-sync
@@ -1,0 +1,1 @@
+../../repo-skills/overleaf-paper-sync

--- a/personal-site/lib/skills.test.ts
+++ b/personal-site/lib/skills.test.ts
@@ -71,6 +71,7 @@ describe("inferCategory", () => {
     expect(inferCategory("careful")).toBe("Engineering");
     expect(inferCategory("vercel-deploy")).toBe("Engineering");
     expect(inferCategory("gh-fix-ci")).toBe("Engineering");
+    expect(inferCategory("overleaf-paper-sync")).toBe("Engineering");
   });
 
   it("falls back to Other for unknown slugs", () => {

--- a/personal-site/lib/skills.ts
+++ b/personal-site/lib/skills.ts
@@ -125,7 +125,7 @@ export function inferCategory(slug: string): SkillCategory {
   }
 
   if (
-    /^(careful|freeze|unfreeze|guard|ship|land-and-deploy|vercel-deploy|setup-deploy|setup-gbrain|gh-address-comments|gh-fix-ci|cli-creator|codex|plugin-creator|skill-creator|skill-installer|mcp-builder|simplify|fewer-permission-prompts|update-config|keybindings-help|loop|schedule|context-save|context-restore|hatch-pet|health|pair-agent)$/.test(
+    /^(careful|freeze|unfreeze|guard|ship|land-and-deploy|vercel-deploy|setup-deploy|setup-gbrain|gh-address-comments|gh-fix-ci|cli-creator|codex|plugin-creator|skill-creator|skill-installer|mcp-builder|simplify|fewer-permission-prompts|update-config|keybindings-help|loop|schedule|context-save|context-restore|hatch-pet|health|pair-agent|overleaf-paper-sync)$/.test(
       slug,
     )
   ) {

--- a/repo-skills/overleaf-paper-sync/SKILL.md
+++ b/repo-skills/overleaf-paper-sync/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: overleaf-paper-sync
+description: Manage a LaTeX paper hosted on Overleaf via a GitHub mirror with bidirectional auto-sync through GitHub Actions. Use this skill whenever the user mentions Overleaf, paper version control, syncing a LaTeX project, a GitHub mirror of an Overleaf project, divergence or merge conflicts between Overleaf and Git, the Overleaf git authentication token, or is working in a repo that contains `.github/workflows/sync-overleaf.yml`, `pull-from-overleaf.yml`, or a `sync.ps1` / `sync.sh` helper. Also use it when onboarding a collaborator (or a collaborator's agent) to an existing Overleaf-backed paper repo. The skill covers initial setup of a brand-new paper, the daily editing ritual, the divergence-resolution playbook, and the gotchas the author hit while building this pattern — enough that an agent with no prior context can pick it up cold.
+author: Bingran You (@bingran-you)
+license: MIT
+---
+
+# Overleaf Paper Sync
+
+Manage a LaTeX paper that lives on Overleaf by mirroring it on GitHub, with both directions kept in sync automatically by two GitHub Actions workflows. The point is to get Overleaf's editor + preview while keeping GitHub's version control, PR review, and tooling — without paying for Overleaf's built-in GitHub integration.
+
+## The mental model
+
+Overleaf is a great editor (live preview, real-time collab, browser-based). It's a weak version control system. GitHub is the inverse. This setup keeps **Overleaf as the editor of record** and **GitHub as the source of version truth**, connected by two automated paths:
+
+1. **GitHub → Overleaf (push trigger).** Every push to GitHub's `master` runs `.github/workflows/sync-overleaf.yml`, which `git push`es to Overleaf's git endpoint within seconds.
+
+2. **Overleaf → GitHub (cron + on-demand).** `.github/workflows/pull-from-overleaf.yml` runs hourly on a cron and on manual trigger. It fetches Overleaf, compares HEADs, and:
+   - if Overleaf has new commits (a web edit), fast-forwards GitHub master onto them and pushes,
+   - if GitHub is already ahead, does nothing — the other workflow handles that direction,
+   - if both sides have unique commits, fails loudly with resolution instructions, because automated merges of LaTeX produce silently-broken papers.
+
+Local clones also get a `sync.ps1` / `sync.sh` helper that the user runs **before each editing session**: it triggers the pull workflow, waits for it to finish, and fast-forwards the local working copy. This catches collaborator web-edits without waiting up to an hour for the next cron tick.
+
+That's the whole system. Everything else in this skill is one of: setup, conflict resolution, or troubleshooting.
+
+## Recognizing an already-wired-up paper
+
+When stepping into an unfamiliar paper repo, these signals mean this skill applies:
+
+- `.github/workflows/sync-overleaf.yml` and/or `.github/workflows/pull-from-overleaf.yml` exist
+- Two git remotes — one with a `git.overleaf.com` URL (often named `origin`), one with a `github.com` URL (often named `github`)
+- A `sync.ps1` / `sync.sh` in the repo root
+- An `OVERLEAF_TOKEN` secret configured on the GitHub repo
+
+If 2+ of these are present, treat the repo as already set up — skip the setup section and go to **Daily editing workflow** below.
+
+## Daily editing workflow
+
+This is the most-used section. Walk the user through it whenever they're about to work on the paper.
+
+### Step 1 — Before editing: pull Overleaf changes
+
+From the paper repo root:
+
+```powershell
+# Windows
+.\sync.ps1
+```
+
+```bash
+# Mac / Linux
+./sync.sh
+```
+
+Takes ~10–30 seconds. It triggers the pull workflow on GitHub, waits for it, then fast-forwards the local clone. After this, the local working copy reflects whatever the latest collaborator web-edit on Overleaf left behind.
+
+If the script reports "diverged" or the workflow run failed, see **Conflict resolution** below — don't keep editing on top of a divergent state.
+
+### Step 2 — Edit normally
+
+VS Code, Cursor, vim, whatever. The paper repo is a regular git repo from here.
+
+### Step 3 — After editing: commit and push to GitHub only
+
+```bash
+git add .
+git commit -m "<message>"
+git push github master
+```
+
+The `sync-overleaf` workflow fires within seconds and pushes to Overleaf automatically. The user does **not** need to `git push origin` (Overleaf) — pushing manually is redundant and racy.
+
+Sanity-check the workflow ran:
+
+```bash
+gh run list --workflow=sync-overleaf.yml --limit 1
+```
+
+### What about commits made directly on Overleaf web?
+
+Those reach GitHub via:
+- The hourly cron of `pull-from-overleaf` (worst case ~60 min latency — GitHub Actions cron is delayed by 5–15 min in practice on top of the schedule)
+- The user running `sync.ps1` / `sync.sh` (fastest — usually under a minute)
+- A manual `gh workflow run pull-from-overleaf.yml`
+
+The commit on GitHub will be authored by `github-actions[bot]` since the workflow does the push — that's expected.
+
+## Conflict resolution
+
+The pull-from-overleaf workflow is **fast-forward only**. If GitHub and Overleaf have each grown commits the other doesn't have, the workflow fails on purpose. Auto-merging LaTeX between two unrelated edits would produce subtly broken output that nobody notices until the figure is upside down in the final PDF.
+
+Full playbook, including the exact commands to detect each case and recover, is in [references/conflict-resolution.md](references/conflict-resolution.md). The short version:
+
+```powershell
+cd <paper-repo>
+git fetch origin master        # origin = Overleaf
+git fetch github master
+git checkout master
+git pull github master --ff-only    # bring local up to GitHub
+git merge origin/master              # merge Overleaf in; resolve conflicts
+git push github master               # triggers sync-overleaf to push back to Overleaf
+```
+
+If the local clone doesn't have credentials cached for the Overleaf remote, fetching from `origin` will prompt. The username is the literal string `git`; the password is the OVERLEAF_TOKEN.
+
+## Setting up sync for a new paper
+
+When the user wants to add this pattern to a paper that's currently only on Overleaf (or set up a new mirrored paper from scratch), follow the procedure in [references/setup-new-paper.md](references/setup-new-paper.md). It covers:
+
+1. Generating an Overleaf git token (and the gotcha that the **token's username must be the literal string `git`**, not the user's email — Overleaf changed this and the old "email + token" auth gives a 403)
+2. Cloning the Overleaf project to a local working dir
+3. Creating an empty GitHub repo and pushing the contents up
+4. Setting the `OVERLEAF_TOKEN` secret on the repo
+5. Dropping the two workflow files and the `sync.ps1` / `sync.sh` helper into place (templates are in `assets/`)
+6. Optional: registering the paper repo as a submodule of a parent monorepo
+
+The templates in `assets/` use the literal string `__OVERLEAF_PROJECT_ID__` everywhere the Overleaf project ID has to go — search-replace it once during setup.
+
+## Common errors and fixes
+
+Quick reference. Full details and recovery commands in [references/troubleshooting.md](references/troubleshooting.md).
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `403: Overleaf now only supports Git authentication tokens` in workflow | Workflow URL uses email as username | Use `https://git:${TOKEN}@git.overleaf.com/<id>` — literal `git`, not email |
+| `fatal: Not possible to fast-forward` in pull workflow | Histories diverged | See conflict-resolution.md |
+| Workflow can't push to GitHub master | Missing `contents: write` permission or branch protection | Add `permissions: contents: write` to the workflow; check branch protection rules |
+| Local push to GitHub succeeds but Overleaf never updates | `OVERLEAF_TOKEN` missing or stale | Check `gh secret list`; reset via `gh secret set OVERLEAF_TOKEN --body "<new>"` |
+| Cron runs are skipped / very late | Normal GitHub Actions backlog | Use the `sync.ps1` / manual trigger when timing matters |
+| `fatal: Unable to create '.git/index.lock'` | Stale lock from an interrupted git operation (common after WSL/sandbox edits on Windows) | `Remove-Item .git/index.lock` (PS) or `rm .git/index.lock` (bash) |
+| `gh pr merge` says "not mergeable" right after a force-push | GitHub's mergeability cache hasn't refreshed | Wait a few seconds and retry |
+
+## Architecture notes
+
+Non-obvious details that matter when debugging:
+
+- **Default branch is `master`** (Overleaf's convention). The workflows hardcode `master`. Don't rename it.
+
+- **Why this doesn't loop infinitely:** `pull-from-overleaf` pushes to GitHub using the default `GITHUB_TOKEN`. GitHub Actions deliberately does not re-trigger workflow runs on commits made by `GITHUB_TOKEN` — that's the platform's built-in loop protection. So `pull-from-overleaf` writing to master does NOT fire `sync-overleaf` back. User pushes from a personal machine DO fire it, because they authenticate with a personal token, not `GITHUB_TOKEN`.
+
+- **Concurrency group:** both workflows share `concurrency: group: sync-overleaf`. This serializes them so one doesn't push while the other is mid-fetch. Without this, you can get into states where each workflow sees a stale view of the other side.
+
+- **Two remotes by convention:** when cloning from Overleaf and adding GitHub, the natural setup is `origin = Overleaf` (from the original clone), `github = GitHub` (added later). Some setups flip these. The workflows don't care — they always construct the Overleaf URL from scratch using the secret.
+
+- **`OVERLEAF_EMAIL` secret is vestigial.** Earlier auth tried email-as-username; Overleaf migrated to requiring the literal `git`. If the secret is set, it's harmless. New setups don't need it.
+
+## Token rotation
+
+Overleaf tokens leak. Rotate them periodically and immediately if exposed:
+
+1. In Overleaf: Account Settings → Git Integration → revoke the old token, generate a new one
+2. Update the GitHub secret:
+   ```bash
+   gh secret set OVERLEAF_TOKEN --body "<new-token>" --repo <owner>/<repo>
+   ```
+3. Manually trigger `pull-from-overleaf.yml` once to confirm the new token works:
+   ```bash
+   gh workflow run pull-from-overleaf.yml --repo <owner>/<repo>
+   ```
+4. No workflow file changes needed. The next push will also exercise the token via `sync-overleaf`.
+
+## What this skill explicitly does NOT do
+
+- It does **not** build the PDF in CI. If the user wants Actions to compile `paper.pdf` on every push, add a separate workflow using `xu-cheng/latex-action@v3`. Not in scope here.
+- It does **not** support branches other than `master`. Overleaf's git endpoint only exposes `master`. If the user wants feature branches, do them on GitHub only and merge to master, which then syncs to Overleaf.
+- It does **not** replace Overleaf's paid GitHub integration. The paid integration handles divergence in a UI. This setup is more transparent and free but requires `sync.ps1` before sessions and occasional manual conflict resolution.
+- It does **not** rebase commits across the boundary. The pull workflow uses fast-forward only, by design. Anything else is a human decision.
+
+## Skill contents
+
+- [`SKILL.md`](SKILL.md) — this file
+- [`references/setup-new-paper.md`](references/setup-new-paper.md) — full procedure for setting up sync on a paper not yet in this pattern
+- [`references/conflict-resolution.md`](references/conflict-resolution.md) — divergence playbook
+- [`references/troubleshooting.md`](references/troubleshooting.md) — common errors and fixes
+- [`assets/sync-overleaf.yml`](assets/sync-overleaf.yml) — push-direction workflow template
+- [`assets/pull-from-overleaf.yml`](assets/pull-from-overleaf.yml) — pull-direction workflow template
+- [`assets/sync.ps1`](assets/sync.ps1) — PowerShell pre-session helper (Windows)
+- [`assets/sync.sh`](assets/sync.sh) — bash pre-session helper (Mac / Linux)

--- a/repo-skills/overleaf-paper-sync/SKILL.md
+++ b/repo-skills/overleaf-paper-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: overleaf-paper-sync
-description: Manage a LaTeX paper hosted on Overleaf via a GitHub mirror with bidirectional auto-sync through GitHub Actions. Use this skill whenever the user mentions Overleaf, paper version control, syncing a LaTeX project, a GitHub mirror of an Overleaf project, divergence or merge conflicts between Overleaf and Git, the Overleaf git authentication token, or is working in a repo that contains `.github/workflows/sync-overleaf.yml`, `pull-from-overleaf.yml`, or a `sync.ps1` / `sync.sh` helper. Also use it when onboarding a collaborator (or a collaborator's agent) to an existing Overleaf-backed paper repo. The skill covers initial setup of a brand-new paper, the daily editing ritual, the divergence-resolution playbook, and the gotchas the author hit while building this pattern — enough that an agent with no prior context can pick it up cold.
+description: Manage a LaTeX paper hosted on Overleaf via a GitHub mirror with bidirectional auto-sync through GitHub Actions. Use this skill whenever the user mentions Overleaf, paper version control, syncing a LaTeX project, a GitHub mirror of an Overleaf project, divergence or merge conflicts between Overleaf and Git, the Overleaf git authentication token, or is working in a repo that contains `.github/workflows/sync-overleaf.yml`, `pull-from-overleaf.yml`, or a `sync.ps1` / `sync.sh` helper. Also use it when onboarding a collaborator (or a collaborator's agent) to an existing Overleaf-backed paper repo. The skill covers initial setup of a brand-new paper, the daily editing ritual, the divergence-resolution playbook, and the gotchas the author hit while building this pattern — enough that an agent with no prior context can pick it up cold. Specific papers wired up with this pattern (e.g., `multiplexed-ion-photon`) are catalogued in `references/instances.md` with their per-paper config and pending action items — trigger this skill when the user mentions one of those papers by name, even without saying "Overleaf".
 author: Bingran You (@bingran-you)
 license: MIT
 ---
@@ -160,6 +160,12 @@ Overleaf tokens leak. Rotate them periodically and immediately if exposed:
    ```
 4. No workflow file changes needed. The next push will also exercise the token via `sync-overleaf`.
 
+## Papers already set up with this pattern
+
+This skill doubles as a memory for the author's own paper instances. Before treating a paper as "new", check [`references/instances.md`](references/instances.md) — it lists each paper repo wired up with this pattern, the per-paper config that differs from the defaults, and any pending action items (e.g., tokens scheduled for rotation).
+
+If the user mentions a paper by name and it's already listed there, you already know its Overleaf project ID, GitHub repo, parent-submodule path, and collaboration mode — skip the discovery questions and go straight to the daily-workflow guidance. When a new paper joins the pattern, append a section to `instances.md` so the next session inherits the context.
+
 ## What this skill explicitly does NOT do
 
 - It does **not** build the PDF in CI. If the user wants Actions to compile `paper.pdf` on every push, add a separate workflow using `xu-cheng/latex-action@v3`. Not in scope here.
@@ -173,6 +179,7 @@ Overleaf tokens leak. Rotate them periodically and immediately if exposed:
 - [`references/setup-new-paper.md`](references/setup-new-paper.md) — full procedure for setting up sync on a paper not yet in this pattern
 - [`references/conflict-resolution.md`](references/conflict-resolution.md) — divergence playbook
 - [`references/troubleshooting.md`](references/troubleshooting.md) — common errors and fixes
+- [`references/instances.md`](references/instances.md) — author's living log of papers using this pattern + pending action items
 - [`assets/sync-overleaf.yml`](assets/sync-overleaf.yml) — push-direction workflow template
 - [`assets/pull-from-overleaf.yml`](assets/pull-from-overleaf.yml) — pull-direction workflow template
 - [`assets/sync.ps1`](assets/sync.ps1) — PowerShell pre-session helper (Windows)

--- a/repo-skills/overleaf-paper-sync/assets/pull-from-overleaf.yml
+++ b/repo-skills/overleaf-paper-sync/assets/pull-from-overleaf.yml
@@ -1,0 +1,70 @@
+name: Pull from Overleaf
+
+# Pull direction: hourly cron + manual trigger.
+# Fetches Overleaf master, compares to GitHub master, and:
+#   - fast-forwards GitHub if Overleaf has new commits,
+#   - does nothing if GitHub is ahead (sync-overleaf will push),
+#   - fails with instructions if branches have diverged.
+#
+# Replace __OVERLEAF_PROJECT_ID__ with your Overleaf project ID before committing.
+# Set the OVERLEAF_TOKEN secret on the repo.
+
+on:
+  schedule:
+    - cron: '0 * * * *'   # hourly. Adjust if you want different cadence.
+  workflow_dispatch:
+
+concurrency:
+  group: sync-overleaf
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch from Overleaf and reconcile
+        env:
+          OVERLEAF_TOKEN: ${{ secrets.OVERLEAF_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch "https://git:${OVERLEAF_TOKEN}@git.overleaf.com/__OVERLEAF_PROJECT_ID__" \
+            master:refs/remotes/overleaf/master
+
+          LOCAL=$(git rev-parse HEAD)
+          REMOTE=$(git rev-parse refs/remotes/overleaf/master)
+          BASE=$(git merge-base HEAD refs/remotes/overleaf/master)
+
+          echo "GitHub master:   $LOCAL"
+          echo "Overleaf master: $REMOTE"
+          echo "Merge base:      $BASE"
+
+          if [ "$LOCAL" = "$REMOTE" ]; then
+            echo "Already in sync."
+          elif [ "$LOCAL" = "$BASE" ]; then
+            echo "Overleaf is ahead; fast-forwarding GitHub master."
+            git merge --ff-only refs/remotes/overleaf/master
+            git push origin master
+          elif [ "$REMOTE" = "$BASE" ]; then
+            echo "GitHub is ahead; sync-overleaf.yml will push to Overleaf."
+          else
+            echo "::error::Branches have diverged. Manual resolution required."
+            echo "Locally:"
+            echo "  git fetch origin master                    # origin = Overleaf"
+            echo "  git checkout master && git pull github master"
+            echo "  git merge origin/master                    # resolve conflicts"
+            echo "  git push github master"
+            exit 1
+          fi

--- a/repo-skills/overleaf-paper-sync/assets/sync-overleaf.yml
+++ b/repo-skills/overleaf-paper-sync/assets/sync-overleaf.yml
@@ -1,0 +1,29 @@
+name: Sync to Overleaf
+
+# Push direction: every commit on master goes to Overleaf.
+# Replace __OVERLEAF_PROJECT_ID__ with your Overleaf project ID before committing.
+# Set the OVERLEAF_TOKEN secret on the repo.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-overleaf
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to Overleaf
+        env:
+          OVERLEAF_TOKEN: ${{ secrets.OVERLEAF_TOKEN }}
+        run: |
+          set -euo pipefail
+          git push "https://git:${OVERLEAF_TOKEN}@git.overleaf.com/__OVERLEAF_PROJECT_ID__" "HEAD:master"

--- a/repo-skills/overleaf-paper-sync/assets/sync.ps1
+++ b/repo-skills/overleaf-paper-sync/assets/sync.ps1
@@ -1,0 +1,47 @@
+# sync.ps1 - Run this BEFORE starting a local editing session.
+# Triggers the GitHub Action that pulls latest Overleaf changes into GitHub,
+# waits for it to finish, then fast-forwards your local clone.
+#
+# Requires: gh CLI installed and authenticated.
+
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
+
+$workflow = "pull-from-overleaf.yml"
+
+Write-Host "==> Triggering Overleaf -> GitHub pull workflow..." -ForegroundColor Cyan
+gh workflow run $workflow --ref master | Out-Null
+
+Write-Host "==> Locating the new run..." -ForegroundColor Cyan
+$runId = $null
+for ($i = 0; $i -lt 20; $i++) {
+    Start-Sleep -Seconds 2
+    $runs = gh run list --workflow=$workflow --event=workflow_dispatch --limit 1 --json databaseId,status | ConvertFrom-Json
+    if ($runs -and $runs[0].status -ne 'completed') {
+        $runId = $runs[0].databaseId
+        break
+    }
+}
+if (-not $runId) {
+    Write-Host "Couldn't find an in-progress run; checking the latest one." -ForegroundColor Yellow
+    $runs = gh run list --workflow=$workflow --limit 1 --json databaseId | ConvertFrom-Json
+    $runId = $runs[0].databaseId
+}
+
+Write-Host "==> Watching run $runId..." -ForegroundColor Cyan
+gh run watch $runId --exit-status
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "Workflow failed - likely cause: GitHub and Overleaf have diverged." -ForegroundColor Red
+    Write-Host "Inspect:  gh run view $runId --log-failed" -ForegroundColor Yellow
+    Write-Host "Resolve locally per the steps printed in the failed log." -ForegroundColor Yellow
+    Write-Host "Skipping local pull." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "==> Fast-forwarding local clone..." -ForegroundColor Cyan
+git fetch github master
+git pull github master --ff-only
+
+Write-Host ""
+Write-Host "Synced. You're good to start editing." -ForegroundColor Green

--- a/repo-skills/overleaf-paper-sync/assets/sync.sh
+++ b/repo-skills/overleaf-paper-sync/assets/sync.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# sync.sh - Run this BEFORE starting a local editing session.
+# Triggers the GitHub Action that pulls latest Overleaf changes into GitHub,
+# waits for it to finish, then fast-forwards your local clone.
+#
+# Requires: gh CLI installed and authenticated.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WORKFLOW="pull-from-overleaf.yml"
+
+echo "==> Triggering Overleaf -> GitHub pull workflow..."
+gh workflow run "$WORKFLOW" --ref master >/dev/null
+
+echo "==> Locating the new run..."
+run_id=""
+for _ in $(seq 1 20); do
+  sleep 2
+  candidate=$(gh run list --workflow="$WORKFLOW" --event=workflow_dispatch --limit 1 --json databaseId,status \
+    | python3 -c 'import json,sys; runs=json.load(sys.stdin); print(runs[0]["databaseId"] if runs and runs[0]["status"]!="completed" else "")')
+  if [ -n "$candidate" ]; then
+    run_id="$candidate"
+    break
+  fi
+done
+
+if [ -z "$run_id" ]; then
+  echo "Couldn't find an in-progress run; checking the latest one."
+  run_id=$(gh run list --workflow="$WORKFLOW" --limit 1 --json databaseId \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["databaseId"])')
+fi
+
+echo "==> Watching run $run_id..."
+if ! gh run watch "$run_id" --exit-status; then
+  echo
+  echo "Workflow failed - likely cause: GitHub and Overleaf have diverged."
+  echo "Inspect:  gh run view $run_id --log-failed"
+  echo "Resolve locally per the steps printed in the failed log."
+  echo "Skipping local pull."
+  exit 1
+fi
+
+echo "==> Fast-forwarding local clone..."
+git fetch github master
+git pull github master --ff-only
+
+echo
+echo "Synced. You're good to start editing."

--- a/repo-skills/overleaf-paper-sync/references/conflict-resolution.md
+++ b/repo-skills/overleaf-paper-sync/references/conflict-resolution.md
@@ -1,0 +1,133 @@
+# Conflict resolution
+
+The pull workflow refuses to auto-merge anything that isn't a fast-forward. This doc covers what to do when it fails — and why automated merges are deliberately off the table.
+
+## Why fast-forward only
+
+LaTeX has no semantic merge. If Alice rewrites the intro on Overleaf while Bob refactors equations in `methods.tex` locally and pushes to GitHub, a naive `git merge` will produce a file that *compiles* and *looks fine* — but silently has Alice's old equation numbering, or Bob's draft of the intro instead of the polished one, or a half-deleted figure caption. The author won't notice until the figure is upside down in the submitted PDF.
+
+So the workflows do the safe thing: detect divergence, stop, and dump the resolution onto a human who can read both sides.
+
+## The four states
+
+Whenever pull-from-overleaf runs, it compares three commits:
+
+- `LOCAL` = current `HEAD` of GitHub's master
+- `REMOTE` = HEAD of Overleaf's master (fetched into `refs/remotes/overleaf/master`)
+- `BASE` = `git merge-base LOCAL REMOTE` — the most recent shared ancestor
+
+Four possible states:
+
+| State | Condition | What the workflow does |
+|---|---|---|
+| **In sync** | `LOCAL == REMOTE` | Nothing |
+| **Overleaf ahead** | `LOCAL == BASE` (and `REMOTE != LOCAL`) | Fast-forward GitHub master to Overleaf, push |
+| **GitHub ahead** | `REMOTE == BASE` (and `LOCAL != REMOTE`) | Skip — `sync-overleaf` will push the other direction on the next event |
+| **Diverged** | None of the above | **Fail with instructions** — this doc |
+
+You can run the same comparison locally to confirm which state you're in:
+
+```bash
+git fetch github master
+git fetch origin master       # origin = Overleaf
+LOCAL=$(git rev-parse github/master)
+REMOTE=$(git rev-parse origin/master)
+BASE=$(git merge-base "$LOCAL" "$REMOTE")
+echo "LOCAL:  $LOCAL"
+echo "REMOTE: $REMOTE"
+echo "BASE:   $BASE"
+```
+
+## Resolution: diverged
+
+Both sides have unique commits on top of `BASE`. The fix is to bring them together locally, with a human reading the merge, then push the merged history back to GitHub. The push-direction workflow will then carry it to Overleaf.
+
+```bash
+cd <paper-repo>
+
+# 1. Get both sides locally
+git fetch origin master         # origin = Overleaf
+git fetch github master
+
+# 2. Start from GitHub's master
+git checkout master
+git reset --hard github/master  # in case local is in a weird state
+
+# 3. Merge Overleaf in
+git merge origin/master
+# Git will list conflicting files. Open each, resolve manually, then:
+#   git add <file>
+# Once all are resolved:
+git commit                       # uses the auto-generated merge message
+```
+
+While resolving each conflict, think about who edited what. For LaTeX, the safest pattern is to **take both sets of changes** unless they touch the same paragraph — Alice's intro rewrite + Bob's equation refactor can usually both go in. The danger is conflicts inside a single `\section{}` or inside the same equation environment.
+
+Then publish the merge:
+
+```bash
+# 4. Push the merged history to GitHub.
+git push github master
+# This fires sync-overleaf, which will push the merge to Overleaf.
+```
+
+The first user to edit either side after this resolution will get a clean view; subsequent collaborators on Overleaf will see the merged content as the starting point for their next session.
+
+## Resolution: Overleaf "stuck" or out of sync after rebase
+
+If someone force-pushed to GitHub (rewriting history) and you need to align Overleaf with the rewritten master:
+
+```bash
+# CAREFUL: this overwrites Overleaf's master. Only do it when you're sure.
+git push origin +github/master:master
+```
+
+The `+` is a force-push. Anyone editing on Overleaf at that moment will see their in-progress edits become a divergence the next time they save. Coordinate with collaborators first.
+
+In general, **avoid rewriting history** on a paper master branch. The setup assumes linear or merge-only history; rebases / force-pushes break the fast-forward invariants the cron workflow relies on.
+
+## Resolution: a single bad commit on Overleaf you want to undo
+
+Overleaf's web UI has a history viewer but no "revert this commit" button. To revert via git:
+
+```bash
+# Find the bad commit
+git fetch origin master
+git log origin/master --oneline
+
+# Revert (creates a new commit that undoes the bad one)
+git checkout master
+git pull github master --ff-only
+git revert <bad-commit-sha>
+git push github master
+# sync-overleaf pushes the revert to Overleaf; the bad changes are now undone there too
+```
+
+## When to give up and call Overleaf canonical
+
+If the divergence is large and untangling the merge is more painful than redoing one side, decide which copy is canonical and force-align the other:
+
+```bash
+# Make GitHub a mirror of Overleaf (DESTRUCTIVE to GitHub master)
+git fetch origin master
+git checkout master
+git reset --hard origin/master
+git push github master --force-with-lease
+```
+
+```bash
+# Make Overleaf a mirror of GitHub (DESTRUCTIVE to Overleaf master)
+git fetch github master
+git checkout master
+git reset --hard github/master
+git push origin master --force-with-lease
+```
+
+These are last-resort moves. Tell the user explicitly what they're about to destroy and get a confirmation before running them. After a destructive reset, the next collaborator who opens Overleaf with a stale tab will lose their unsaved edits.
+
+## Preventing future divergence
+
+The two cheap habits that prevent ~all conflicts:
+
+- **Run `sync.ps1` / `sync.sh` before every editing session.** Cheap, fast, eliminates most stale-state divergence.
+- **Tell collaborators: "edit on Overleaf OR edit locally, never both at once."** Even with the sync in place, simultaneous edits on different platforms invite divergence.

--- a/repo-skills/overleaf-paper-sync/references/instances.md
+++ b/repo-skills/overleaf-paper-sync/references/instances.md
@@ -1,0 +1,49 @@
+# Papers using this sync pattern
+
+Living log of actual paper repos set up with this skill. The skill's general playbook tells you HOW to set things up; this file records WHAT the author has already set up, so future sessions don't have to re-derive the state and can pick up pending action items.
+
+> **Privacy note.** This file lives in the **public** [`bingran-you/bingran-you`](https://github.com/bingran-you/bingran-you) repo and is shipped to the personal site catalog. Never write tokens or anything that would grant access here. Overleaf project IDs alone are not credentials — they identify which Overleaf project, but accessing the project still requires a valid token, which lives only in GitHub Secrets (not here). Pair a leaked token with a project ID and you have a working credential set, so rotate tokens promptly when leaked.
+
+## multiplexed-ion-photon
+
+- **Overleaf project:** `6a0ccb389dd0fc243b1004fb` — https://www.overleaf.com/project/6a0ccb389dd0fc243b1004fb
+- **GitHub repo:** [`bingran-you/multiplexed-ion-photon`](https://github.com/bingran-you/multiplexed-ion-photon) (private)
+- **Local clone:** `C:\GitHub\bingran-you\papers\multiplexed-ion-photon`
+- **Parent submodule:** `papers/multiplexed-ion-photon` in [`bingran-you/bingran-you`](https://github.com/bingran-you/bingran-you)
+- **Set up:** 2026-05-19
+- **Pull cadence:** hourly (`0 * * * *`) — see [`.github/workflows/pull-from-overleaf.yml`](https://github.com/bingran-you/multiplexed-ion-photon/blob/master/.github/workflows/pull-from-overleaf.yml)
+- **Collaboration mode:** bidirectional sync is intentional — collaborators may edit on Overleaf web. Don't downgrade to GitHub-only.
+- **Secrets configured on the GitHub repo:**
+  - `OVERLEAF_TOKEN` — used by both workflows
+  - `OVERLEAF_EMAIL` — set during early setup, now unused (the workflow URL uses literal `git` as username); harmless to leave or remove
+
+### Action items
+
+- [ ] **Rotate `OVERLEAF_TOKEN`.** The current token (`olp_4z4k…`, partial fingerprint) was shared once during initial setup before this skill existed. Access is still gated (private GitHub repo + active token + project ID), but rotate as a precaution:
+    1. In Overleaf: Account Settings → Git Integration → revoke `olp_4z4k…`, generate a fresh token
+    2. `gh secret set OVERLEAF_TOKEN --body "<new>" --repo bingran-you/multiplexed-ion-photon`
+    3. `gh workflow run pull-from-overleaf.yml --repo bingran-you/multiplexed-ion-photon` — log should say "Already in sync."
+    4. Update this file: strike the action item, note the rotation date
+
+### Notable PRs
+
+- [`bingran-you#242`](https://github.com/bingran-you/bingran-you/pull/242) — added as submodule
+- [`multiplexed-ion-photon#1`](https://github.com/bingran-you/multiplexed-ion-photon/pull/1) — initial `sync-overleaf.yml`
+- [`multiplexed-ion-photon#2`](https://github.com/bingran-you/multiplexed-ion-photon/pull/2) — fixed Overleaf token-auth URL (literal `git` as username)
+- [`multiplexed-ion-photon#3`](https://github.com/bingran-you/multiplexed-ion-photon/pull/3) — added scheduled `pull-from-overleaf.yml`
+- [`multiplexed-ion-photon#4`](https://github.com/bingran-you/multiplexed-ion-photon/pull/4) — cron → hourly + added `sync.ps1`
+- [`multiplexed-ion-photon#5`](https://github.com/bingran-you/multiplexed-ion-photon/pull/5) — fixed PowerShell jq-quoting in `sync.ps1`
+- [`bingran-you#243`](https://github.com/bingran-you/bingran-you/pull/243) — this skill (overleaf-paper-sync)
+- [`bingran-you#244`](https://github.com/bingran-you/bingran-you/pull/244) — bumped submodule pointer to include the workflows
+
+## Adding a new paper
+
+When the next paper joins this pattern:
+
+1. Follow [`setup-new-paper.md`](setup-new-paper.md)
+2. Add a section here mirroring the structure above
+3. If the paper's defaults differ from the templates (e.g., 30-min cron, single-editor mode), note it explicitly so future agents don't assume
+
+## Pattern usage so far
+
+One paper.

--- a/repo-skills/overleaf-paper-sync/references/setup-new-paper.md
+++ b/repo-skills/overleaf-paper-sync/references/setup-new-paper.md
@@ -1,0 +1,173 @@
+# Setting up sync for a new paper
+
+End-to-end procedure for taking a paper that lives only on Overleaf and getting it onto GitHub with bidirectional auto-sync. Total time: ~10 minutes.
+
+The user runs these commands; the agent's job is to guide them, fill in the variables, and verify each step.
+
+## Prerequisites
+
+- The user has push access to Overleaf for the paper
+- The user has the `gh` CLI installed and authenticated (`gh auth status` says "Logged in")
+- The user can create a new GitHub repo under an account / org they own
+- Git installed locally
+
+Collect these up front:
+
+- `OVERLEAF_PROJECT_ID` — the path component in the Overleaf URL, e.g. for `https://www.overleaf.com/project/abc123def456...` it's `abc123def456...`
+- `GITHUB_OWNER` — the user / org for the new GitHub repo (e.g. `bingran-you`)
+- `GITHUB_REPO_NAME` — what the new repo will be called (e.g. `multiplexed-ion-photon`)
+- `LOCAL_DIR` — where the local working copy goes (e.g. `C:\GitHub\bingran-you\papers\multiplexed-ion-photon`)
+
+## Step 1 — Generate an Overleaf git token
+
+1. In Overleaf, click the user avatar → **Account Settings**
+2. Scroll to **Git Integration** (or "Project and account synchronisation")
+3. Click **Create Token** — Overleaf shows the token once. Copy it.
+4. The token starts with `olp_`. Treat it like a password — don't paste it into chat, screenshots, or shared docs.
+
+> **Gotcha — auth format changed.** Overleaf used to accept `email + token` as username/password. It no longer does and returns `403: Overleaf now only supports Git authentication tokens`. The current format is `username = "git"` (literal string), `password = <token>`. The workflow templates already do this; if a user adapts another snippet from a blog post that uses email-as-username, it will break.
+
+## Step 2 — Clone Overleaf to a local working directory
+
+```bash
+git clone https://git.overleaf.com/<OVERLEAF_PROJECT_ID> <LOCAL_DIR>
+# username: git
+# password: paste the token from step 1
+cd <LOCAL_DIR>
+```
+
+After this the local repo has one remote, `origin`, pointing at Overleaf.
+
+> **Don't keep the token in `.git/config`.** Some git clients embed the token in the remote URL after a successful credential prompt. Inspect `.git/config` and clean it if needed; the workflow handles auth via secrets, not via embedded URLs.
+
+## Step 3 — Create the GitHub repo and push
+
+```bash
+gh repo create <GITHUB_OWNER>/<GITHUB_REPO_NAME> --private --source=. --remote=github --push
+```
+
+This single command:
+- creates a new private repo under `<GITHUB_OWNER>`,
+- adds `github` as a new remote in the local clone,
+- pushes `master` to GitHub.
+
+Verify the two remotes:
+
+```bash
+git remote -v
+# origin  https://git.overleaf.com/<OVERLEAF_PROJECT_ID> (fetch)
+# origin  https://git.overleaf.com/<OVERLEAF_PROJECT_ID> (push)
+# github  https://github.com/<GITHUB_OWNER>/<GITHUB_REPO_NAME>.git (fetch)
+# github  https://github.com/<GITHUB_OWNER>/<GITHUB_REPO_NAME>.git (push)
+```
+
+## Step 4 — Store the Overleaf token as a GitHub secret
+
+```bash
+gh secret set OVERLEAF_TOKEN --body "<the token from step 1>" --repo <GITHUB_OWNER>/<GITHUB_REPO_NAME>
+```
+
+Verify:
+
+```bash
+gh secret list --repo <GITHUB_OWNER>/<GITHUB_REPO_NAME>
+# OVERLEAF_TOKEN  <timestamp>
+```
+
+## Step 5 — Add the workflow files and helper scripts
+
+Copy the four templates from this skill's `assets/` directory into the local clone:
+
+```
+assets/sync-overleaf.yml       →  .github/workflows/sync-overleaf.yml
+assets/pull-from-overleaf.yml  →  .github/workflows/pull-from-overleaf.yml
+assets/sync.ps1                →  sync.ps1
+assets/sync.sh                 →  sync.sh
+```
+
+Then **search-and-replace** the literal string `__OVERLEAF_PROJECT_ID__` in all four files with the actual project ID. PowerShell one-liner from the paper repo root:
+
+```powershell
+Get-ChildItem -Recurse -File -Include sync-overleaf.yml,pull-from-overleaf.yml,sync.ps1,sync.sh |
+    ForEach-Object { (Get-Content $_.FullName) -replace '__OVERLEAF_PROJECT_ID__', '<OVERLEAF_PROJECT_ID>' | Set-Content $_.FullName }
+```
+
+Bash equivalent:
+
+```bash
+find . -type f \( -name 'sync-overleaf.yml' -o -name 'pull-from-overleaf.yml' -o -name 'sync.ps1' -o -name 'sync.sh' \) \
+  -exec sed -i 's/__OVERLEAF_PROJECT_ID__/<OVERLEAF_PROJECT_ID>/g' {} +
+```
+
+Make `sync.sh` executable for Mac/Linux collaborators:
+
+```bash
+chmod +x sync.sh
+```
+
+## Step 6 — Commit, push, and test
+
+Open a PR (cleaner) or commit straight to master (faster). PR flow:
+
+```bash
+git checkout -b add-overleaf-sync
+git add .github/workflows sync.ps1 sync.sh
+git commit -m "Add GitHub Actions: bidirectional Overleaf sync"
+git push -u github add-overleaf-sync
+gh pr create --base master --head add-overleaf-sync \
+  --title "Add bidirectional Overleaf sync" \
+  --body "Adds sync-overleaf (push direction) and pull-from-overleaf (cron pull) workflows plus a sync.ps1/sync.sh helper. Uses OVERLEAF_TOKEN secret."
+gh pr merge --squash --delete-branch
+```
+
+The PR merge will fire `sync-overleaf` for the first time. Watch it:
+
+```bash
+gh run watch --exit-status
+```
+
+If it succeeds — Overleaf now has the workflow files committed too. (Harmless: Overleaf renders the LaTeX and ignores `.github/` and `sync.*`.)
+
+## Step 7 — Test the pull direction
+
+Trigger `pull-from-overleaf` manually:
+
+```bash
+gh workflow run pull-from-overleaf.yml --ref master
+```
+
+Watch for "Already in sync." in the log — that means the fetch worked and the two HEADs match. Anything else, see [`troubleshooting.md`](troubleshooting.md).
+
+## Step 8 — (Optional) Register as a submodule of a parent monorepo
+
+If the paper is one of many tracked in a parent repo (e.g., a personal monorepo with a `papers/` directory):
+
+```bash
+cd <parent-repo>
+git submodule add https://github.com/<GITHUB_OWNER>/<GITHUB_REPO_NAME>.git papers/<GITHUB_REPO_NAME>
+git commit -m "Add <GITHUB_REPO_NAME> paper as submodule"
+git push
+```
+
+This commits only `.gitmodules` and a pointer; the paper repo stays independent. Day-to-day the user works inside `papers/<GITHUB_REPO_NAME>/` directly. The parent repo's pointer can be bumped occasionally:
+
+```bash
+cd <parent-repo>
+git add papers/<GITHUB_REPO_NAME>
+git commit -m "Bump <GITHUB_REPO_NAME> submodule"
+git push
+```
+
+## Step 9 — Done — tell the user the workflow
+
+Hand off these two commands as the daily ritual:
+
+```powershell
+# Before editing
+.\sync.ps1
+
+# After editing
+git add . ; git commit -m "..." ; git push github master
+```
+
+And remind them: if `sync.ps1` ever reports a divergence failure, jump to [`conflict-resolution.md`](conflict-resolution.md).

--- a/repo-skills/overleaf-paper-sync/references/troubleshooting.md
+++ b/repo-skills/overleaf-paper-sync/references/troubleshooting.md
@@ -1,0 +1,172 @@
+# Troubleshooting
+
+Common errors and what to do about them, organized by where the symptom shows up.
+
+## Errors in the `sync-overleaf` workflow run
+
+### `remote: Overleaf now only supports Git authentication tokens` (403)
+
+**Cause.** The workflow's git URL uses the wrong auth format. Overleaf removed the legacy "email + token" form. The current form is `username = "git"` (literal string), `password = <token>`.
+
+**Fix.** The workflow URL must be:
+
+```
+https://git:${OVERLEAF_TOKEN}@git.overleaf.com/<OVERLEAF_PROJECT_ID>
+```
+
+If you find an older template using `${OVERLEAF_EMAIL}:${OVERLEAF_TOKEN}@...`, replace the email part with the literal `git`.
+
+### `fatal: could not read Username for 'https://github.com'`
+
+**Cause.** The workflow is trying to push to GitHub but doesn't have `contents: write` permission, or the `actions/checkout` step didn't authenticate.
+
+**Fix.** Add this top-level block to the workflow:
+
+```yaml
+permissions:
+  contents: write
+```
+
+And ensure `actions/checkout@v4` is used — it auto-configures `GITHUB_TOKEN` as the credential for the cloned remote.
+
+### Non-fast-forward rejection when pushing to Overleaf
+
+**Cause.** Someone edited on Overleaf web after the last sync, so Overleaf is ahead and GitHub is trying to push old + new commits. The `sync-overleaf` workflow does NOT pull first — that's intentional, to avoid silent auto-merges.
+
+**Fix.** Trigger `pull-from-overleaf` (or run `sync.ps1`) to bring Overleaf's commits into GitHub. If that succeeds, the next push of new local work will be a clean fast-forward. If `pull-from-overleaf` itself fails — go to [`conflict-resolution.md`](conflict-resolution.md).
+
+## Errors in the `pull-from-overleaf` workflow run
+
+### `::error::Branches have diverged. Manual resolution required.`
+
+**Cause.** Both sides have new commits since the last common ancestor.
+
+**Fix.** [`conflict-resolution.md`](conflict-resolution.md).
+
+### Permission error pushing to GitHub master
+
+Same as above — add `permissions: contents: write` to the workflow.
+
+If branch protection on GitHub requires PR review or status checks for master, the default `GITHUB_TOKEN` can't satisfy them. Options:
+- Loosen the protection rule for `github-actions[bot]` (Settings → Branches → exclude bots)
+- Use a personal access token (PAT) stored in another secret instead of `GITHUB_TOKEN` — extra complexity, only worth it if you really need branch protection here
+
+### Cron runs are skipped or very late
+
+**Cause.** GitHub Actions scheduled workflows run on a best-effort basis. On busy runners, an hourly cron might fire 10–20 minutes late, occasionally an hour late or skipped entirely. This is documented behavior, not a bug in the setup.
+
+**Mitigation.** Don't rely on the cron for time-sensitive sync. Run `sync.ps1` / `sync.sh` before editing sessions.
+
+## Errors in `sync.ps1` (PowerShell, Windows)
+
+### `function not defined: completed/0`
+
+**Cause.** Older versions of `sync.ps1` used `--jq` filter strings on the `gh` CLI. PowerShell strips inner double quotes when passing them to native commands, so `select(.status != "completed")` arrives at `jq` as `select(.status != completed)` and `completed` gets parsed as a function name.
+
+**Fix.** Use `ConvertFrom-Json` and filter in PowerShell instead of letting `jq` parse the filter:
+
+```powershell
+$runs = gh run list --workflow=$workflow --event=workflow_dispatch --limit 1 --json databaseId,status | ConvertFrom-Json
+if ($runs -and $runs[0].status -ne 'completed') { $runId = $runs[0].databaseId }
+```
+
+The asset template `assets/sync.ps1` already does this.
+
+### `fatal: Unable to create '.git/index.lock': File exists.`
+
+**Cause.** A previous git operation crashed or was interrupted and left a stale lock file. This is especially common when the repo is touched by both Windows tooling and WSL / a Linux sandbox — the lock cleanup fails across filesystem boundaries.
+
+**Fix.**
+
+```powershell
+Remove-Item .git\index.lock -ErrorAction SilentlyContinue
+```
+
+```bash
+rm -f .git/index.lock
+```
+
+Also check for `.git/refs/heads/<branch>.lock` if branch operations fail.
+
+### `gh` not found / authentication missing
+
+**Cause.** `sync.ps1` requires the GitHub CLI (`gh`) installed and logged in.
+
+**Fix.** Install: https://cli.github.com/ — then `gh auth login`. The user needs `repo`, `workflow` scopes at minimum.
+
+## Errors during local fetches from Overleaf
+
+### `fatal: could not read Username for 'https://git.overleaf.com'` (when running git locally)
+
+**Cause.** No credentials cached for the Overleaf remote in the local clone.
+
+**Fix.** Run the command interactively once so git prompts. Username: `git`. Password: the OVERLEAF_TOKEN value. Windows Credential Manager (default credential helper) caches it for next time. On Mac/Linux, configure a credential helper if you haven't:
+
+```bash
+git config --global credential.helper osxkeychain    # Mac
+git config --global credential.helper store          # Linux (stores plaintext — careful)
+```
+
+### Local clone of Overleaf prompts for credentials on every push/pull
+
+**Cause.** No credential helper, or the helper doesn't recognize the URL.
+
+**Fix.** Same as above — set a credential helper. Or, store the token as part of the URL (not recommended for shared machines):
+
+```bash
+git remote set-url origin "https://git:<TOKEN>@git.overleaf.com/<PROJECT_ID>"
+```
+
+If you go this route, the token sits in `.git/config`. Don't commit `.git/config` (you can't, normally) and don't share the local clone.
+
+## Secret / token issues
+
+### `gh secret list` shows no secrets for the repo
+
+**Cause.** Either the secrets were never set, or you're checking the wrong repo / scope (org vs. repo level).
+
+**Fix.**
+
+```bash
+gh secret set OVERLEAF_TOKEN --body "<token>" --repo <owner>/<repo>
+gh secret list --repo <owner>/<repo>
+```
+
+### How to confirm `OVERLEAF_TOKEN` is actually being used
+
+You can't read a GitHub secret back — by design. To verify it's set correctly, manually trigger the pull workflow and watch the log:
+
+```bash
+gh workflow run pull-from-overleaf.yml --repo <owner>/<repo>
+sleep 5
+gh run watch --repo <owner>/<repo> --exit-status
+```
+
+If you get "Already in sync." the token works. If you get 403, the token is wrong or revoked — rotate it.
+
+## Submodule integration issues (parent monorepo case)
+
+### Cloning the parent repo leaves `papers/<paper>/` empty
+
+**Cause.** Submodules aren't initialized.
+
+**Fix.**
+
+```bash
+git submodule update --init --recursive papers/<paper>
+```
+
+### Parent repo shows the submodule as "dirty" after editing the paper
+
+**Cause.** The submodule's HEAD has moved (you committed paper changes) but the parent's pointer hasn't been bumped.
+
+**Fix.** This is by design — the parent's pointer only updates when you choose to bump it. To bump:
+
+```bash
+cd <parent-repo>
+git add papers/<paper>
+git commit -m "Bump <paper> submodule"
+git push
+```
+
+Or leave it dirty and bump only at milestones — there's no requirement to bump on every paper commit.


### PR DESCRIPTION
Captures the GitHub-mirrors-Overleaf workflow we built in [#242](https://github.com/bingran-you/bingran-you/pull/242) as a reusable skill that other agents (mine + collaborators') can reference cold.

## What's in the skill

- **`SKILL.md`** — mental model, recognition signals, daily editing workflow, architecture notes, token rotation, scope
- **`references/setup-new-paper.md`** — step-by-step setup for a fresh paper (token gen, clone, GitHub repo, secrets, workflow drop-in, optional submodule registration)
- **`references/conflict-resolution.md`** — four-state decision matrix and divergence playbook, including how to force-align when necessary
- **`references/troubleshooting.md`** — error catalogue (Overleaf 403 auth gotcha, GitHub Token permissions, cron delays, stale lock files, the PowerShell jq quoting trap)
- **`assets/`** — copy-paste templates for both workflows and the `sync.ps1` / `sync.sh` helpers, with `__OVERLEAF_PROJECT_ID__` as the single placeholder to swap during setup

## Wired into the catalog

- `.agents/skills/overleaf-paper-sync` + `.claude/skills/overleaf-paper-sync` symlinks (mode 120000)
- `personal-site/lib/skills.ts` `inferCategory()` → returns `Engineering` for this slug
- `skills.test.ts` covers the new slug

## ⚠️ Needs `make sync` before merge

Working tree where I edited (a Windows worktree) couldn't run `make sync` — zsh isn't available and most submodules aren't initialized here. So this PR does NOT include the regenerated catalog artifacts. Before merging, on a Mac / Linux / fully-initialized WSL checkout of this branch:

```bash
make sync
git add personal-site/lib/skills.generated.json personal-site/public/skill-files/
git commit -m "make sync"
git push
```

Then the `skills-sync-check` CI gate should pass and this is mergeable.