### PR TITLE
Fix remote experiment launch detachment

### DIFF
--- a/current-projects/benchflow-experiment-control/app/remote.py
+++ b/current-projects/benchflow-experiment-control/app/remote.py
@@ -157,16 +157,31 @@ def start_remote_process(
     remote_exit_code_path: str,
 ) -> int:
     quoted_cmd = shlex.join(command)
+    remote_runner_path = f"{remote_jobs_dir.rstrip('/')}/run-remote.sh"
     dotenv_line = f"export BENCHFLOW_DOTENV_PATH={shlex.quote(remote_env_path)};"
     env_line = (
         f"{dotenv_line} set -a; . {shlex.quote(remote_env_path)}; set +a;"
         if config.env_file
         else dotenv_line
     )
+    runner_script = "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            "set +e",
+            f"cd {shlex.quote(config.remote_benchflow_root)}",
+            f"{env_line} {quoted_cmd}",
+            "status=$?",
+            f"printf '%s\\n' \"$status\" > {shlex.quote(remote_exit_code_path)}",
+            "exit \"$status\"",
+        ]
+    )
     script = (
         f"mkdir -p {shlex.quote(remote_jobs_dir)} {shlex.quote(str(Path(remote_log_path).parent))}; "
-        f"cd {shlex.quote(config.remote_benchflow_root)} && "
-        f"( {env_line} {quoted_cmd}; echo $? > {shlex.quote(remote_exit_code_path)} ) "
+        f"cat > {shlex.quote(remote_runner_path)} <<'BENCHFLOW_REMOTE_RUN'\n"
+        f"{runner_script}\n"
+        "BENCHFLOW_REMOTE_RUN\n"
+        f"chmod 700 {shlex.quote(remote_runner_path)}; "
+        f"nohup bash {shlex.quote(remote_runner_path)} "
         f"> {shlex.quote(remote_log_path)} 2>&1 < /dev/null & echo $!"
     )
     result = remote_shell(config, script, timeout=30, as_run_user=True)

--- a/current-projects/benchflow-experiment-control/tests/test_jobs.py
+++ b/current-projects/benchflow-experiment-control/tests/test_jobs.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from app import remote
 from app.archive import local_run_dir
 from app.jobs import discover_tasks, scan_run
 from app.models import ExperimentConfig, RunRecord
@@ -154,6 +155,55 @@ class JobsScanTest(unittest.TestCase):
         config = ExperimentConfig.from_dict({"name": "test", "env_file": ""})
 
         self.assertEqual(config.env_file, "")
+
+    def test_remote_start_uses_nohup_runner_for_pid_capture(self) -> None:
+        """Guards this PR's SSH launch fix against hanging before PID capture."""
+        captured: dict[str, object] = {}
+
+        def fake_remote_shell(
+            config: ExperimentConfig,
+            script: str,
+            *,
+            input_text: str | None = None,
+            timeout: int = 30,
+            as_run_user: bool = False,
+        ):
+            captured["script"] = script
+            captured["timeout"] = timeout
+            captured["as_run_user"] = as_run_user
+
+            class Result:
+                returncode = 0
+                stdout = "12345\n"
+                stderr = ""
+
+            return Result()
+
+        original = remote.remote_shell
+        try:
+            remote.remote_shell = fake_remote_shell
+            pid = remote.start_remote_process(
+                ExperimentConfig(
+                    name="test",
+                    run_target="gcp_ssh",
+                    remote_benchflow_root="/opt/benchflow/benchflow",
+                    env_file="/tmp/.env",
+                ),
+                ["uv", "run", "bench", "eval", "create"],
+                remote_jobs_dir="/jobs/run",
+                remote_log_path="/jobs/run/run.log",
+                remote_env_path="/jobs/run/.env",
+                remote_exit_code_path="/jobs/run/exit-code.txt",
+            )
+        finally:
+            remote.remote_shell = original
+
+        script = str(captured["script"])
+        self.assertEqual(pid, 12345)
+        self.assertTrue(captured["as_run_user"])
+        self.assertIn("run-remote.sh", script)
+        self.assertIn("nohup bash /jobs/run/run-remote.sh", script)
+        self.assertIn("printf '%s\\n' \"$status\" > /jobs/run/exit-code.txt", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- write remote experiment commands to a runner script before detaching
- launch the runner with nohup so SSH can return the PID immediately
- keep writing the remote exit code for later sync

## Tests
- python3 -m py_compile app/*.py
- python3 -m unittest discover -s tests