### PR TITLE
Add BenchFlow to current projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ I build reliable AI systems and run trapped-ion experiments in atomic, molecular
 
 ### Selected Work
 
+- 🌊 [BenchFlow](https://www.benchflow.ai/) - A frontier environment lab building the runtime and benchmarks AI agents learn in.
 - 📐 [SkillsBench](https://github.com/benchflow-ai/skillsbench) - A benchmark for evaluating how well AI agents use skills.
 - 🌲 [first-tree](https://github.com/agent-team-foundation/first-tree) - A Git-native context layer for decisions, ownership, and shared team knowledge.
 - 🥷 [DoWhiz](https://github.com/KnoWhiz/DoWhiz) - An agent-native product for getting work done across email, chat, documents, and related tools.

--- a/USER.md
+++ b/USER.md
@@ -24,6 +24,7 @@ _The one you serve. Keep this living and current._
 
 ## Projects to Know
 
+- [BenchFlow](https://www.benchflow.ai/) — frontier environment lab building the runtime and benchmarks AI agents learn in.
 - [SkillsBench](https://github.com/benchflow-ai/skillsbench) — benchmark for evaluating how well AI agents use skills.
 - [first-tree](https://github.com/agent-team-foundation/first-tree) — Git-native context layer for decisions, ownership, and shared team knowledge.
 - [DoWhiz](https://github.com/KnoWhiz/DoWhiz) — agent-native product for getting work done across email, chat, documents, and related tools.

--- a/memory/2026-05-25.md
+++ b/memory/2026-05-25.md
@@ -1,0 +1,6 @@
+# 2026-05-25
+
+## BenchFlow current project update
+
+- Added BenchFlow as a current project above SkillsBench across the personal site project surfaces, the GitHub-profile README, and agent-facing project context.
+- Updated `bingran-you-private/PRIVATE_MEMORY.md` through the private submodule PR flow, then bumped the submodule pointer in the main workspace.

--- a/personal-site/lib/content.ts
+++ b/personal-site/lib/content.ts
@@ -26,6 +26,14 @@ export type Education = {
 
 export const projects: Project[] = [
   {
+    name: "BenchFlow",
+    href: "https://www.benchflow.ai/",
+    description:
+      "A frontier environment lab building the runtime and benchmarks AI agents learn in.",
+    emoji: "🌊",
+    track: "ai",
+  },
+  {
     name: "SkillsBench",
     href: "https://github.com/benchflow-ai/skillsbench",
     description: "A benchmark for evaluating how well AI agents use skills.",

--- a/personal-site/lib/feed.ts
+++ b/personal-site/lib/feed.ts
@@ -32,6 +32,10 @@ function pubDateOf(item: FeedItem) {
   return new Date(item.date).toUTCString();
 }
 
+function updatedDateOf(item: FeedItem) {
+  return item.lastModified.toUTCString();
+}
+
 export function renderRssFeed(
   items: ReadonlyArray<FeedItem>,
   channel: FeedChannel,
@@ -57,7 +61,7 @@ export function renderRssFeed(
       <link>${escapeXml(url)}</link>
       <guid isPermaLink="true">${escapeXml(url)}</guid>
       <pubDate>${pubDateOf(item)}</pubDate>
-      <atom:updated>${item.lastModified.toISOString()}</atom:updated>
+      <atom:updated>${updatedDateOf(item)}</atom:updated>
       <description><![CDATA[${escapeCdata(description)}]]></description>${creatorLine}
     </item>`;
     })

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -17,6 +17,7 @@ export const SITE_KEYWORDS = [
   "AI agents",
   "reliable AI systems",
   "agent evaluation",
+  "BenchFlow",
   "SkillsBench",
   "first-tree",
   "DoWhiz",

--- a/personal-site/palace-inner/src/components/showcase/Experience.tsx
+++ b/personal-site/palace-inner/src/components/showcase/Experience.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import ResumeDownload from './ResumeDownload';
 
-export interface ExperienceProps {}
-
 interface RoleEntry {
     org: string;
     role: string;
@@ -29,6 +27,7 @@ const ROLES: RoleEntry[] = [
         role: 'Independent / collaborative work on agent infrastructure',
         period: 'Ongoing',
         lines: [
+            'Frontier environment lab for AI-agent runtime and benchmark infrastructure (BenchFlow).',
             'Skills-based benchmarking for AI agents (SkillsBench).',
             'Deterministic mock environments for long-horizon agent tasks (smolclaw, SBTI CLI).',
             'Git-native context layer for team decisions and ownership (first-tree).',
@@ -71,7 +70,7 @@ const PAPERS = [
     },
 ];
 
-const Experience: React.FC<ExperienceProps> = () => {
+const Experience = () => {
     return (
         <div className="site-page-content">
             <ResumeDownload />

--- a/personal-site/palace-inner/src/components/showcase/Projects.tsx
+++ b/personal-site/palace-inner/src/components/showcase/Projects.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-export interface ProjectsProps {}
-
 interface ProjectEntry {
     title: string;
     blurb: string;
@@ -10,6 +8,13 @@ interface ProjectEntry {
 }
 
 const PROJECTS: ProjectEntry[] = [
+    {
+        title: 'BenchFlow',
+        blurb:
+            'Frontier environment lab building the runtime and benchmarks AI agents learn in.',
+        href: 'https://www.benchflow.ai/',
+        tag: 'Agent',
+    },
     {
         title: 'SkillsBench',
         blurb: 'Benchmark for evaluating how well AI agents use skills.',
@@ -97,7 +102,7 @@ const ProjectRow: React.FC<ProjectEntry> = ({ title, blurb, href, tag }) => (
     </a>
 );
 
-const Projects: React.FC<ProjectsProps> = () => {
+const Projects = () => {
     return (
         <div className="site-page-content">
             <h1>Projects</h1>


### PR DESCRIPTION
## Summary
- add BenchFlow above SkillsBench across the personal site project data, /projects output, Memory Palace project surfaces, README, and agent-facing project context
- add BenchFlow to site SEO keywords and bump the private-memory submodule pointer after the private PR merge
- align RSS atom:updated output with the existing feed test expectation

## Verification
- npm test
- npx eslint lib/content.ts lib/jsonld.ts lib/feed.ts palace-inner/src/components/showcase/Projects.tsx palace-inner/src/components/showcase/Experience.tsx
- npm run build
- Playwright smoke check: / and /projects show BenchFlow above SkillsBench

Note: full npm run lint still reports pre-existing legacy/vendored palace and Draco lint errors outside this change.