### PR TITLE
Add BenchFlow experiment control dashboard

### DIFF
--- a/current-projects/benchflow-experiment-control/.gitignore
+++ b/current-projects/benchflow-experiment-control/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.DS_Store
+/data/

--- a/current-projects/benchflow-experiment-control/Makefile
+++ b/current-projects/benchflow-experiment-control/Makefile
@@ -1,0 +1,10 @@
+.PHONY: run test
+
+PORT ?= 8765
+
+run:
+	python3 -m app.server $(PORT)
+
+test:
+	python3 -m py_compile app/*.py
+	python3 -m unittest discover -s tests

--- a/current-projects/benchflow-experiment-control/README.md
+++ b/current-projects/benchflow-experiment-control/README.md
@@ -1,0 +1,123 @@
+# BenchFlow Experiment Control
+
+一个独立的 BenchFlow 实验控制台。它默认通过 SSH 在 GCP VM 上启动 `bench eval create`，在 VM 里使用 Docker sandbox 跑 tasks，然后从远端 jobs 目录读取 task 状态、日志和 `result.json` / `config.json`。
+
+这个项目只管理实验启动和监控，不修改 BenchFlow 主 repo，也不修改 SkillsBench task repo。
+
+## Quick Start
+
+```bash
+git clone https://github.com/bingran-you/bingran-you.git
+cd bingran-you/current-projects/benchflow-experiment-control
+make run
+```
+
+然后打开：
+
+```text
+http://127.0.0.1:8765
+```
+
+也可以换端口：
+
+```bash
+make run PORT=9000
+```
+
+## Requirements
+
+本机：
+
+- Python 3.11+。
+- 可以 SSH 到目标 GCP VM。
+- 一个本地 `.env` 文件，里面放模型 provider 的 key，例如 `GEMINI_API_KEY=...`。启动 run 时会上传到远端 run 目录下的 `.env`。
+
+GCP VM：
+
+- BenchFlow repo 已经 clone 到 VM 上。
+- `uv run bench eval create --help` 可以在远端 BenchFlow root 里正常执行。
+- Docker 已安装并可用，因为默认 harness 是 `docker`。
+- tasks 目录已经在 VM 上，例如 SkillsBench tasks。
+
+## Dashboard Flow
+
+1. 启动本地 webapp。
+2. 填写 GCP VM 的 SSH host、user、port 和 key。
+3. 填写远端 BenchFlow root、远端 tasks dir、远端 jobs root。
+4. 选择 agent、model、harness、concurrency。
+5. 可选填写 include/exclude tasks，支持逗号或换行分隔。
+6. 点击“启动”，右侧会显示 run、task 状态、远端日志和 artifacts。
+
+默认生成的远端命令形态是：
+
+```bash
+cd <remote_benchflow_root>
+uv run bench eval create \
+  --tasks-dir <remote_tasks_dir> \
+  --agent <agent> \
+  --model <model> \
+  --sandbox docker \
+  --concurrency <n> \
+  --jobs-dir <remote_jobs_dir>
+```
+
+## Remote Execution
+
+默认运行目标是 `gcp_ssh`：
+
+```bash
+ssh <user>@<host> 'cd <remote_benchflow_root> && uv run bench eval create ... --sandbox docker'
+```
+
+关键路径：
+
+- `env_file`: 本机 `.env` 路径。启动 run 时会上传到远端 run 目录下的 `.env`，远端权限使用 `umask 077`。
+- `remote_benchflow_root`: 远端 VM 上 BenchFlow repo 的 `benchflow` 目录。
+- `remote_tasks_dir`: 远端 VM 上的 task 目录，传给 `--tasks-dir`。
+- `remote_jobs_root`: 远端保存 run 输出的根目录。
+
+远端路径可以写绝对路径，也可以写相对 SSH 登录 home 的路径；默认值使用相对路径，避免 shell 引号影响 `~` 展开。
+
+## Config Fields
+
+- `Key / env 文件本地路径`: 本机 `.env` 文件路径，里面的 key 会被上传到远端 run 目录。
+- `Agent`: 传给 `--agent`。
+- `Model`: 传给 `--model`；如果 agent 是 `oracle`，后端不会传 model。
+- `Harness`: 传给 `--sandbox`，默认是 `docker`。
+- `Include tasks`: 传给重复的 `--include`。
+- `Exclude tasks`: 传给重复的 `--exclude`。
+- `Skills dir`: 传给 `--skills-dir`。
+- `Skills mode`: 非 `default` 时传给 `--skill-mode`。
+- `Extra args`: 追加到 `bench eval create` 的最后。
+
+## Local State
+
+本 webapp 只写当前项目目录下的 `data/`：
+
+- `data/state.json`: run 元数据和命令记录。
+- `data/logs/`: 本地 run 日志；远端 run 的真实日志在 GCP VM 的 jobs 目录。
+
+它不会修改 BenchFlow 主 repo 或 SkillsBench task repo。
+
+## Troubleshooting
+
+先用同一组 SSH 配置验证 VM：
+
+```bash
+ssh -i <key> -p <port> <user>@<host> 'cd <remote_benchflow_root> && uv run bench eval create --help'
+```
+
+如果启动失败，优先检查：
+
+- VM 上的 BenchFlow root 是否正确。
+- VM 上的 tasks dir 是否正确。
+- Docker daemon 是否可用。
+- 本地 `.env` 是否存在且 key 名称符合当前 agent 需要。
+- SSH key 是否能在 BatchMode 下免交互登录。
+
+## Tests
+
+```bash
+python3 -m py_compile app/*.py
+python3 -m unittest discover -s tests
+```

--- a/current-projects/benchflow-experiment-control/app/__init__.py
+++ b/current-projects/benchflow-experiment-control/app/__init__.py
@@ -1,0 +1,2 @@
+"""Local BenchFlow experiment control app."""
+

--- a/current-projects/benchflow-experiment-control/app/jobs.py
+++ b/current-projects/benchflow-experiment-control/app/jobs.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .models import RunRecord
+from .remote import read_remote_artifact, remote_log_tail, remote_snapshot
+
+
+@dataclass
+class TaskRow:
+    task_name: str
+    trial_name: str
+    status: str
+    reward: float | None
+    duration_sec: float | None
+    agent: str
+    model: str
+    error: str | None
+    result_path: str | None
+    config_path: str | None
+    trial_path: str
+    updated_at: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.__dict__.copy()
+
+
+def discover_tasks(tasks_dir: str) -> list[str]:
+    root = Path(tasks_dir).expanduser()
+    if not root.is_dir():
+        return []
+    return sorted(child.name for child in root.iterdir() if (child / "task.toml").is_file())
+
+
+def scan_run(run: RunRecord) -> dict[str, Any]:
+    if run.config.run_target == "gcp_ssh":
+        snapshot = remote_snapshot(run)
+        rows = [_task_row_from_remote(item, run.status) for item in snapshot.get("trials", [])]
+        rows.sort(key=lambda item: (status_order(item.status), item.task_name, item.trial_name))
+        return {
+            "run": run.to_dict(),
+            "summary": summarize(rows),
+            "tasks": [row.to_dict() for row in rows],
+            "log_tail": remote_log_tail(run),
+            "snapshot_error": snapshot.get("error"),
+        }
+
+    root = Path(run.jobs_dir).expanduser()
+    rows = [_task_row(path, root, run.status) for path in find_trial_dirs(root)]
+    rows.sort(key=lambda item: (status_order(item.status), item.task_name, item.trial_name))
+    summary = summarize(rows)
+    return {
+        "run": run.to_dict(),
+        "summary": summary,
+        "tasks": [row.to_dict() for row in rows],
+        "log_tail": tail_file(run.log_path),
+    }
+
+
+def find_trial_dirs(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    dirs: list[Path] = []
+    for child in root.rglob("*"):
+        if not child.is_dir():
+            continue
+        if (child / "result.json").is_file() or (child / "config.json").is_file():
+            if child.name.startswith("."):
+                continue
+            dirs.append(child)
+    return sorted(set(dirs))
+
+
+def summarize(rows: list[TaskRow]) -> dict[str, Any]:
+    counts = {status: 0 for status in ("running", "pass", "fail", "error", "pending")}
+    reward_sum = 0.0
+    reward_count = 0
+    for row in rows:
+        counts[row.status] = counts.get(row.status, 0) + 1
+        if row.reward is not None:
+            reward_sum += row.reward
+            reward_count += 1
+    total = len(rows)
+    done = counts.get("pass", 0) + counts.get("fail", 0) + counts.get("error", 0)
+    return {
+        "total": total,
+        "done": done,
+        "running": counts.get("running", 0),
+        "passed": counts.get("pass", 0),
+        "failed": counts.get("fail", 0),
+        "errored": counts.get("error", 0),
+        "pending": counts.get("pending", 0),
+        "mean_reward": reward_sum / reward_count if reward_count else None,
+    }
+
+
+def _task_row(trial_dir: Path, root: Path, run_status: str) -> TaskRow:
+    result_path = trial_dir / "result.json"
+    config_path = trial_dir / "config.json"
+    result = read_json(result_path)
+    config = read_json(config_path)
+    task_name = (
+        result.get("task_name")
+        or Path(str(config.get("task_path") or "")).name
+        or trial_dir.name.split("__")[0]
+    )
+    reward = read_reward(result)
+    error = result.get("error") or result.get("verifier_error")
+    status = task_status(result, reward, error, run_status)
+    timing = result.get("timing") if isinstance(result.get("timing"), dict) else {}
+    duration = timing.get("total") if isinstance(timing.get("total"), int | float) else None
+    updated = modified_at(result_path if result_path.exists() else trial_dir)
+    return TaskRow(
+        task_name=str(task_name),
+        trial_name=trial_dir.name,
+        status=status,
+        reward=reward,
+        duration_sec=float(duration) if duration is not None else None,
+        agent=str(result.get("agent") or config.get("agent") or ""),
+        model=str(result.get("model") or config.get("model") or ""),
+        error=str(error) if error else None,
+        result_path=relative_path(result_path, root) if result_path.exists() else None,
+        config_path=relative_path(config_path, root) if config_path.exists() else None,
+        trial_path=relative_path(trial_dir, root),
+        updated_at=updated,
+    )
+
+
+def _task_row_from_remote(item: dict[str, Any], run_status: str) -> TaskRow:
+    result = item.get("result") if isinstance(item.get("result"), dict) else {}
+    config = item.get("config") if isinstance(item.get("config"), dict) else {}
+    task_name = (
+        result.get("task_name")
+        or Path(str(config.get("task_path") or "")).name
+        or str(item.get("trial_name") or "").split("__")[0]
+    )
+    reward = read_reward(result)
+    error = result.get("error") or result.get("verifier_error")
+    timing = result.get("timing") if isinstance(result.get("timing"), dict) else {}
+    duration = timing.get("total") if isinstance(timing.get("total"), int | float) else None
+    return TaskRow(
+        task_name=str(task_name),
+        trial_name=str(item.get("trial_name") or ""),
+        status=task_status(result, reward, error, run_status),
+        reward=reward,
+        duration_sec=float(duration) if duration is not None else None,
+        agent=str(result.get("agent") or config.get("agent") or ""),
+        model=str(result.get("model") or config.get("model") or ""),
+        error=str(error) if error else None,
+        result_path=item.get("result_path"),
+        config_path=item.get("config_path"),
+        trial_path=str(item.get("trial_path") or ""),
+        updated_at=remote_modified_at(item.get("updated_at")),
+    )
+
+
+def task_status(
+    result: dict[str, Any], reward: float | None, error: Any, run_status: str
+) -> str:
+    if not result:
+        return "running" if run_status == "running" else "pending"
+    if error:
+        return "error"
+    if reward is None:
+        return "fail"
+    return "pass" if reward >= 1.0 else "fail"
+
+
+def read_reward(result: dict[str, Any]) -> float | None:
+    rewards = result.get("rewards")
+    if isinstance(rewards, dict) and isinstance(rewards.get("reward"), int | float):
+        return float(rewards["reward"])
+    if isinstance(rewards, int | float):
+        return float(rewards)
+    return None
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def read_artifact(run: RunRecord, relative: str) -> dict[str, Any]:
+    if run.config.run_target == "gcp_ssh":
+        return read_remote_artifact(run, relative)
+
+    root = Path(run.jobs_dir).expanduser().resolve()
+    target = (root / relative).resolve()
+    if not target.is_file() or not is_within(target, root):
+        raise FileNotFoundError(relative)
+    if target.stat().st_size > 2_000_000:
+        return {"path": relative, "too_large": True, "content": ""}
+    return {"path": relative, "too_large": False, "content": target.read_text(errors="replace")}
+
+
+def tail_file(path: str, limit: int = 16_000) -> str:
+    file_path = Path(path)
+    if not file_path.is_file():
+        return ""
+    data = file_path.read_bytes()
+    return data[-limit:].decode(errors="replace")
+
+
+def relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def modified_at(path: Path) -> str | None:
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime).astimezone().isoformat(timespec="seconds")
+    except OSError:
+        return None
+
+
+def remote_modified_at(value: Any) -> str | None:
+    if not isinstance(value, int | float):
+        return None
+    return datetime.fromtimestamp(value).astimezone().isoformat(timespec="seconds")
+
+
+def is_within(path: Path, root: Path) -> bool:
+    return path == root or root in path.parents
+
+
+def status_order(status: str) -> int:
+    return {"running": 0, "error": 1, "fail": 2, "pending": 3, "pass": 4}.get(status, 5)

--- a/current-projects/benchflow-experiment-control/app/models.py
+++ b/current-projects/benchflow-experiment-control/app/models.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DATA_DIR = PROJECT_ROOT / "data"
+
+
+def now_iso() -> str:
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+@dataclass
+class ExperimentConfig:
+    name: str
+    run_target: str = "gcp_ssh"
+    benchflow_root: str = ""
+    tasks_dir: str = ""
+    env_file: str = ""
+    jobs_root: str = str(DEFAULT_DATA_DIR / "benchflow-jobs")
+    remote_host: str = ""
+    remote_user: str = ""
+    remote_port: int = 22
+    remote_ssh_key: str = ""
+    remote_benchflow_root: str = ""
+    remote_tasks_dir: str = ""
+    remote_jobs_root: str = "benchflow-experiment-runs"
+    agent: str = "gemini"
+    model: str = "gemini-3-flash-preview"
+    sandbox: str = "docker"
+    concurrency: int = 4
+    skills_mode: str = "default"
+    skills_dir: str = ""
+    include_tasks: list[str] = field(default_factory=list)
+    exclude_tasks: list[str] = field(default_factory=list)
+    extra_args: str = ""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ExperimentConfig":
+        def list_field(name: str) -> list[str]:
+            value = raw.get(name) or []
+            if isinstance(value, str):
+                return split_names(value)
+            return [str(item).strip() for item in value if str(item).strip()]
+
+        return cls(
+            name=str(raw.get("name") or "experiment").strip() or "experiment",
+            run_target=str(raw.get("run_target") or raw.get("runTarget") or cls.run_target),
+            benchflow_root=str(raw.get("benchflow_root") or raw.get("benchflowRoot") or ""),
+            tasks_dir=str(raw.get("tasks_dir") or raw.get("tasksDir") or ""),
+            env_file=str(raw.get("env_file") or raw.get("envFile") or ""),
+            jobs_root=str(raw.get("jobs_root") or raw.get("jobsRoot") or DEFAULT_DATA_DIR / "benchflow-jobs"),
+            remote_host=str(raw.get("remote_host") or raw.get("remoteHost") or ""),
+            remote_user=str(raw.get("remote_user") or raw.get("remoteUser") or ""),
+            remote_port=int(raw.get("remote_port") or raw.get("remotePort") or cls.remote_port),
+            remote_ssh_key=str(raw.get("remote_ssh_key") or raw.get("remoteSshKey") or ""),
+            remote_benchflow_root=str(raw.get("remote_benchflow_root") or raw.get("remoteBenchflowRoot") or ""),
+            remote_tasks_dir=str(raw.get("remote_tasks_dir") or raw.get("remoteTasksDir") or ""),
+            remote_jobs_root=str(raw.get("remote_jobs_root") or raw.get("remoteJobsRoot") or cls.remote_jobs_root),
+            agent=str(raw.get("agent") or cls.agent),
+            model=str(raw.get("model") or ""),
+            sandbox=str(raw.get("sandbox") or cls.sandbox),
+            concurrency=max(1, int(raw.get("concurrency") or cls.concurrency)),
+            skills_mode=str(raw.get("skills_mode") or raw.get("skillsMode") or cls.skills_mode),
+            skills_dir=str(raw.get("skills_dir") or raw.get("skillsDir") or ""),
+            include_tasks=list_field("include_tasks") or list_field("includeTasks"),
+            exclude_tasks=list_field("exclude_tasks") or list_field("excludeTasks"),
+            extra_args=str(raw.get("extra_args") or raw.get("extraArgs") or ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RunRecord:
+    id: str
+    status: str
+    config: ExperimentConfig
+    jobs_dir: str
+    log_path: str
+    command: list[str]
+    remote_jobs_dir: str = ""
+    remote_log_path: str = ""
+    remote_pid: int | None = None
+    remote_exit_code_path: str = ""
+    pid: int | None = None
+    return_code: int | None = None
+    created_at: str = field(default_factory=now_iso)
+    started_at: str | None = None
+    finished_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "RunRecord":
+        return cls(
+            id=str(raw["id"]),
+            status=str(raw.get("status") or "created"),
+            config=ExperimentConfig.from_dict(raw.get("config") or {}),
+            jobs_dir=str(raw.get("jobs_dir") or raw.get("jobsDir") or ""),
+            log_path=str(raw.get("log_path") or raw.get("logPath") or ""),
+            command=[str(part) for part in raw.get("command") or []],
+            remote_jobs_dir=str(raw.get("remote_jobs_dir") or raw.get("remoteJobsDir") or ""),
+            remote_log_path=str(raw.get("remote_log_path") or raw.get("remoteLogPath") or ""),
+            remote_pid=raw.get("remote_pid") or raw.get("remotePid"),
+            remote_exit_code_path=str(raw.get("remote_exit_code_path") or raw.get("remoteExitCodePath") or ""),
+            pid=raw.get("pid"),
+            return_code=raw.get("return_code"),
+            created_at=str(raw.get("created_at") or now_iso()),
+            started_at=raw.get("started_at"),
+            finished_at=raw.get("finished_at"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["config"] = self.config.to_dict()
+        return data
+
+
+def split_names(text: str) -> list[str]:
+    return [item.strip() for item in text.replace("\n", ",").split(",") if item.strip()]

--- a/current-projects/benchflow-experiment-control/app/remote.py
+++ b/current-projects/benchflow-experiment-control/app/remote.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .models import ExperimentConfig, RunRecord
+
+
+def ssh_base(config: ExperimentConfig) -> list[str]:
+    if not config.remote_host:
+        raise ValueError("remote host is required for gcp_ssh runs")
+    target = f"{config.remote_user}@{config.remote_host}" if config.remote_user else config.remote_host
+    cmd = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-p",
+        str(config.remote_port),
+    ]
+    if config.remote_ssh_key:
+        cmd.extend(["-i", str(Path(config.remote_ssh_key).expanduser())])
+    cmd.append(target)
+    return cmd
+
+
+def remote_shell(
+    config: ExperimentConfig,
+    script: str,
+    *,
+    input_text: str | None = None,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*ssh_base(config), script],
+        input=input_text,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def upload_env_file(config: ExperimentConfig, remote_path: str) -> None:
+    if not config.env_file:
+        return
+    local_path = Path(config.env_file).expanduser()
+    content = local_path.read_text()
+    script = f"umask 077; mkdir -p {shlex.quote(str(Path(remote_path).parent))}; cat > {shlex.quote(remote_path)}"
+    result = remote_shell(config, script, input_text=content, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "failed to upload env file")
+
+
+def start_remote_process(
+    config: ExperimentConfig,
+    command: list[str],
+    *,
+    remote_jobs_dir: str,
+    remote_log_path: str,
+    remote_env_path: str,
+    remote_exit_code_path: str,
+) -> int:
+    quoted_cmd = shlex.join(command)
+    env_line = f"set -a; . {shlex.quote(remote_env_path)}; set +a;" if config.env_file else ""
+    script = (
+        f"mkdir -p {shlex.quote(remote_jobs_dir)} {shlex.quote(str(Path(remote_log_path).parent))}; "
+        f"cd {shlex.quote(config.remote_benchflow_root)} && "
+        f"( {env_line} {quoted_cmd}; echo $? > {shlex.quote(remote_exit_code_path)} ) "
+        f"> {shlex.quote(remote_log_path)} 2>&1 < /dev/null & echo $!"
+    )
+    result = remote_shell(config, script, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "failed to start remote run")
+    try:
+        return int(result.stdout.strip().splitlines()[-1])
+    except (IndexError, ValueError) as exc:
+        raise RuntimeError(f"could not parse remote pid: {result.stdout!r}") from exc
+
+
+def read_remote_exit_code(run: RunRecord) -> int | None:
+    if not run.remote_exit_code_path:
+        return None
+    script = f"test -f {shlex.quote(run.remote_exit_code_path)} && cat {shlex.quote(run.remote_exit_code_path)} || true"
+    result = remote_shell(run.config, script, timeout=10)
+    text = result.stdout.strip()
+    return int(text) if text.isdigit() else None
+
+
+def stop_remote_run(run: RunRecord) -> None:
+    if not run.remote_pid:
+        return
+    script = f"kill -TERM {int(run.remote_pid)} 2>/dev/null || true"
+    remote_shell(run.config, script, timeout=10)
+
+
+def remote_log_tail(run: RunRecord, limit: int = 16_000) -> str:
+    if not run.remote_log_path:
+        return ""
+    script = f"test -f {shlex.quote(run.remote_log_path)} && tail -c {limit} {shlex.quote(run.remote_log_path)} || true"
+    return remote_shell(run.config, script, timeout=10).stdout
+
+
+def remote_snapshot(run: RunRecord) -> dict[str, Any]:
+    script = r'''
+import json, os
+from pathlib import Path
+
+root = Path(os.environ["JOBS_DIR"]).expanduser()
+
+def read_json(path):
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+trials = []
+if root.is_dir():
+    for child in root.rglob("*"):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        result_path = child / "result.json"
+        config_path = child / "config.json"
+        if not result_path.is_file() and not config_path.is_file():
+            continue
+        try:
+            rel = child.relative_to(root).as_posix()
+        except ValueError:
+            rel = child.as_posix()
+        trials.append({
+            "trial_path": rel,
+            "trial_name": child.name,
+            "result_path": (result_path.relative_to(root).as_posix() if result_path.is_file() else None),
+            "config_path": (config_path.relative_to(root).as_posix() if config_path.is_file() else None),
+            "result": read_json(result_path),
+            "config": read_json(config_path),
+            "updated_at": child.stat().st_mtime,
+        })
+print(json.dumps({"trials": trials}))
+'''
+    shell = f"JOBS_DIR={shlex.quote(run.remote_jobs_dir)} python3 -"
+    result = remote_shell(run.config, shell, input_text=script, timeout=30)
+    if result.returncode != 0:
+        return {"trials": [], "error": result.stderr.strip()}
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"trials": [], "error": "remote snapshot did not return JSON"}
+
+
+def read_remote_artifact(run: RunRecord, relative: str) -> dict[str, Any]:
+    script = r'''
+import json, os, sys
+from pathlib import Path
+
+root = Path(os.environ["JOBS_DIR"]).expanduser().resolve()
+target = (root / os.environ["REL_PATH"]).resolve()
+if target != root and root not in target.parents:
+    print(json.dumps({"error": "not found"}))
+    raise SystemExit(0)
+if not target.is_file():
+    print(json.dumps({"error": "not found"}))
+    raise SystemExit(0)
+size = target.stat().st_size
+if size > 2_000_000:
+    print(json.dumps({"path": os.environ["REL_PATH"], "too_large": True, "content": ""}))
+else:
+    print(json.dumps({"path": os.environ["REL_PATH"], "too_large": False, "content": target.read_text(errors="replace")}))
+'''
+    shell = (
+        f"JOBS_DIR={shlex.quote(run.remote_jobs_dir)} "
+        f"REL_PATH={shlex.quote(relative)} python3 -"
+    )
+    result = remote_shell(run.config, shell, input_text=script, timeout=20)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"error": result.stderr.strip() or "could not read remote artifact"}

--- a/current-projects/benchflow-experiment-control/app/runner.py
+++ b/current-projects/benchflow-experiment-control/app/runner.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import os
+import posixpath
+import shlex
+import signal
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+from .models import DEFAULT_DATA_DIR, ExperimentConfig, RunRecord, now_iso
+from .remote import (
+    read_remote_exit_code,
+    start_remote_process,
+    stop_remote_run,
+    upload_env_file,
+)
+from .store import StateStore
+
+
+_PROCESSES: dict[str, subprocess.Popen] = {}
+
+
+def parse_env_file(path: str) -> dict[str, str]:
+    if not path:
+        return {}
+    env_path = Path(path).expanduser()
+    if not env_path.exists():
+        raise FileNotFoundError(f"env file does not exist: {env_path}")
+
+    values: dict[str, str] = {}
+    for raw in env_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line.removeprefix("export ").strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            values[key] = value
+    return values
+
+
+def build_command(config: ExperimentConfig, jobs_dir: str) -> list[str]:
+    tasks_dir = config.remote_tasks_dir if config.run_target == "gcp_ssh" else config.tasks_dir
+    cmd = [
+        "uv",
+        "run",
+        "bench",
+        "eval",
+        "create",
+        "--tasks-dir",
+        tasks_dir,
+        "--agent",
+        config.agent,
+        "--sandbox",
+        config.sandbox,
+        "--concurrency",
+        str(config.concurrency),
+        "--jobs-dir",
+        jobs_dir,
+    ]
+    if config.model and config.agent != "oracle":
+        cmd.extend(["--model", config.model])
+    if config.skills_dir:
+        cmd.extend(["--skills-dir", config.skills_dir])
+    if config.skills_mode and config.skills_mode != "default":
+        cmd.extend(["--skill-mode", config.skills_mode])
+    for task_name in config.include_tasks:
+        cmd.extend(["--include", task_name])
+    for task_name in config.exclude_tasks:
+        cmd.extend(["--exclude", task_name])
+    if config.extra_args:
+        cmd.extend(shlex.split(config.extra_args))
+    return cmd
+
+
+def start_run(config: ExperimentConfig, store: StateStore) -> RunRecord:
+    validate_config(config)
+    run_id = datetime.now().strftime("%Y%m%d-%H%M%S")
+    safe_name = slug(config.name)
+    log_path = str(Path(store.data_dir) / "logs" / f"{safe_name}-{run_id}.log")
+    Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+    if config.run_target == "gcp_ssh":
+        return start_remote_run(config, store, run_id, safe_name, log_path)
+
+    jobs_dir = str(Path(config.jobs_root).expanduser() / safe_name / run_id)
+    Path(jobs_dir).mkdir(parents=True, exist_ok=True)
+
+    command = build_command(config, jobs_dir)
+    run = RunRecord(
+        id=f"{safe_name}-{run_id}",
+        status="running",
+        config=config,
+        jobs_dir=jobs_dir,
+        log_path=log_path,
+        command=command,
+        started_at=now_iso(),
+    )
+    store.upsert_run(run)
+
+    env = os.environ.copy()
+    env.update(parse_env_file(config.env_file))
+    log_file = Path(log_path).open("ab", buffering=0)
+    process = subprocess.Popen(
+        command,
+        cwd=config.benchflow_root,
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    run.pid = process.pid
+    _PROCESSES[run.id] = process
+    store.upsert_run(run)
+    return run
+
+
+def start_remote_run(
+    config: ExperimentConfig,
+    store: StateStore,
+    run_id: str,
+    safe_name: str,
+    log_path: str,
+) -> RunRecord:
+    remote_jobs_dir = posixpath.join(config.remote_jobs_root.rstrip("/"), safe_name, run_id)
+    remote_log_path = posixpath.join(remote_jobs_dir, "run.log")
+    remote_env_path = posixpath.join(remote_jobs_dir, ".env")
+    remote_exit_code_path = posixpath.join(remote_jobs_dir, "exit-code.txt")
+    command = build_command(config, remote_jobs_dir)
+    run = RunRecord(
+        id=f"{safe_name}-{run_id}",
+        status="running",
+        config=config,
+        jobs_dir=str(Path(config.jobs_root).expanduser() / safe_name / run_id),
+        log_path=log_path,
+        command=command,
+        remote_jobs_dir=remote_jobs_dir,
+        remote_log_path=remote_log_path,
+        remote_exit_code_path=remote_exit_code_path,
+        started_at=now_iso(),
+    )
+    store.upsert_run(run)
+    upload_env_file(config, remote_env_path)
+    run.remote_pid = start_remote_process(
+        config,
+        command,
+        remote_jobs_dir=remote_jobs_dir,
+        remote_log_path=remote_log_path,
+        remote_env_path=remote_env_path,
+        remote_exit_code_path=remote_exit_code_path,
+    )
+    store.upsert_run(run)
+    return run
+
+
+def refresh_processes(store: StateStore) -> None:
+    for run in store.list_runs():
+        if run.status == "running" and run.config.run_target == "gcp_ssh":
+            return_code = read_remote_exit_code(run)
+            if return_code is None:
+                continue
+            store.update_run(
+                run.id,
+                status="completed" if return_code == 0 else "failed",
+                return_code=return_code,
+                finished_at=now_iso(),
+            )
+
+    for run_id, process in list(_PROCESSES.items()):
+        return_code = process.poll()
+        if return_code is None:
+            continue
+        _PROCESSES.pop(run_id, None)
+        store.update_run(
+            run_id,
+            status="completed" if return_code == 0 else "failed",
+            return_code=return_code,
+            finished_at=now_iso(),
+        )
+
+
+def stop_run(run_id: str, store: StateStore) -> RunRecord | None:
+    run = store.get_run(run_id)
+    if run is None:
+        return None
+    if run.config.run_target == "gcp_ssh":
+        stop_remote_run(run)
+        return store.update_run(run_id, status="stopped", finished_at=now_iso())
+
+    process = _PROCESSES.pop(run_id, None)
+    if process is not None and process.poll() is None:
+        os.killpg(process.pid, signal.SIGTERM)
+    elif run.pid:
+        try:
+            os.kill(run.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    return store.update_run(run_id, status="stopped", finished_at=now_iso())
+
+
+def validate_config(config: ExperimentConfig) -> None:
+    if config.run_target not in {"gcp_ssh", "local"}:
+        raise ValueError("run_target must be gcp_ssh or local")
+    if config.run_target == "local":
+        benchflow_root = Path(config.benchflow_root).expanduser()
+        tasks_dir = Path(config.tasks_dir).expanduser()
+        if not benchflow_root.exists():
+            raise FileNotFoundError(f"BenchFlow root does not exist: {benchflow_root}")
+        if not tasks_dir.exists():
+            raise FileNotFoundError(f"tasks dir does not exist: {tasks_dir}")
+    else:
+        if not config.remote_host:
+            raise ValueError("remote host is required")
+        if not config.remote_benchflow_root:
+            raise ValueError("remote BenchFlow root is required")
+        if not config.remote_tasks_dir:
+            raise ValueError("remote tasks dir is required")
+    if config.env_file and not Path(config.env_file).expanduser().exists():
+        raise FileNotFoundError(f"env file does not exist: {config.env_file}")
+    if config.concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+
+
+def slug(text: str) -> str:
+    cleaned = "".join(ch.lower() if ch.isalnum() else "-" for ch in text.strip())
+    return "-".join(part for part in cleaned.split("-") if part) or "experiment"
+
+
+def default_paths() -> dict[str, str]:
+    workspace = Path("/Users/bingran_you/Downloads/GitHub/BenchFlow.ai")
+    return {
+        "run_target": "gcp_ssh",
+        "benchflow_root": str(workspace / "benchflow"),
+        "tasks_dir": str(workspace / "skillsbench" / "tasks"),
+        "jobs_root": str(DEFAULT_DATA_DIR / "benchflow-jobs"),
+        "remote_benchflow_root": "BenchFlow.ai/benchflow",
+        "remote_tasks_dir": "BenchFlow.ai/skillsbench/tasks",
+        "remote_jobs_root": "benchflow-experiment-runs",
+        "agent": "gemini",
+        "model": "gemini-3-flash-preview",
+        "concurrency": "4",
+        "sandbox": "docker",
+    }

--- a/current-projects/benchflow-experiment-control/app/server.py
+++ b/current-projects/benchflow-experiment-control/app/server.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import mimetypes
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, unquote, urlparse
+
+from .jobs import discover_tasks, read_artifact, scan_run
+from .models import DEFAULT_DATA_DIR, ExperimentConfig
+from .runner import default_paths, refresh_processes, start_run, stop_run
+from .store import StateStore
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+STATIC_ROOT = PROJECT_ROOT / "app" / "static"
+
+
+class AppContext:
+    def __init__(self, data_dir: Path = DEFAULT_DATA_DIR):
+        self.store = StateStore(data_dir)
+
+
+class Handler(BaseHTTPRequestHandler):
+    context: AppContext
+
+    def do_GET(self) -> None:
+        try:
+            self.route_get()
+        except Exception as exc:
+            self.json_response({"error": str(exc)}, status=500)
+
+    def do_POST(self) -> None:
+        try:
+            self.route_post()
+        except Exception as exc:
+            self.json_response({"error": str(exc)}, status=500)
+
+    def route_get(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/defaults":
+            self.json_response(default_paths())
+        elif parsed.path == "/api/state":
+            refresh_processes(self.context.store)
+            runs = [scan_run(run) for run in reversed(self.context.store.list_runs())]
+            self.json_response({"runs": runs})
+        elif parsed.path == "/api/tasks":
+            query = parse_qs(parsed.query)
+            self.json_response({"tasks": discover_tasks(query.get("tasks_dir", [""])[0])})
+        elif parsed.path.startswith("/api/runs/"):
+            self.handle_run_get(parsed.path, parsed.query)
+        else:
+            self.static_response(parsed.path)
+
+    def route_post(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/runs":
+            payload = self.read_json_body()
+            run = start_run(ExperimentConfig.from_dict(payload), self.context.store)
+            self.json_response({"run": scan_run(run)}, status=201)
+        elif parsed.path.startswith("/api/runs/") and parsed.path.endswith("/stop"):
+            run_id = parsed.path.split("/")[3]
+            run = stop_run(run_id, self.context.store)
+            self.json_response({"run": scan_run(run)} if run else {"error": "run not found"}, status=200 if run else 404)
+        else:
+            self.json_response({"error": "not found"}, status=404)
+
+    def handle_run_get(self, path: str, query: str) -> None:
+        parts = path.strip("/").split("/")
+        if len(parts) < 3:
+            self.json_response({"error": "not found"}, status=404)
+            return
+        run = self.context.store.get_run(parts[2])
+        if run is None:
+            self.json_response({"error": "run not found"}, status=404)
+            return
+        if len(parts) == 3:
+            self.json_response(scan_run(run))
+        elif len(parts) == 4 and parts[3] == "log":
+            self.json_response({"log": scan_run(run)["log_tail"]})
+        elif len(parts) == 4 and parts[3] == "artifact":
+            rel = parse_qs(query).get("path", [""])[0]
+            self.json_response(read_artifact(run, unquote(rel)))
+        else:
+            self.json_response({"error": "not found"}, status=404)
+
+    def static_response(self, request_path: str) -> None:
+        rel = "index.html" if request_path in {"", "/"} else request_path.lstrip("/")
+        path = (STATIC_ROOT / rel).resolve()
+        if not str(path).startswith(str(STATIC_ROOT.resolve())) or not path.is_file():
+            path = STATIC_ROOT / "index.html"
+        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(path.read_bytes())
+
+    def read_json_body(self) -> dict:
+        length = int(self.headers.get("Content-Length") or "0")
+        if length <= 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode())
+
+    def json_response(self, payload: dict, status: int = 200) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def main() -> int:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8765
+    Handler.context = AppContext()
+    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    print(f"BenchFlow experiment control: http://127.0.0.1:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/current-projects/benchflow-experiment-control/app/static/app.js
+++ b/current-projects/benchflow-experiment-control/app/static/app.js
@@ -1,0 +1,343 @@
+const form = document.querySelector("#runForm");
+const state = {
+  runs: [],
+  selectedRunId: null,
+  busy: false,
+};
+
+const fields = [
+  "name",
+  "run_target",
+  "benchflow_root",
+  "tasks_dir",
+  "env_file",
+  "jobs_root",
+  "remote_host",
+  "remote_user",
+  "remote_port",
+  "remote_ssh_key",
+  "remote_benchflow_root",
+  "remote_tasks_dir",
+  "remote_jobs_root",
+  "agent",
+  "model",
+  "sandbox",
+  "concurrency",
+  "skills_mode",
+  "skills_dir",
+  "include_tasks",
+  "exclude_tasks",
+  "extra_args",
+];
+
+function $(selector) {
+  return document.querySelector(selector);
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(payload.error || `HTTP ${response.status}`);
+  }
+  return payload;
+}
+
+function formPayload() {
+  const data = new FormData(form);
+  const payload = {};
+  for (const name of fields) {
+    payload[name] = data.get(name) ?? "";
+  }
+  payload.concurrency = Number(payload.concurrency || 1);
+  payload.remote_port = Number(payload.remote_port || 22);
+  return payload;
+}
+
+function setFormValues(values) {
+  for (const [key, value] of Object.entries(values)) {
+    const input = form.elements[key];
+    if (input && value !== undefined && value !== null && value !== "") {
+      input.value = value;
+    }
+  }
+  updateMode();
+}
+
+function updateMode() {
+  const target = form.elements.run_target.value;
+  document.querySelector(".remote-fields").dataset.hidden = target === "local";
+  document.querySelector(".local-fields").dataset.hidden = target !== "local";
+  $("#connectionLine").textContent =
+    target === "gcp_ssh" ? "GCP SSH · Docker · BenchFlow tasks" : "Local · BenchFlow tasks";
+}
+
+function setMessage(text, type = "") {
+  const box = $("#formMessage");
+  box.textContent = text;
+  box.className = `message ${type}`.trim();
+}
+
+async function loadDefaults() {
+  const defaults = await api("/api/defaults");
+  setFormValues(defaults);
+}
+
+async function loadState({ silent = false } = {}) {
+  if (state.busy) return;
+  try {
+    state.busy = true;
+    const payload = await api("/api/state");
+    state.runs = payload.runs || [];
+    if (!state.selectedRunId && state.runs.length) {
+      state.selectedRunId = state.runs[0].run.id;
+    }
+    if (!state.runs.some((item) => item.run.id === state.selectedRunId)) {
+      state.selectedRunId = state.runs[0]?.run.id || null;
+    }
+    render();
+    $("#lastUpdated").textContent = `同步于 ${new Date().toLocaleTimeString()}`;
+    if (!silent) setMessage("");
+  } catch (error) {
+    if (!silent) setMessage(error.message, "error");
+  } finally {
+    state.busy = false;
+  }
+}
+
+async function startRun(event) {
+  event.preventDefault();
+  setMessage("正在启动...");
+  try {
+    const payload = await api("/api/runs", {
+      method: "POST",
+      body: JSON.stringify(formPayload()),
+    });
+    state.selectedRunId = payload.run.run.id;
+    setMessage(`已启动 ${payload.run.run.id}`, "ok");
+    await loadState({ silent: true });
+  } catch (error) {
+    setMessage(error.message, "error");
+  }
+}
+
+async function stopActiveRun() {
+  const run = activeRun();
+  if (!run) return;
+  setMessage(`正在停止 ${run.run.id}...`);
+  try {
+    await api(`/api/runs/${encodeURIComponent(run.run.id)}/stop`, { method: "POST" });
+    setMessage(`已停止 ${run.run.id}`, "ok");
+    await loadState({ silent: true });
+  } catch (error) {
+    setMessage(error.message, "error");
+  }
+}
+
+async function loadTaskIndex() {
+  const tasksDir = form.elements.tasks_dir.value;
+  try {
+    const payload = await api(`/api/tasks?tasks_dir=${encodeURIComponent(tasksDir)}`);
+    renderTaskIndex(payload.tasks || []);
+  } catch (error) {
+    $("#taskIndex").textContent = error.message;
+    $("#taskIndex").className = "task-index-list empty";
+  }
+}
+
+function activeRun() {
+  return state.runs.find((item) => item.run.id === state.selectedRunId) || null;
+}
+
+function render() {
+  renderRuns();
+  renderActiveRun();
+}
+
+function renderRuns() {
+  $("#runCount").textContent = String(state.runs.length);
+  const list = $("#runsList");
+  if (!state.runs.length) {
+    list.className = "runs-list empty";
+    list.textContent = "暂无运行记录";
+    return;
+  }
+  list.className = "runs-list";
+  list.innerHTML = state.runs
+    .map((item) => {
+      const run = item.run;
+      const summary = item.summary || {};
+      const active = run.id === state.selectedRunId ? " active" : "";
+      const command = (run.command || []).join(" ");
+      return `
+        <button class="run-item${active}" type="button" data-run-id="${escapeHtml(run.id)}">
+          <span class="run-title">${escapeHtml(run.config.name || run.id)}</span>
+          <span class="status-pill status-${escapeHtml(run.status)}">${escapeHtml(run.status)}</span>
+          <span class="run-meta">${escapeHtml(run.started_at || run.created_at || "")} · ${summary.done || 0}/${summary.total || 0} done · reward ${formatReward(summary.mean_reward)}</span>
+          <span class="run-command">${escapeHtml(command)}</span>
+        </button>
+      `;
+    })
+    .join("");
+  list.querySelectorAll(".run-item").forEach((button) => {
+    button.addEventListener("click", () => {
+      state.selectedRunId = button.dataset.runId;
+      render();
+    });
+  });
+}
+
+function renderActiveRun() {
+  const item = activeRun();
+  if (!item) {
+    $("#activeRunTitle").textContent = "未选择 run";
+    $("#activeRunMeta").textContent = "启动一个实验后会自动显示最新 run";
+    $("#stopRun").disabled = true;
+    $("#summaryStrip").innerHTML = "";
+    $("#tasksBody").innerHTML = '<tr><td colspan="7" class="empty-cell">暂无 task 结果</td></tr>';
+    $("#logOutput").textContent = "暂无日志";
+    $("#artifactOutput").textContent = "选择 result.json 或 config.json";
+    $("#artifactPath").textContent = "";
+    return;
+  }
+
+  const run = item.run;
+  const summary = item.summary || {};
+  $("#activeRunTitle").textContent = run.config.name || run.id;
+  $("#activeRunMeta").textContent = `${run.id} · ${run.config.run_target} · ${run.remote_jobs_dir || run.jobs_dir}`;
+  $("#stopRun").disabled = run.status !== "running";
+  $("#summaryStrip").innerHTML = metricHtml(summary);
+  $("#logOutput").textContent = item.log_tail || "暂无日志";
+  $("#logHint").textContent = run.remote_log_path || run.log_path || "";
+  renderTasks(item.tasks || []);
+}
+
+function metricHtml(summary) {
+  const metrics = [
+    ["Total", summary.total ?? 0],
+    ["Done", summary.done ?? 0],
+    ["Running", summary.running ?? 0],
+    ["Pass", summary.passed ?? 0],
+    ["Fail", summary.failed ?? 0],
+    ["Error", summary.errored ?? 0],
+    ["Mean", formatReward(summary.mean_reward)],
+  ];
+  return metrics
+    .map(([label, value]) => `<div class="metric"><span>${label}</span><strong>${value}</strong></div>`)
+    .join("");
+}
+
+function renderTasks(tasks) {
+  const body = $("#tasksBody");
+  const status = $("#statusFilter").value;
+  const needle = $("#taskFilter").value.trim().toLowerCase();
+  const filtered = tasks.filter((task) => {
+    const matchesStatus = !status || task.status === status;
+    const haystack = `${task.task_name} ${task.trial_name}`.toLowerCase();
+    return matchesStatus && (!needle || haystack.includes(needle));
+  });
+
+  if (!filtered.length) {
+    body.innerHTML = '<tr><td colspan="7" class="empty-cell">暂无匹配 task</td></tr>';
+    return;
+  }
+
+  body.innerHTML = filtered
+    .map((task) => {
+      const artifactButtons = [
+        artifactButton(task.result_path, "result"),
+        artifactButton(task.config_path, "config"),
+      ].join("");
+      return `
+        <tr>
+          <td><span class="status-pill status-${escapeHtml(task.status)}">${escapeHtml(task.status)}</span></td>
+          <td class="task-name" title="${escapeHtml(task.task_name)}">${escapeHtml(task.task_name)}</td>
+          <td class="trial-name" title="${escapeHtml(task.trial_name)}">${escapeHtml(task.trial_name)}</td>
+          <td>${formatReward(task.reward)}</td>
+          <td>${formatSeconds(task.duration_sec)}</td>
+          <td>${escapeHtml(task.updated_at || "")}</td>
+          <td><div class="artifact-buttons">${artifactButtons || ""}</div></td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  body.querySelectorAll("[data-artifact]").forEach((button) => {
+    button.addEventListener("click", () => viewArtifact(button.dataset.artifact));
+  });
+}
+
+function artifactButton(path, label) {
+  if (!path) return "";
+  return `<button type="button" data-artifact="${escapeHtml(path)}">${label}</button>`;
+}
+
+async function viewArtifact(path) {
+  const run = activeRun();
+  if (!run || !path) return;
+  $("#artifactPath").textContent = path;
+  $("#artifactOutput").textContent = "读取中...";
+  try {
+    const payload = await api(
+      `/api/runs/${encodeURIComponent(run.run.id)}/artifact?path=${encodeURIComponent(path)}`,
+    );
+    if (payload.error) {
+      $("#artifactOutput").textContent = payload.error;
+    } else if (payload.too_large) {
+      $("#artifactOutput").textContent = "文件超过 2 MB，未加载";
+    } else {
+      $("#artifactOutput").textContent = payload.content || "";
+    }
+  } catch (error) {
+    $("#artifactOutput").textContent = error.message;
+  }
+}
+
+function renderTaskIndex(tasks) {
+  const box = $("#taskIndex");
+  if (!tasks.length) {
+    box.className = "task-index-list empty";
+    box.textContent = "没有读取到 task.toml";
+    return;
+  }
+  box.className = "task-index-list";
+  box.innerHTML = tasks.map((task) => `<span class="task-chip">${escapeHtml(task)}</span>`).join("");
+}
+
+function formatReward(value) {
+  if (value === null || value === undefined || value === "") return "—";
+  const number = Number(value);
+  return Number.isFinite(number) ? number.toFixed(3).replace(/\.?0+$/, "") : String(value);
+}
+
+function formatSeconds(value) {
+  if (value === null || value === undefined || value === "") return "—";
+  const number = Number(value);
+  if (!Number.isFinite(number)) return String(value);
+  if (number < 60) return `${number.toFixed(1)}s`;
+  return `${Math.floor(number / 60)}m ${Math.round(number % 60)}s`;
+}
+
+form.addEventListener("submit", startRun);
+$("#stopRun").addEventListener("click", stopActiveRun);
+$("#refreshState").addEventListener("click", () => loadState());
+$("#loadTasks").addEventListener("click", loadTaskIndex);
+$("#runTarget").addEventListener("change", updateMode);
+$("#statusFilter").addEventListener("change", renderActiveRun);
+$("#taskFilter").addEventListener("input", renderActiveRun);
+
+await loadDefaults();
+await loadState({ silent: true });
+setInterval(() => loadState({ silent: true }), 5000);

--- a/current-projects/benchflow-experiment-control/app/static/index.html
+++ b/current-projects/benchflow-experiment-control/app/static/index.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BenchFlow Experiment Control</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div>
+        <h1>BenchFlow Experiment Control</h1>
+        <p id="connectionLine">GCP SSH · Docker · BenchFlow tasks</p>
+      </div>
+      <div class="top-actions">
+        <span id="lastUpdated">未同步</span>
+        <button id="refreshState" type="button">刷新</button>
+      </div>
+    </header>
+
+    <main class="shell">
+      <aside class="sidebar">
+        <section class="panel launch-panel">
+          <div class="panel-head">
+            <h2>启动实验</h2>
+            <button id="startRun" form="runForm" type="submit">启动</button>
+          </div>
+          <form id="runForm" class="form-grid">
+            <label>
+              名称
+              <input name="name" value="skillsbench-batch" autocomplete="off" />
+            </label>
+            <label>
+              运行位置
+              <select name="run_target" id="runTarget">
+                <option value="gcp_ssh">GCP VM via SSH</option>
+                <option value="local">Local</option>
+              </select>
+            </label>
+            <label>
+              Agent
+              <input name="agent" value="gemini" autocomplete="off" />
+            </label>
+            <label>
+              Model
+              <input name="model" autocomplete="off" />
+            </label>
+            <label>
+              Harness
+              <select name="sandbox">
+                <option value="docker">docker</option>
+                <option value="daytona">daytona</option>
+                <option value="local">local</option>
+                <option value="firecracker">firecracker</option>
+                <option value="k8s">k8s</option>
+              </select>
+            </label>
+            <label>
+              并发
+              <input name="concurrency" type="number" min="1" max="256" value="4" />
+            </label>
+            <label class="wide">
+              Key / env 文件本地路径
+              <input name="env_file" placeholder="/Users/.../.env" autocomplete="off" />
+            </label>
+
+            <div class="group wide remote-fields">
+              <div class="group-title">GCP VM</div>
+              <label>
+                Host
+                <input name="remote_host" placeholder="34.x.x.x 或 vm alias" autocomplete="off" />
+              </label>
+              <label>
+                User
+                <input name="remote_user" placeholder="留空使用 ssh 默认用户" autocomplete="off" />
+              </label>
+              <label>
+                Port
+                <input name="remote_port" type="number" min="1" max="65535" value="22" />
+              </label>
+              <label>
+                SSH key
+                <input name="remote_ssh_key" placeholder="~/.ssh/google_compute_engine" autocomplete="off" />
+              </label>
+              <label class="wide">
+                远端 BenchFlow root
+                <input name="remote_benchflow_root" autocomplete="off" />
+              </label>
+              <label class="wide">
+                远端 tasks dir
+                <input name="remote_tasks_dir" autocomplete="off" />
+              </label>
+              <label class="wide">
+                远端 jobs root
+                <input name="remote_jobs_root" autocomplete="off" />
+              </label>
+            </div>
+
+            <div class="group wide local-fields">
+              <div class="group-title">Local</div>
+              <label class="wide">
+                本地 BenchFlow root
+                <input name="benchflow_root" autocomplete="off" />
+              </label>
+              <label class="wide">
+                本地 tasks dir
+                <input name="tasks_dir" autocomplete="off" />
+              </label>
+              <label class="wide">
+                本地 jobs root
+                <input name="jobs_root" autocomplete="off" />
+              </label>
+            </div>
+
+            <label>
+              Skills mode
+              <select name="skills_mode">
+                <option value="default">default</option>
+                <option value="self-gen">self-gen</option>
+              </select>
+            </label>
+            <label>
+              Skills dir
+              <input name="skills_dir" autocomplete="off" />
+            </label>
+            <label class="wide">
+              Include tasks
+              <textarea name="include_tasks" rows="3" spellcheck="false"></textarea>
+            </label>
+            <label class="wide">
+              Exclude tasks
+              <textarea name="exclude_tasks" rows="2" spellcheck="false"></textarea>
+            </label>
+            <label class="wide">
+              Extra args
+              <input name="extra_args" placeholder="--agent-idle-timeout 600" autocomplete="off" />
+            </label>
+          </form>
+          <div id="formMessage" class="message"></div>
+        </section>
+
+        <section class="panel task-index">
+          <div class="panel-head">
+            <h2>任务索引</h2>
+            <button id="loadTasks" type="button">读取</button>
+          </div>
+          <div id="taskIndex" class="task-index-list empty">尚未读取本地 tasks dir</div>
+        </section>
+
+        <section class="panel runs-panel">
+          <div class="panel-head">
+            <h2>Runs</h2>
+            <span id="runCount">0</span>
+          </div>
+          <div id="runsList" class="runs-list empty">暂无运行记录</div>
+        </section>
+      </aside>
+
+      <section class="workspace">
+        <section class="panel monitor-panel">
+          <div class="panel-head">
+            <div>
+              <h2 id="activeRunTitle">未选择 run</h2>
+              <p id="activeRunMeta">启动一个实验后会自动显示最新 run</p>
+            </div>
+            <button id="stopRun" type="button" disabled>停止</button>
+          </div>
+          <div id="summaryStrip" class="summary-strip"></div>
+        </section>
+
+        <section class="panel table-panel">
+          <div class="panel-head">
+            <h2>Tasks</h2>
+            <div class="table-tools">
+              <select id="statusFilter">
+                <option value="">全部状态</option>
+                <option value="running">running</option>
+                <option value="error">error</option>
+                <option value="fail">fail</option>
+                <option value="pending">pending</option>
+                <option value="pass">pass</option>
+              </select>
+              <input id="taskFilter" placeholder="过滤 task" autocomplete="off" />
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Status</th>
+                  <th>Task</th>
+                  <th>Trial</th>
+                  <th>Reward</th>
+                  <th>Duration</th>
+                  <th>Updated</th>
+                  <th>Artifacts</th>
+                </tr>
+              </thead>
+              <tbody id="tasksBody">
+                <tr><td colspan="7" class="empty-cell">暂无 task 结果</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="lower-grid">
+          <section class="panel log-panel">
+            <div class="panel-head">
+              <h2>Log</h2>
+              <span id="logHint"></span>
+            </div>
+            <pre id="logOutput">暂无日志</pre>
+          </section>
+          <section class="panel artifact-panel">
+            <div class="panel-head">
+              <h2>Artifact</h2>
+              <span id="artifactPath"></span>
+            </div>
+            <pre id="artifactOutput">选择 result.json 或 config.json</pre>
+          </section>
+        </section>
+      </section>
+    </main>
+
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/current-projects/benchflow-experiment-control/app/static/styles.css
+++ b/current-projects/benchflow-experiment-control/app/static/styles.css
@@ -1,0 +1,513 @@
+:root {
+  --bg: #f6f5f1;
+  --panel: #ffffff;
+  --panel-2: #faf9f5;
+  --ink: #252523;
+  --muted: #6c6a64;
+  --line: #dedbd1;
+  --line-strong: #c6c0b1;
+  --accent: #0f766e;
+  --accent-ink: #ffffff;
+  --warn: #b45309;
+  --bad: #b42318;
+  --good: #16803c;
+  --blue: #2f5f8f;
+  --shadow: 0 10px 30px rgba(52, 49, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  letter-spacing: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  min-height: 34px;
+  padding: 0 12px;
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+button:disabled {
+  color: #aaa49a;
+  cursor: not-allowed;
+}
+
+#startRun,
+#refreshState {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+#stopRun:not(:disabled) {
+  background: #fff5f3;
+  border-color: #e3a29a;
+  color: var(--bad);
+}
+
+.topbar {
+  height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(246, 245, 241, 0.92);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 22px;
+  line-height: 1.2;
+  font-weight: 730;
+}
+
+h2 {
+  font-size: 14px;
+  line-height: 1.3;
+  font-weight: 720;
+}
+
+.topbar p,
+.panel-head p,
+.top-actions,
+#lastUpdated {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  white-space: nowrap;
+}
+
+.shell {
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+  gap: 14px;
+  padding: 14px;
+  max-width: 1720px;
+  margin: 0 auto;
+}
+
+.sidebar,
+.workspace {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.panel-head {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding: 14px;
+}
+
+label {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 620;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  min-height: 34px;
+  padding: 7px 9px;
+  outline: none;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 62px;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.12);
+}
+
+.wide,
+.group {
+  grid-column: 1 / -1;
+}
+
+.group {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding: 10px;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.group-title {
+  grid-column: 1 / -1;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.local-fields[data-hidden="true"],
+.remote-fields[data-hidden="true"] {
+  display: none;
+}
+
+.message {
+  min-height: 34px;
+  padding: 0 14px 14px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.message.error {
+  color: var(--bad);
+}
+
+.message.ok {
+  color: var(--good);
+}
+
+.task-index-list,
+.runs-list {
+  max-height: 260px;
+  overflow: auto;
+  padding: 10px;
+}
+
+.task-index-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.task-chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 8px;
+  background: var(--panel-2);
+  color: var(--ink);
+  font-size: 12px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.empty,
+.empty-cell {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.runs-list {
+  display: grid;
+  gap: 8px;
+}
+
+.run-item {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  text-align: left;
+  min-height: 66px;
+  padding: 9px;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.run-item.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+}
+
+.run-title {
+  font-size: 13px;
+  font-weight: 720;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.run-meta,
+.run-command {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-pill {
+  align-self: start;
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 760;
+  background: #ebe8df;
+  color: var(--muted);
+}
+
+.status-running {
+  background: #e8f6f4;
+  color: var(--accent);
+}
+
+.status-pass,
+.status-completed {
+  background: #edf8ef;
+  color: var(--good);
+}
+
+.status-fail,
+.status-failed,
+.status-error {
+  background: #fff0ed;
+  color: var(--bad);
+}
+
+.status-pending,
+.status-stopped {
+  background: #fff7e8;
+  color: var(--warn);
+}
+
+.summary-strip {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(86px, 1fr));
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.metric {
+  min-height: 58px;
+  padding: 9px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-2);
+}
+
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 640;
+}
+
+.metric strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 20px;
+  line-height: 1.1;
+}
+
+.table-tools {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.table-tools select,
+.table-tools input {
+  min-height: 32px;
+}
+
+.table-tools input {
+  max-width: 220px;
+}
+
+.table-wrap {
+  overflow: auto;
+  max-height: calc(100vh - 390px);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+th,
+td {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 1;
+  color: var(--muted);
+  font-weight: 750;
+}
+
+td.task-name {
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 650;
+}
+
+td.trial-name {
+  max-width: 230px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+}
+
+.artifact-buttons {
+  display: flex;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
+.artifact-buttons button {
+  min-height: 28px;
+  padding: 0 8px;
+  font-size: 11px;
+}
+
+.lower-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.78fr);
+  gap: 14px;
+}
+
+pre {
+  margin: 0;
+  padding: 12px;
+  min-height: 260px;
+  max-height: 360px;
+  overflow: auto;
+  background: #1f211f;
+  color: #f6f3ea;
+  border-radius: 0 0 8px 8px;
+  font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+#artifactPath,
+#logHint {
+  color: var(--muted);
+  font-size: 11px;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 1180px) {
+  .shell,
+  .lower-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-strip {
+    grid-template-columns: repeat(4, minmax(86px, 1fr));
+  }
+
+  .table-wrap {
+    max-height: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    align-items: flex-start;
+    height: auto;
+    flex-direction: column;
+  }
+
+  .shell {
+    padding: 10px;
+  }
+
+  .form-grid,
+  .group,
+  .summary-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .table-tools {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/current-projects/benchflow-experiment-control/app/store.py
+++ b/current-projects/benchflow-experiment-control/app/store.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .models import DEFAULT_DATA_DIR, RunRecord
+
+
+class StateStore:
+    def __init__(self, data_dir: str | Path = DEFAULT_DATA_DIR):
+        self.data_dir = Path(data_dir)
+        self.path = self.data_dir / "state.json"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+    def load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"runs": []}
+        try:
+            data = json.loads(self.path.read_text())
+        except json.JSONDecodeError:
+            return {"runs": []}
+        runs = data.get("runs")
+        return {"runs": runs if isinstance(runs, list) else []}
+
+    def save(self, state: dict[str, Any]) -> None:
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state, indent=2))
+        tmp.replace(self.path)
+
+    def list_runs(self) -> list[RunRecord]:
+        return [RunRecord.from_dict(item) for item in self.load()["runs"]]
+
+    def get_run(self, run_id: str) -> RunRecord | None:
+        for run in self.list_runs():
+            if run.id == run_id:
+                return run
+        return None
+
+    def upsert_run(self, run: RunRecord) -> None:
+        state = self.load()
+        runs = state["runs"]
+        payload = run.to_dict()
+        for index, item in enumerate(runs):
+            if item.get("id") == run.id:
+                runs[index] = payload
+                self.save(state)
+                return
+        runs.append(payload)
+        self.save(state)
+
+    def update_run(self, run_id: str, **changes: Any) -> RunRecord | None:
+        run = self.get_run(run_id)
+        if run is None:
+            return None
+        for key, value in changes.items():
+            if hasattr(run, key):
+                setattr(run, key, value)
+        self.upsert_run(run)
+        return run
+

--- a/current-projects/benchflow-experiment-control/tests/test_jobs.py
+++ b/current-projects/benchflow-experiment-control/tests/test_jobs.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.jobs import discover_tasks, scan_run
+from app.models import ExperimentConfig, RunRecord
+
+
+class JobsScanTest(unittest.TestCase):
+    def test_discover_tasks_reads_task_toml_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "alpha").mkdir()
+            (root / "alpha" / "task.toml").write_text("name = 'alpha'\n")
+            (root / "notes").mkdir()
+
+            self.assertEqual(discover_tasks(str(root)), ["alpha"])
+
+    def test_scan_run_summarizes_local_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            trial = root / "alpha__001"
+            trial.mkdir()
+            (trial / "config.json").write_text(json.dumps({"agent": "gemini", "model": "m"}))
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rewards": {"reward": 1.0},
+                        "timing": {"total": 12.5},
+                    }
+                )
+            )
+            run = RunRecord(
+                id="test-run",
+                status="completed",
+                config=ExperimentConfig(name="test", run_target="local"),
+                jobs_dir=str(root),
+                log_path=str(root / "run.log"),
+                command=[],
+            )
+
+            payload = scan_run(run)
+
+            self.assertEqual(payload["summary"]["total"], 1)
+            self.assertEqual(payload["summary"]["passed"], 1)
+            self.assertEqual(payload["summary"]["mean_reward"], 1.0)
+            self.assertEqual(payload["tasks"][0]["status"], "pass")
+            self.assertEqual(payload["tasks"][0]["duration_sec"], 12.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an independent BenchFlow experiment control webapp under current-projects
- Default execution path runs BenchFlow tasks on a remote GCP VM over SSH with Docker sandbox
- Add README, Makefile, and focused tests for task discovery/result scanning

## Test
- make test