### PR TITLE
Fix remote experiment stop cleanup

### DIFF
--- a/current-projects/benchflow-experiment-control/app/remote.py
+++ b/current-projects/benchflow-experiment-control/app/remote.py
@@ -181,7 +181,7 @@ def start_remote_process(
         f"{runner_script}\n"
         "BENCHFLOW_REMOTE_RUN\n"
         f"chmod 700 {shlex.quote(remote_runner_path)}; "
-        f"nohup bash {shlex.quote(remote_runner_path)} "
+        f"nohup setsid bash {shlex.quote(remote_runner_path)} "
         f"> {shlex.quote(remote_log_path)} 2>&1 < /dev/null & echo $!"
     )
     result = remote_shell(config, script, timeout=30, as_run_user=True)
@@ -203,10 +203,45 @@ def read_remote_exit_code(run: RunRecord) -> int | None:
 
 
 def stop_remote_run(run: RunRecord) -> None:
-    if not run.remote_pid:
+    process_script = ""
+    if run.remote_pid:
+        pid = int(run.remote_pid)
+        process_script = f"""
+pid={pid}
+if kill -0 "$pid" 2>/dev/null; then
+    pgid=$(ps -o pgid= -p "$pid" | tr -d ' ')
+    if [ -n "$pgid" ]; then
+        kill -TERM -- "-$pgid" 2>/dev/null || true
+        sleep 2
+        kill -KILL -- "-$pgid" 2>/dev/null || true
+    else
+        kill -TERM "$pid" 2>/dev/null || true
+        sleep 2
+        kill -KILL "$pid" 2>/dev/null || true
+    fi
+fi
+"""
+        remote_shell(run.config, process_script, timeout=10, as_run_user=True)
+
+    if not run.remote_jobs_dir:
         return
-    script = f"kill -TERM {int(run.remote_pid)} 2>/dev/null || true"
-    remote_shell(run.config, script, timeout=10, as_run_user=True)
+    cleanup_script = f"""
+set +e
+run_dir={shlex.quote(run.remote_jobs_dir.rstrip('/'))}
+containers=$(sudo -n docker ps -aq --filter label=benchflow.owned=true)
+if [ -n "$containers" ]; then
+    matched=""
+    for container in $containers; do
+        if sudo -n docker inspect "$container" --format '{{{{json .Mounts}}}}' | grep -Fq "$run_dir/"; then
+            matched="$matched $container"
+        fi
+    done
+    if [ -n "$matched" ]; then
+        sudo -n docker rm -f $matched >/dev/null
+    fi
+fi
+"""
+    remote_shell(run.config, cleanup_script, timeout=60, as_run_user=False)
 
 
 def remote_log_tail(run: RunRecord, limit: int = 16_000) -> str:

--- a/current-projects/benchflow-experiment-control/tests/test_jobs.py
+++ b/current-projects/benchflow-experiment-control/tests/test_jobs.py
@@ -202,8 +202,65 @@ class JobsScanTest(unittest.TestCase):
         self.assertEqual(pid, 12345)
         self.assertTrue(captured["as_run_user"])
         self.assertIn("run-remote.sh", script)
-        self.assertIn("nohup bash /jobs/run/run-remote.sh", script)
+        self.assertIn("nohup setsid bash /jobs/run/run-remote.sh", script)
         self.assertIn("printf '%s\\n' \"$status\" > /jobs/run/exit-code.txt", script)
+
+    def test_remote_stop_kills_process_group_and_run_containers(self) -> None:
+        """Guards the fix from PR #286 against leaving remote Docker tasks running after stop."""
+        calls: list[dict[str, object]] = []
+
+        def fake_remote_shell(
+            config: ExperimentConfig,
+            script: str,
+            *,
+            input_text: str | None = None,
+            timeout: int = 30,
+            as_run_user: bool = False,
+        ):
+            calls.append(
+                {
+                    "script": script,
+                    "timeout": timeout,
+                    "as_run_user": as_run_user,
+                }
+            )
+
+            class Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Result()
+
+        original = remote.remote_shell
+        try:
+            remote.remote_shell = fake_remote_shell
+            remote.stop_remote_run(
+                RunRecord(
+                    id="test-run",
+                    status="running",
+                    config=ExperimentConfig(name="test", run_target="gcp_ssh"),
+                    jobs_dir="/local/jobs",
+                    log_path="/local/run.log",
+                    command=[],
+                    remote_pid=12345,
+                    remote_jobs_dir="/mnt/jobs/run",
+                )
+            )
+        finally:
+            remote.remote_shell = original
+
+        self.assertEqual(len(calls), 2)
+        process_script = str(calls[0]["script"])
+        cleanup_script = str(calls[1]["script"])
+        self.assertTrue(calls[0]["as_run_user"])
+        self.assertFalse(calls[1]["as_run_user"])
+        self.assertIn("kill -TERM -- \"-$pgid\"", process_script)
+        self.assertIn("kill -KILL -- \"-$pgid\"", process_script)
+        self.assertIn("--filter label=benchflow.owned=true", cleanup_script)
+        self.assertIn("run_dir=/mnt/jobs/run", cleanup_script)
+        self.assertIn("grep -Fq \"$run_dir/\"", cleanup_script)
+        self.assertIn("docker rm -f $matched", cleanup_script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- launch remote runs in a separate session/process group so stop can terminate the full command tree
- make remote stop remove only BenchFlow-owned Docker containers mounted under the run's remote jobs directory
- add regression coverage for remote stop cleanup

## Tests
- python3 -m py_compile app/*.py
- python3 -m unittest discover -s tests