### PR TITLE
personal-site: add new X post (2026-05-25)

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "x-2058982303104401576",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2058982303104401576",
+    "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2058636384399933738",
     "platform": "x",
     "url": "https://x.com/xdotli/status/2058636384399933738",


### PR DESCRIPTION
## Summary

Scheduled `bingran-you-update` /posts sweep found one new tweet from `@bingran_bry` not yet on /posts:

- `x-2058982303104401576` — "this is how a home made '/goal' mode looks like 🤣" (2026-05-25)

No new Xiaohongshu posts since `xhs-6a1211750000000006034d3a` (2026-05-23) — `Bingran.ai` profile's top 4 notes all match what's already in `posts.json`.

Entry was unshifted manually (not via `add-post.mjs`) to keep the diff at +7/-0 and avoid the resort-on-add shuffle.

## Test plan
- [x] Cross-referenced 7 most-recent X status IDs from `from:bingran_bry -filter:replies` search against `posts.json` — only `2058982303104401576` was missing
- [x] Visited `Bingran.ai` XHS profile — top notes all present
- [x] Diff is +7/-0 in `posts.json`; no other files changed
- [x] `<Tweet>` (react-tweet) will render content client-side, so no thumbnail/title fields needed