### PR TITLE
Use English copy in BenchFlow experiment control

### DIFF
--- a/current-projects/benchflow-experiment-control/README.md
+++ b/current-projects/benchflow-experiment-control/README.md
@@ -1,14 +1,22 @@
 # BenchFlow Experiment Control
 
-一个独立的 BenchFlow 实验控制台。它默认通过 SSH 在 GCP VM 上启动 `bench eval create`，在 VM 里使用 Docker sandbox 跑 tasks，然后从远端 jobs 目录读取 task 状态、日志和 `result.json` / `config.json`。
+BenchFlow Experiment Control is a local experiment console for launching and
+monitoring BenchFlow batch runs. By default it connects to a GCP VM over SSH,
+runs `bench eval create` with Docker sandboxing on the VM, then reads task
+status, logs, and BenchFlow artifacts from the run output.
 
-这个项目只管理实验启动和监控，不修改 BenchFlow 主 repo，也不修改 SkillsBench task repo。
+This project only manages experiment launch and monitoring. It does not modify
+the BenchFlow repository or the SkillsBench task repository.
 
-架构上它是 **CLI-first**：
+The architecture is CLI-first:
 
-- `python3 -m app.cli ...` 是实验启动、停止、状态刷新、artifact 读取的 canonical 管理层。
-- `python3 -m app.server` 只提供一个 local-only dashboard，调用同一套 manager 逻辑。
-- Web UI 不直接拼 BenchFlow 命令；它提交配置给 manager，manager 负责生成 task selection、远端命令、状态文件和 artifact 读取。
+- `python3 -m app.cli ...` is the canonical management layer for starting,
+  stopping, refreshing, and reading run artifacts.
+- `python3 -m app.server` serves a local-only dashboard that calls the same
+  manager logic.
+- The web UI does not build BenchFlow commands directly. It submits config to
+  the manager, which owns task selection, remote commands, state files, and
+  artifact reads.
 
 ## Quick Start
 
@@ -18,19 +26,19 @@ cd bingran-you/current-projects/benchflow-experiment-control
 make run
 ```
 
-然后打开：
+Open:
 
 ```text
 http://127.0.0.1:8765
 ```
 
-也可以换端口：
+Use a different port:
 
 ```bash
 make run PORT=9000
 ```
 
-CLI 也可以直接用：
+Use the CLI directly:
 
 ```bash
 python3 -m app.cli defaults --pretty
@@ -41,30 +49,36 @@ python3 -m app.cli stop <run-id> --pretty
 
 ## Requirements
 
-本机：
+Local machine:
 
-- Python 3.11+。
-- 可以 SSH 到目标 GCP VM。
-- 一个本地 `.env` 文件，里面放模型 provider 的 key。启动 run 时会上传到远端 run 目录下的 `.env`，不会写入 `data/state.json`。
-- 本地实验结果根目录，默认是 `/Users/bingran_you/Downloads/GitHub/bingran-you/workspace/experiment`。
+- Python 3.11+.
+- SSH access to the target GCP VM.
+- A local `.env` file with model provider keys. The file is uploaded to the
+  remote run directory when a run starts, but key contents are not written to
+  `data/state.json`.
+- A local experiment archive root. The default is
+  `/Users/bingran_you/Downloads/GitHub/bingran-you/workspace/experiment`.
 
-GCP VM：
+GCP VM:
 
-- BenchFlow repo 已经 clone 到 VM 上。
-- `uv run bench eval create --help` 可以在远端 BenchFlow root 里正常执行。
-- Docker 已安装并可用，因为默认 harness 是 `docker`。
-- tasks 目录已经在 VM 上，例如 SkillsBench tasks。
+- The BenchFlow repository is cloned on the VM.
+- `uv run bench eval create --help` works from the remote BenchFlow root.
+- Docker is installed and usable because the default harness is `docker`.
+- The task directory exists on the VM, for example the SkillsBench `tasks`
+  directory.
 
 ## Dashboard Flow
 
-1. 启动本地 webapp。
-2. 填写 GCP VM 的 SSH host、user、port 和 key。
-3. 填写本地结果 root、远端 BenchFlow root、远端 tasks dir、远端 jobs root。
-4. 选择 agent、model、harness、concurrency、skills label。
-5. 可选填写 include/exclude tasks，支持逗号或换行分隔。
-6. 点击“启动”，右侧会显示 run、task 状态、远端日志和 artifacts。
+1. Start the local webapp.
+2. Fill in the GCP VM SSH host, user, port, and key.
+3. Fill in the local results root, remote BenchFlow root, remote tasks
+   directory, and remote jobs root.
+4. Choose agent, model, harness, concurrency, and skills label.
+5. Optionally set include/exclude task lists. Commas and newlines are accepted.
+6. Click "Start". The right side shows run status, task status, remote logs,
+   and artifacts.
 
-默认生成的远端命令形态是：
+The generated remote command has this shape:
 
 ```bash
 cd <remote_benchflow_root>
@@ -77,11 +91,15 @@ uv run bench eval create \
   --jobs-dir <remote_jobs_dir>
 ```
 
-注意：当前 BenchFlow CLI 没有 `--include/--exclude`。本项目会在 run 目录里生成 `.benchflow-selected-tasks/`，用 symlink 指向被选择的 task，然后把这个目录作为 `--tasks-dir` 传给 BenchFlow。这样 CLI 和 dashboard 的 include/exclude 行为一致，而且不需要修改 BenchFlow 主 repo。
+BenchFlow currently does not expose `--include` or `--exclude` flags for this
+batch path. This project creates a `.benchflow-selected-tasks/` directory inside
+the run directory, symlinks only the selected tasks into it, and passes that
+directory as `--tasks-dir`. CLI and dashboard task selection therefore share the
+same behavior without requiring changes to the BenchFlow repo.
 
 ## Remote Execution
 
-默认运行目标是 `gcp_ssh`，并预填当前实验 VM：
+The default target is `gcp_ssh`, prefilled for the current experiment VM:
 
 - Host: `34.58.166.203`
 - SSH user: `bingran_you`
@@ -89,50 +107,60 @@ uv run bench eval create \
 - BenchFlow root: `/opt/benchflow/benchflow`
 - Tasks dir: `/opt/benchflow/skillsbench/tasks`
 - Jobs root: `/mnt/benchflow/jobs/experiment-control`
-- Local results root: `/Users/bingran_you/Downloads/GitHub/bingran-you/workspace/experiment`
+- Local results root:
+  `/Users/bingran_you/Downloads/GitHub/bingran-you/workspace/experiment`
 
-远端执行形态是：
+Remote execution shape:
 
 ```bash
 ssh <user>@<host> 'cd <remote_benchflow_root> && uv run bench eval create ... --sandbox docker'
 ```
 
-SSH user 负责连接 VM；Run user 负责实际执行 `uv run bench eval create` 和读取 artifacts。默认 VM 上 `benchflow` 用户在 `docker` group 里，因此可以本地启动 Docker sandbox。
+The SSH user connects to the VM. The run user executes `uv run bench eval
+create` and reads artifacts. On the default VM, the `benchflow` user is in the
+`docker` group, so it can launch Docker sandboxes locally.
 
-如果你换成自己的 VM，需要确保 SSH user 可以免密码执行：
+For another VM, make sure the SSH user can run this without an interactive
+password prompt:
 
 ```bash
 sudo -n -u <run-user> bash -lc 'docker ps >/dev/null'
 ```
 
-关键路径：
+Key paths:
 
-- `env_file`: 本机 `.env` 路径。启动 run 时会上传到远端 run 目录下的 `.env`，远端权限使用 `umask 077`。
-- `jobs_root`: 本机保存完整 BenchFlow artifacts 的根目录。
-- `remote_run_user`: 远端实际执行 BenchFlow/Docker 的 Linux 用户；留空则直接使用 SSH 登录用户。
-- `remote_benchflow_root`: 远端 VM 上 BenchFlow repo 的 `benchflow` 目录。
-- `remote_tasks_dir`: 远端 VM 上的 task 目录，传给 `--tasks-dir`。
-- `remote_jobs_root`: 远端保存 run 输出的根目录。
+- `env_file`: local `.env` path. It is uploaded to the remote run directory
+  with `umask 077`.
+- `jobs_root`: local root for complete BenchFlow artifact archives.
+- `remote_run_user`: Linux user that actually runs BenchFlow and Docker on the
+  VM. Leave it empty to use the SSH login user directly.
+- `remote_benchflow_root`: remote BenchFlow repository root.
+- `remote_tasks_dir`: remote task directory passed to `--tasks-dir`.
+- `remote_jobs_root`: remote root for run output.
 
-远端路径可以写绝对路径，也可以写相对 SSH 登录 home 的路径；默认值使用相对路径，避免 shell 引号影响 `~` 展开。
+Remote paths may be absolute or relative to the SSH login home.
 
 ## Config Fields
 
-- `Key / env 文件本地路径`: 本机 `.env` 文件路径，里面的 key 会被上传到远端 run 目录。
-- `本地结果 root`: 完整 run artifacts 的本地 archive 根目录。
-- `Agent`: 传给 `--agent`。
-- `Model`: 传给 `--model`；如果 agent 是 `oracle`，后端不会传 model。
-- `Harness`: 传给 `--sandbox`，默认是 `docker`。
-- `Include tasks`: 选择要运行的 task；manager 会生成 `.benchflow-selected-tasks/` 后传给 `--tasks-dir`。
-- `Exclude tasks`: 从选择集中排除 task；不会传不存在的 BenchFlow `--exclude` 参数。
-- `Skills label`: 本地/远端 archive 分组标签，例如 `with-skills` 或 `without-skills`。
-- `Skills dir`: 传给 `--skills-dir`。
-- `Skills mode`: 非 `default` 时传给 `--skill-mode`。
-- `Extra args`: 追加到 `bench eval create` 的最后。
+- `Key / env file path`: local `.env` file path. The key file is uploaded to
+  the remote run directory.
+- `Local results root`: local archive root for complete run artifacts.
+- `Agent`: passed to `--agent`.
+- `Model`: passed to `--model`; omitted when the agent is `oracle`.
+- `Harness`: passed to `--sandbox`; the default is `docker`.
+- `Include tasks`: selected tasks. The manager creates
+  `.benchflow-selected-tasks/` and passes it to `--tasks-dir`.
+- `Exclude tasks`: tasks removed from the selected set. This does not pass a
+  non-existent BenchFlow `--exclude` flag.
+- `Skills label`: local and remote archive grouping label, for example
+  `with-skills` or `without-skills`.
+- `Skills dir`: passed to `--skills-dir`.
+- `Skills mode`: passed to `--skill-mode` when not `default`.
+- `Extra args`: appended to the `bench eval create` command.
 
 ## Result Archive Layout
 
-所有完整结果都会同步到本机 `jobs_root` 下，默认结构是：
+Complete results sync to the local `jobs_root`. The default layout is:
 
 ```text
 /Users/bingran_you/Downloads/GitHub/bingran-you/workspace/experiment/
@@ -154,7 +182,9 @@ sudo -n -u <run-user> bash -lc 'docker ps >/dev/null'
                 trainer/
 ```
 
-远端 VM 上也使用同样的 `skills-label/agent/model/run-name/run-id` 分层。远端 run 结束后，CLI/dashboard 会把 BenchFlow 生成的 artifacts 同步回本机 archive；`.env` 会被排除，不进入本地结果包。
+The VM uses the same `skills-label/agent/model/run-name/run-id` grouping. When
+the remote run exits, the CLI/dashboard syncs BenchFlow-generated artifacts back
+to the local archive. `.env` is excluded from the synced artifact tree.
 
 ## CLI Commands
 
@@ -168,7 +198,8 @@ python3 -m app.cli artifact <run-id> --path '2026-.../task__id/result.json' --pr
 python3 -m app.cli stop <run-id> --pretty
 ```
 
-`start` 接受 JSON config。可以用 `--set key=value` 临时覆盖顶层字段：
+`start` accepts a JSON config. Use `--set key=value` to override top-level
+fields:
 
 ```bash
 python3 -m app.cli start \
@@ -179,29 +210,32 @@ python3 -m app.cli start \
 
 ## Local State
 
-本 webapp 写两类本地路径：
+The webapp writes two kinds of local paths:
 
-- `data/state.json`: run 元数据和命令记录。只保存 `.env` 文件路径，不保存 key 内容。
-- `data/logs/`: 本地 run 日志；远端 run 的真实日志在 GCP VM 的 jobs 目录。
-- `jobs_root`: 完整 BenchFlow artifacts archive，默认在 `workspace/experiment`。
+- `data/state.json`: run metadata and command records. It stores the `.env`
+  file path, not key contents.
+- `data/logs/`: local run logs. Remote run logs live in the GCP VM jobs
+  directory.
+- `jobs_root`: complete BenchFlow artifact archive, defaulting to
+  `workspace/experiment`.
 
-它不会修改 BenchFlow 主 repo 或 SkillsBench task repo。
+It does not modify the BenchFlow repository or the SkillsBench task repository.
 
 ## Troubleshooting
 
-先用同一组 SSH 配置验证 VM：
+Verify VM access with the same SSH config:
 
 ```bash
 ssh -i <key> -p <port> <user>@<host> 'cd <remote_benchflow_root> && uv run bench eval create --help'
 ```
 
-如果启动失败，优先检查：
+If launch fails, check:
 
-- VM 上的 BenchFlow root 是否正确。
-- VM 上的 tasks dir 是否正确。
-- Docker daemon 是否可用。
-- 本地 `.env` 是否存在且 key 名称符合当前 agent 需要。
-- SSH key 是否能在 BatchMode 下免交互登录。
+- The remote BenchFlow root is correct.
+- The remote tasks directory is correct.
+- Docker daemon access works for the run user.
+- The local `.env` exists and uses key names expected by the selected agent.
+- The SSH key works in BatchMode without interactive prompts.
 
 ## Tests
 

--- a/current-projects/benchflow-experiment-control/app/static/app.js
+++ b/current-projects/benchflow-experiment-control/app/static/app.js
@@ -110,7 +110,7 @@ async function loadState({ silent = false } = {}) {
       state.selectedRunId = state.runs[0]?.run.id || null;
     }
     render();
-    $("#lastUpdated").textContent = `同步于 ${new Date().toLocaleTimeString()}`;
+    $("#lastUpdated").textContent = `Synced at ${new Date().toLocaleTimeString()}`;
     if (!silent) setMessage("");
   } catch (error) {
     if (!silent) setMessage(error.message, "error");
@@ -121,14 +121,14 @@ async function loadState({ silent = false } = {}) {
 
 async function startRun(event) {
   event.preventDefault();
-  setMessage("正在启动...");
+  setMessage("Starting...");
   try {
     const payload = await api("/api/runs", {
       method: "POST",
       body: JSON.stringify(formPayload()),
     });
     state.selectedRunId = payload.run.run.id;
-    setMessage(`已启动 ${payload.run.run.id}`, "ok");
+    setMessage(`Started ${payload.run.run.id}`, "ok");
     await loadState({ silent: true });
   } catch (error) {
     setMessage(error.message, "error");
@@ -138,10 +138,10 @@ async function startRun(event) {
 async function stopActiveRun() {
   const run = activeRun();
   if (!run) return;
-  setMessage(`正在停止 ${run.run.id}...`);
+  setMessage(`Stopping ${run.run.id}...`);
   try {
     await api(`/api/runs/${encodeURIComponent(run.run.id)}/stop`, { method: "POST" });
-    setMessage(`已停止 ${run.run.id}`, "ok");
+    setMessage(`Stopped ${run.run.id}`, "ok");
     await loadState({ silent: true });
   } catch (error) {
     setMessage(error.message, "error");
@@ -173,7 +173,7 @@ function renderRuns() {
   const list = $("#runsList");
   if (!state.runs.length) {
     list.className = "runs-list empty";
-    list.textContent = "暂无运行记录";
+    list.textContent = "No runs yet";
     return;
   }
   list.className = "runs-list";
@@ -204,13 +204,13 @@ function renderRuns() {
 function renderActiveRun() {
   const item = activeRun();
   if (!item) {
-    $("#activeRunTitle").textContent = "未选择 run";
-    $("#activeRunMeta").textContent = "启动一个实验后会自动显示最新 run";
+    $("#activeRunTitle").textContent = "No run selected";
+    $("#activeRunMeta").textContent = "Start an experiment to show the latest run";
     $("#stopRun").disabled = true;
     $("#summaryStrip").innerHTML = "";
-    $("#tasksBody").innerHTML = '<tr><td colspan="7" class="empty-cell">暂无 task 结果</td></tr>';
-    $("#logOutput").textContent = "暂无日志";
-    $("#artifactOutput").textContent = "选择 result.json 或 config.json";
+    $("#tasksBody").innerHTML = '<tr><td colspan="7" class="empty-cell">No task results yet</td></tr>';
+    $("#logOutput").textContent = "No logs yet";
+    $("#artifactOutput").textContent = "Select result.json or config.json";
     $("#artifactPath").textContent = "";
     return;
   }
@@ -222,7 +222,7 @@ function renderActiveRun() {
   $("#activeRunMeta").textContent = `${run.id} · ${run.config.run_target} · ${run.jobs_dir}${syncText}`;
   $("#stopRun").disabled = run.status !== "running";
   $("#summaryStrip").innerHTML = metricHtml(summary);
-  $("#logOutput").textContent = item.log_tail || "暂无日志";
+  $("#logOutput").textContent = item.log_tail || "No logs yet";
   $("#logHint").textContent = run.remote_log_path || run.log_path || "";
   renderTasks(item.tasks || []);
 }
@@ -253,7 +253,7 @@ function renderTasks(tasks) {
   });
 
   if (!filtered.length) {
-    body.innerHTML = '<tr><td colspan="7" class="empty-cell">暂无匹配 task</td></tr>';
+    body.innerHTML = '<tr><td colspan="7" class="empty-cell">No matching tasks</td></tr>';
     return;
   }
 
@@ -291,7 +291,7 @@ async function viewArtifact(path) {
   const run = activeRun();
   if (!run || !path) return;
   $("#artifactPath").textContent = path;
-  $("#artifactOutput").textContent = "读取中...";
+  $("#artifactOutput").textContent = "Loading...";
   try {
     const payload = await api(
       `/api/runs/${encodeURIComponent(run.run.id)}/artifact?path=${encodeURIComponent(path)}`,
@@ -299,7 +299,7 @@ async function viewArtifact(path) {
     if (payload.error) {
       $("#artifactOutput").textContent = payload.error;
     } else if (payload.too_large) {
-      $("#artifactOutput").textContent = "文件超过 2 MB，未加载";
+      $("#artifactOutput").textContent = "File is larger than 2 MB and was not loaded";
     } else {
       $("#artifactOutput").textContent = payload.content || "";
     }
@@ -312,7 +312,7 @@ function renderTaskIndex(tasks) {
   const box = $("#taskIndex");
   if (!tasks.length) {
     box.className = "task-index-list empty";
-    box.textContent = "没有读取到 task.toml";
+    box.textContent = "No task.toml files found";
     return;
   }
   box.className = "task-index-list";

--- a/current-projects/benchflow-experiment-control/app/static/index.html
+++ b/current-projects/benchflow-experiment-control/app/static/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -13,8 +13,8 @@
         <p id="connectionLine">GCP SSH · Docker · BenchFlow tasks</p>
       </div>
       <div class="top-actions">
-        <span id="lastUpdated">未同步</span>
-        <button id="refreshState" type="button">刷新</button>
+        <span id="lastUpdated">Not synced</span>
+        <button id="refreshState" type="button">Refresh</button>
       </div>
     </header>
 
@@ -22,16 +22,16 @@
       <aside class="sidebar">
         <section class="panel launch-panel">
           <div class="panel-head">
-            <h2>启动实验</h2>
-            <button id="startRun" form="runForm" type="submit">启动</button>
+            <h2>Launch Experiment</h2>
+            <button id="startRun" form="runForm" type="submit">Start</button>
           </div>
           <form id="runForm" class="form-grid">
             <label>
-              名称
+              Name
               <input name="name" value="skillsbench-batch" autocomplete="off" />
             </label>
             <label>
-              运行位置
+              Run target
               <select name="run_target" id="runTarget">
                 <option value="gcp_ssh">GCP VM via SSH</option>
                 <option value="local">Local</option>
@@ -56,15 +56,15 @@
               </select>
             </label>
             <label>
-              并发
+              Concurrency
               <input name="concurrency" type="number" min="1" max="256" value="4" />
             </label>
             <label class="wide">
-              Key / env 文件本地路径
+              Key / env file path
               <input name="env_file" placeholder="/Users/.../.env" autocomplete="off" />
             </label>
             <label class="wide">
-              本地结果 root
+              Local results root
               <input name="jobs_root" placeholder="/Users/.../workspace/experiment" autocomplete="off" />
             </label>
 
@@ -72,11 +72,11 @@
               <div class="group-title">GCP VM</div>
               <label>
                 Host
-                <input name="remote_host" placeholder="34.x.x.x 或 vm alias" autocomplete="off" />
+                <input name="remote_host" placeholder="34.x.x.x or VM alias" autocomplete="off" />
               </label>
               <label>
                 User
-                <input name="remote_user" placeholder="留空使用 ssh 默认用户" autocomplete="off" />
+                <input name="remote_user" placeholder="Leave empty for the default SSH user" autocomplete="off" />
               </label>
               <label>
                 Run user
@@ -91,15 +91,15 @@
                 <input name="remote_ssh_key" placeholder="~/.ssh/google_compute_engine" autocomplete="off" />
               </label>
               <label class="wide">
-                远端 BenchFlow root
+                Remote BenchFlow root
                 <input name="remote_benchflow_root" autocomplete="off" />
               </label>
               <label class="wide">
-                远端 tasks dir
+                Remote tasks dir
                 <input name="remote_tasks_dir" autocomplete="off" />
               </label>
               <label class="wide">
-                远端 jobs root
+                Remote jobs root
                 <input name="remote_jobs_root" autocomplete="off" />
               </label>
             </div>
@@ -107,11 +107,11 @@
             <div class="group wide local-fields">
               <div class="group-title">Local</div>
               <label class="wide">
-                本地 BenchFlow root
+                Local BenchFlow root
                 <input name="benchflow_root" autocomplete="off" />
               </label>
               <label class="wide">
-                本地 tasks dir
+                Local tasks dir
                 <input name="tasks_dir" autocomplete="off" />
               </label>
             </div>
@@ -153,10 +153,10 @@
 
         <section class="panel task-index">
           <div class="panel-head">
-            <h2>任务索引</h2>
-            <button id="loadTasks" type="button">读取</button>
+            <h2>Task Index</h2>
+            <button id="loadTasks" type="button">Load</button>
           </div>
-          <div id="taskIndex" class="task-index-list empty">尚未读取本地 tasks dir</div>
+          <div id="taskIndex" class="task-index-list empty">No local tasks directory loaded</div>
         </section>
 
         <section class="panel runs-panel">
@@ -164,7 +164,7 @@
             <h2>Runs</h2>
             <span id="runCount">0</span>
           </div>
-          <div id="runsList" class="runs-list empty">暂无运行记录</div>
+          <div id="runsList" class="runs-list empty">No runs yet</div>
         </section>
       </aside>
 
@@ -172,10 +172,10 @@
         <section class="panel monitor-panel">
           <div class="panel-head">
             <div>
-              <h2 id="activeRunTitle">未选择 run</h2>
-              <p id="activeRunMeta">启动一个实验后会自动显示最新 run</p>
+              <h2 id="activeRunTitle">No run selected</h2>
+              <p id="activeRunMeta">Start an experiment to show the latest run</p>
             </div>
-            <button id="stopRun" type="button" disabled>停止</button>
+            <button id="stopRun" type="button" disabled>Stop</button>
           </div>
           <div id="summaryStrip" class="summary-strip"></div>
         </section>
@@ -185,14 +185,14 @@
             <h2>Tasks</h2>
             <div class="table-tools">
               <select id="statusFilter">
-                <option value="">全部状态</option>
+                <option value="">All statuses</option>
                 <option value="running">running</option>
                 <option value="error">error</option>
                 <option value="fail">fail</option>
                 <option value="pending">pending</option>
                 <option value="pass">pass</option>
               </select>
-              <input id="taskFilter" placeholder="过滤 task" autocomplete="off" />
+              <input id="taskFilter" placeholder="Filter task" autocomplete="off" />
             </div>
           </div>
           <div class="table-wrap">
@@ -209,7 +209,7 @@
                 </tr>
               </thead>
               <tbody id="tasksBody">
-                <tr><td colspan="7" class="empty-cell">暂无 task 结果</td></tr>
+                <tr><td colspan="7" class="empty-cell">No task results yet</td></tr>
               </tbody>
             </table>
           </div>
@@ -221,14 +221,14 @@
               <h2>Log</h2>
               <span id="logHint"></span>
             </div>
-            <pre id="logOutput">暂无日志</pre>
+            <pre id="logOutput">No logs yet</pre>
           </section>
           <section class="panel artifact-panel">
             <div class="panel-head">
               <h2>Artifact</h2>
               <span id="artifactPath"></span>
             </div>
-            <pre id="artifactOutput">选择 result.json 或 config.json</pre>
+            <pre id="artifactOutput">Select result.json or config.json</pre>
           </section>
         </section>
       </section>


### PR DESCRIPTION
## Summary
- translate the BenchFlow experiment control dashboard copy to English
- translate dashboard status messages and empty states to English
- rewrite the project README in English to match the CLI/dashboard language

## Validation
- make test
- rg for CJK characters in current-projects/benchflow-experiment-control
- restarted http://127.0.0.1:8765 and confirmed the served HTML has no CJK text