### PR TITLE
Add continuous experiment pool scheduler

### DIFF
--- a/current-projects/benchflow-experiment-control/README.md
+++ b/current-projects/benchflow-experiment-control/README.md
@@ -43,6 +43,7 @@ Use the CLI directly:
 ```bash
 python3 -m app.cli defaults --pretty
 python3 -m app.cli start --config configs/example.gcp.json --pretty
+python3 -m app.cli pool-start --config configs/example.gcp.json --pretty
 python3 -m app.cli state --pretty
 python3 -m app.cli stop <run-id> --pretty
 ```
@@ -77,6 +78,10 @@ GCP VM:
 5. Optionally set include/exclude task lists. Commas and newlines are accepted.
 6. Click "Start". The right side shows run status, task status, remote logs,
    and artifacts.
+7. Click "Start Pool" when you want task-level continuous scheduling. The pool
+   keeps up to `Concurrency` single-task runs active, audits each completed
+   run after its artifacts sync, then starts the next queued task when a slot
+   opens.
 
 The generated remote command has this shape:
 
@@ -192,11 +197,22 @@ to the local archive. `.env` is excluded from the synced artifact tree.
 python3 -m app.cli defaults --pretty
 python3 -m app.cli tasks --tasks-dir /path/to/tasks --pretty
 python3 -m app.cli start --config configs/example.gcp.json --pretty
+python3 -m app.cli pool-start --config configs/example.gcp.json --pretty
+python3 -m app.cli pool <pool-id> --pretty
+python3 -m app.cli pool-step <pool-id> --pretty
+python3 -m app.cli pool-stop <pool-id> --pretty
 python3 -m app.cli state --pretty
 python3 -m app.cli run <run-id> --pretty
 python3 -m app.cli artifact <run-id> --path '2026-.../task__id/result.json' --pretty
 python3 -m app.cli stop <run-id> --pretty
 ```
+
+`pool-start` treats `concurrency` as pool capacity. Each slot is a normal
+BenchFlow run with one selected task and `concurrency=1`, so existing artifact
+sync, archive layout, run inspection, and stop semantics stay canonical. A
+pool attempt becomes usable only after the synced run has a numeric reward,
+complete ACP trajectory JSONL, `partial_trajectory=false`, and provider token
+usage with `total_tokens`.
 
 `start` accepts a JSON config. Use `--set key=value` to override top-level
 fields:

--- a/current-projects/benchflow-experiment-control/app/cli.py
+++ b/current-projects/benchflow-experiment-control/app/cli.py
@@ -69,6 +69,25 @@ def build_parser() -> argparse.ArgumentParser:
     artifact = sub.add_parser("artifact", help="Read one artifact from a run.")
     artifact.add_argument("run_id")
     artifact.add_argument("--path", required=True)
+
+    pool_start = sub.add_parser("pool-start", help="Start a continuous task pool.")
+    pool_start.add_argument("--config", required=True, help="JSON config path, or '-' for stdin.")
+    pool_start.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override a top-level config field.",
+    )
+
+    pool = sub.add_parser("pool", help="Refresh and print one pool snapshot by id.")
+    pool.add_argument("pool_id")
+
+    pool_step = sub.add_parser("pool-step", help="Advance one pool scheduler tick.")
+    pool_step.add_argument("pool_id")
+
+    pool_stop = sub.add_parser("pool-stop", help="Stop scheduling new tasks for a pool.")
+    pool_stop.add_argument("pool_id")
     return parser
 
 
@@ -97,6 +116,14 @@ def main(argv: list[str] | None = None) -> int:
             payload = manager.run(args.run_id) or {"error": "run not found"}
         elif args.command == "artifact":
             payload = manager.artifact(args.run_id, args.path) or {"error": "run not found"}
+        elif args.command == "pool-start":
+            payload = manager.start_pool(apply_overrides(load_config(args.config), args.set))
+        elif args.command == "pool":
+            payload = manager.pool(args.pool_id) or {"error": "pool not found"}
+        elif args.command == "pool-step":
+            payload = manager.step_pool(args.pool_id) or {"error": "pool not found"}
+        elif args.command == "pool-stop":
+            payload = manager.stop_pool(args.pool_id) or {"error": "pool not found"}
         else:
             parser.error("unknown command")
             return 2

--- a/current-projects/benchflow-experiment-control/app/health.py
+++ b/current-projects/benchflow-experiment-control/app/health.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class TrialAudit:
+    task_name: str
+    usable: bool
+    verdict: str
+    reason: str
+    reward: float | None
+    total_tokens: int | None
+    trajectory_events: int
+    result_path: str
+    trial_path: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def audit_run_dir(run_dir: str | Path) -> TrialAudit | None:
+    root = Path(run_dir).expanduser()
+    trial_dirs = [
+        path.parent
+        for path in sorted(root.rglob("result.json"))
+        if path.is_file() and not path.parent.name.startswith(".")
+    ]
+    if not trial_dirs:
+        return None
+    return audit_trial_dir(trial_dirs[0], root)
+
+
+def audit_trial_dir(trial_dir: str | Path, root: str | Path | None = None) -> TrialAudit:
+    trial_path = Path(trial_dir).expanduser()
+    root_path = Path(root).expanduser() if root else trial_path.parent
+    result_path = trial_path / "result.json"
+    result = read_json(result_path)
+    agent_result = result.get("agent_result") if isinstance(result.get("agent_result"), dict) else {}
+    trajectory_path = trial_path / "trajectory" / "acp_trajectory.jsonl"
+    trajectory_events, trajectory_error = count_jsonl_events(trajectory_path)
+    reward = read_reward(result)
+    total_tokens = read_int(agent_result.get("total_tokens"))
+    task_name = str(result.get("task_name") or trial_path.name.split("__")[0])
+    reasons = health_failures(result, agent_result, trajectory_path, trajectory_events, trajectory_error)
+    usable = not reasons
+    return TrialAudit(
+        task_name=task_name,
+        usable=usable,
+        verdict="usable" if usable else "invalid",
+        reason="; ".join(reasons),
+        reward=reward,
+        total_tokens=total_tokens,
+        trajectory_events=trajectory_events,
+        result_path=relative_path(result_path, root_path),
+        trial_path=relative_path(trial_path, root_path),
+    )
+
+
+def health_failures(
+    result: dict[str, Any],
+    agent_result: dict[str, Any],
+    trajectory_path: Path,
+    trajectory_events: int,
+    trajectory_error: str,
+) -> list[str]:
+    failures: list[str] = []
+    if read_reward(result) is None:
+        failures.append("missing numeric reward")
+    if result.get("verifier_error"):
+        failures.append("verifier error")
+    if result.get("export_error"):
+        failures.append("export error")
+    if result.get("trajectory_source") != "acp":
+        failures.append("trajectory_source is not acp")
+    if result.get("partial_trajectory") is not False:
+        failures.append("partial trajectory")
+    if not trajectory_path.is_file() or trajectory_path.stat().st_size <= 0:
+        failures.append("missing acp trajectory")
+    elif trajectory_error:
+        failures.append(trajectory_error)
+    elif trajectory_events <= 0:
+        failures.append("empty acp trajectory")
+    if agent_result.get("usage_source") != "provider_response":
+        failures.append("usage source is not provider_response")
+    if read_int(agent_result.get("total_tokens")) is None:
+        failures.append("missing total_tokens")
+    return failures
+
+
+def count_jsonl_events(path: Path) -> tuple[int, str]:
+    if not path.is_file():
+        return 0, ""
+    count = 0
+    try:
+        with path.open(errors="replace") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                json.loads(line)
+                count += 1
+    except json.JSONDecodeError as exc:
+        return count, f"invalid trajectory jsonl: {exc.msg}"
+    return count, ""
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def read_reward(result: dict[str, Any]) -> float | None:
+    rewards = result.get("rewards")
+    if isinstance(rewards, dict):
+        return read_float(rewards.get("reward"))
+    return read_float(rewards)
+
+
+def read_float(value: Any) -> float | None:
+    return float(value) if isinstance(value, int | float) else None
+
+
+def read_int(value: Any) -> int | None:
+    return int(value) if isinstance(value, int | float) else None
+
+
+def relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/current-projects/benchflow-experiment-control/app/manager.py
+++ b/current-projects/benchflow-experiment-control/app/manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from . import pool as pool_service
 from .jobs import discover_tasks, read_artifact, scan_run
 from .models import DEFAULT_DATA_DIR, ExperimentConfig
 from .runner import default_paths, refresh_processes, start_run, stop_run
@@ -22,7 +23,16 @@ class ExperimentManager:
 
     def state(self) -> dict[str, Any]:
         refresh_processes(self.store)
-        return {"runs": [scan_run(run) for run in reversed(self.store.list_runs())]}
+        for pool in self.store.list_pools():
+            if pool.status == "running":
+                pool_service.step_pool(pool.id, self.store)
+        return {
+            "runs": [scan_run(run) for run in reversed(self.store.list_runs())],
+            "pools": [
+                pool_service.pool_snapshot(pool, self.store)
+                for pool in reversed(self.store.list_pools())
+            ],
+        }
 
     def run(self, run_id: str) -> dict[str, Any] | None:
         refresh_processes(self.store)
@@ -32,6 +42,22 @@ class ExperimentManager:
     def stop(self, run_id: str) -> dict[str, Any] | None:
         run = stop_run(run_id, self.store)
         return {"run": scan_run(run)} if run else None
+
+    def start_pool(self, raw_config: dict[str, Any]) -> dict[str, Any]:
+        pool = pool_service.start_pool(ExperimentConfig.from_dict(raw_config), self.store)
+        return {"pool": pool_service.pool_snapshot(pool, self.store)}
+
+    def pool(self, pool_id: str) -> dict[str, Any] | None:
+        pool = pool_service.step_pool(pool_id, self.store)
+        return {"pool": pool_service.pool_snapshot(pool, self.store)} if pool else None
+
+    def step_pool(self, pool_id: str) -> dict[str, Any] | None:
+        pool = pool_service.step_pool(pool_id, self.store)
+        return {"pool": pool_service.pool_snapshot(pool, self.store)} if pool else None
+
+    def stop_pool(self, pool_id: str) -> dict[str, Any] | None:
+        pool = pool_service.stop_pool(pool_id, self.store)
+        return {"pool": pool_service.pool_snapshot(pool, self.store)} if pool else None
 
     def tasks(self, tasks_dir: str) -> dict[str, Any]:
         return {"tasks": discover_tasks(tasks_dir)}

--- a/current-projects/benchflow-experiment-control/app/models.py
+++ b/current-projects/benchflow-experiment-control/app/models.py
@@ -158,6 +158,89 @@ class RunRecord:
         return data
 
 
+@dataclass
+class PoolAttempt:
+    task_name: str
+    run_id: str
+    status: str
+    usable: bool | None = None
+    reason: str = ""
+    reward: float | None = None
+    total_tokens: int | None = None
+    trajectory_events: int | None = None
+    result_path: str = ""
+    trial_path: str = ""
+    started_at: str | None = None
+    finished_at: str | None = None
+    audited_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "PoolAttempt":
+        return cls(
+            task_name=str(raw.get("task_name") or raw.get("taskName") or ""),
+            run_id=str(raw.get("run_id") or raw.get("runId") or ""),
+            status=str(raw.get("status") or "unknown"),
+            usable=raw.get("usable"),
+            reason=str(raw.get("reason") or ""),
+            reward=raw.get("reward"),
+            total_tokens=raw.get("total_tokens") or raw.get("totalTokens"),
+            trajectory_events=raw.get("trajectory_events") or raw.get("trajectoryEvents"),
+            result_path=str(raw.get("result_path") or raw.get("resultPath") or ""),
+            trial_path=str(raw.get("trial_path") or raw.get("trialPath") or ""),
+            started_at=raw.get("started_at") or raw.get("startedAt"),
+            finished_at=raw.get("finished_at") or raw.get("finishedAt"),
+            audited_at=raw.get("audited_at") or raw.get("auditedAt"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class PoolRecord:
+    id: str
+    status: str
+    config: ExperimentConfig
+    capacity: int
+    queue: list[str] = field(default_factory=list)
+    active_runs: dict[str, str] = field(default_factory=dict)
+    attempts: list[PoolAttempt] = field(default_factory=list)
+    created_at: str = field(default_factory=now_iso)
+    started_at: str | None = None
+    updated_at: str | None = None
+    finished_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "PoolRecord":
+        return cls(
+            id=str(raw["id"]),
+            status=str(raw.get("status") or "created"),
+            config=ExperimentConfig.from_dict(raw.get("config") or {}),
+            capacity=max(1, int(raw.get("capacity") or 1)),
+            queue=[str(item) for item in raw.get("queue") or [] if str(item)],
+            active_runs={
+                str(task): str(run_id)
+                for task, run_id in (raw.get("active_runs") or raw.get("activeRuns") or {}).items()
+                if str(task) and str(run_id)
+            },
+            attempts=[
+                PoolAttempt.from_dict(item)
+                for item in raw.get("attempts") or []
+                if isinstance(item, dict)
+            ],
+            created_at=str(raw.get("created_at") or now_iso()),
+            started_at=raw.get("started_at") or raw.get("startedAt"),
+            updated_at=raw.get("updated_at") or raw.get("updatedAt"),
+            finished_at=raw.get("finished_at") or raw.get("finishedAt"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["config"] = self.config.to_dict()
+        data["attempts"] = [attempt.to_dict() for attempt in self.attempts]
+        return data
+
+
 def split_names(text: str) -> list[str]:
     return [item.strip() for item in text.replace("\n", ",").split(",") if item.strip()]
 

--- a/current-projects/benchflow-experiment-control/app/pool.py
+++ b/current-projects/benchflow-experiment-control/app/pool.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from typing import Any
+
+from .health import audit_run_dir
+from .models import ExperimentConfig, PoolAttempt, PoolRecord, now_iso
+from .remote import list_remote_tasks
+from .runner import refresh_processes, slug, start_run, stop_run, sync_finished_remote_run, validate_config
+from .store import StateStore
+from .task_selection import available_task_names, select_task_names
+
+
+def start_pool(config: ExperimentConfig, store: StateStore) -> PoolRecord:
+    validate_config(config)
+    capacity = config.concurrency
+    selected_tasks = select_pool_tasks(config)
+    pool_id = f"{slug(config.name)}-pool-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    pool = PoolRecord(
+        id=pool_id,
+        status="running",
+        config=config,
+        capacity=capacity,
+        queue=selected_tasks,
+        started_at=now_iso(),
+        updated_at=now_iso(),
+    )
+    store.upsert_pool(pool)
+    return step_pool(pool.id, store) or pool
+
+
+def step_pool(pool_id: str, store: StateStore) -> PoolRecord | None:
+    refresh_processes(store)
+    pool = store.get_pool(pool_id)
+    if pool is None:
+        return None
+    pool = collect_finished_runs(pool, store)
+    pool = fill_open_slots(pool, store)
+    pool.status = pool_status(pool)
+    pool.updated_at = now_iso()
+    if pool.status == "completed" and not pool.finished_at:
+        pool.finished_at = now_iso()
+    store.upsert_pool(pool)
+    return pool
+
+
+def stop_pool(pool_id: str, store: StateStore) -> PoolRecord | None:
+    pool = store.get_pool(pool_id)
+    if pool is None:
+        return None
+    for run_id in pool.active_runs.values():
+        stop_run(run_id, store)
+    pool.status = "stopped"
+    pool.updated_at = now_iso()
+    pool.finished_at = now_iso()
+    store.upsert_pool(pool)
+    return pool
+
+
+def pool_snapshot(pool: PoolRecord, store: StateStore) -> dict[str, Any]:
+    active = []
+    for task, run_id in sorted(pool.active_runs.items()):
+        run = store.get_run(run_id)
+        active.append({"task_name": task, "run_id": run_id, "run": run.to_dict() if run else None})
+    attempts = [attempt.to_dict() for attempt in pool.attempts]
+    usable = sum(1 for attempt in pool.attempts if attempt.usable)
+    invalid = sum(1 for attempt in pool.attempts if attempt.usable is False)
+    return {
+        "pool": pool.to_dict(),
+        "summary": {
+            "capacity": pool.capacity,
+            "queued": len(pool.queue),
+            "active": len(pool.active_runs),
+            "attempts": len(pool.attempts),
+            "usable": usable,
+            "invalid": invalid,
+            "total": len(pool.queue) + len(pool.active_runs) + len(pool.attempts),
+        },
+        "active": active,
+        "attempts": attempts,
+    }
+
+
+def select_pool_tasks(config: ExperimentConfig) -> list[str]:
+    if config.run_target == "gcp_ssh":
+        available = list_remote_tasks(config)
+    else:
+        available = available_task_names(config.tasks_dir)
+    return select_task_names(available, config.include_tasks, config.exclude_tasks)
+
+
+def collect_finished_runs(pool: PoolRecord, store: StateStore) -> PoolRecord:
+    active = dict(pool.active_runs)
+    for task_name, run_id in list(active.items()):
+        run = store.get_run(run_id)
+        if run is None or run.status == "running":
+            continue
+        if run.config.run_target == "gcp_ssh" and not run.synced_at and not run.sync_error:
+            sync_finished_remote_run(run, store)
+            run = store.get_run(run_id)
+        if run is None:
+            continue
+        if run.config.run_target == "gcp_ssh" and run.sync_error:
+            pool.attempts.append(invalid_attempt(task_name, run, f"sync failed: {run.sync_error}"))
+            active.pop(task_name)
+            continue
+        if run.config.run_target == "gcp_ssh" and not run.synced_at:
+            continue
+        pool.attempts.append(attempt_from_run(task_name, run))
+        active.pop(task_name)
+    pool.active_runs = active
+    return pool
+
+
+def fill_open_slots(pool: PoolRecord, store: StateStore) -> PoolRecord:
+    if pool.status not in {"running", "created"}:
+        return pool
+    while pool.queue and len(pool.active_runs) < pool.capacity:
+        task_name = pool.queue.pop(0)
+        try:
+            run = start_run(pool_run_config(pool, task_name), store)
+        except Exception:
+            pool.queue.insert(0, task_name)
+            raise
+        pool.active_runs[task_name] = run.id
+    return pool
+
+
+def pool_run_config(pool: PoolRecord, task_name: str) -> ExperimentConfig:
+    return replace(
+        pool.config,
+        name=f"{pool.config.name}-{task_name}",
+        concurrency=1,
+        include_tasks=[task_name],
+        exclude_tasks=[],
+    )
+
+
+def attempt_from_run(task_name: str, run) -> PoolAttempt:
+    audit = audit_run_dir(run.jobs_dir)
+    if audit is None:
+        return invalid_attempt(task_name, run, "missing result.json")
+    return PoolAttempt(
+        task_name=audit.task_name or task_name,
+        run_id=run.id,
+        status="usable" if audit.usable else "invalid",
+        usable=audit.usable,
+        reason=audit.reason,
+        reward=audit.reward,
+        total_tokens=audit.total_tokens,
+        trajectory_events=audit.trajectory_events,
+        result_path=audit.result_path,
+        trial_path=audit.trial_path,
+        started_at=run.started_at,
+        finished_at=run.finished_at,
+        audited_at=now_iso(),
+    )
+
+
+def invalid_attempt(task_name: str, run, reason: str) -> PoolAttempt:
+    return PoolAttempt(
+        task_name=task_name,
+        run_id=run.id,
+        status="invalid",
+        usable=False,
+        reason=reason,
+        started_at=run.started_at,
+        finished_at=run.finished_at,
+        audited_at=now_iso(),
+    )
+
+
+def pool_status(pool: PoolRecord) -> str:
+    if pool.status == "stopped":
+        return "stopped"
+    if pool.queue or pool.active_runs:
+        return "running"
+    return "completed"

--- a/current-projects/benchflow-experiment-control/app/remote.py
+++ b/current-projects/benchflow-experiment-control/app/remote.py
@@ -147,6 +147,30 @@ print(json.dumps({
     )
 
 
+def list_remote_tasks(config: ExperimentConfig) -> list[str]:
+    payload = {"tasks_dir": config.remote_tasks_dir}
+    script = r'''
+import json
+import os
+from pathlib import Path
+
+payload = json.loads(os.environ["TASK_INDEX"])
+root = Path(payload["tasks_dir"]).expanduser()
+if not root.is_dir():
+    raise SystemExit(f"tasks dir does not exist: {root}")
+print(json.dumps(sorted(child.name for child in root.iterdir() if (child / "task.toml").is_file())))
+'''
+    shell = f"TASK_INDEX={shlex.quote(json.dumps(payload))} python3 -"
+    result = remote_shell(config, shell, input_text=script, timeout=30, as_run_user=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "failed to list remote tasks")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"could not parse remote task list: {result.stdout!r}") from exc
+    return [str(item) for item in data]
+
+
 def start_remote_process(
     config: ExperimentConfig,
     command: list[str],
@@ -203,10 +227,26 @@ def read_remote_exit_code(run: RunRecord) -> int | None:
 
 
 def stop_remote_run(run: RunRecord) -> None:
-    process_script = ""
     if run.remote_pid:
-        pid = int(run.remote_pid)
-        process_script = f"""
+        remote_shell(
+            run.config,
+            process_group_stop_script(int(run.remote_pid)),
+            timeout=10,
+            as_run_user=True,
+        )
+
+    if not run.remote_jobs_dir:
+        return
+    remote_shell(
+        run.config,
+        container_cleanup_script(run.remote_jobs_dir),
+        timeout=180,
+        as_run_user=False,
+    )
+
+
+def process_group_stop_script(pid: int) -> str:
+    return f"""
 pid={pid}
 if kill -0 "$pid" 2>/dev/null; then
     pgid=$(ps -o pgid= -p "$pid" | tr -d ' ')
@@ -221,13 +261,12 @@ if kill -0 "$pid" 2>/dev/null; then
     fi
 fi
 """
-        remote_shell(run.config, process_script, timeout=10, as_run_user=True)
 
-    if not run.remote_jobs_dir:
-        return
-    cleanup_script = f"""
+
+def container_cleanup_script(remote_jobs_dir: str) -> str:
+    return f"""
 set +e
-run_dir={shlex.quote(run.remote_jobs_dir.rstrip('/'))}
+run_dir={shlex.quote(remote_jobs_dir.rstrip('/'))}
 containers=$(sudo -n docker ps -aq --filter label=benchflow.owned=true)
 if [ -n "$containers" ]; then
     matched=""
@@ -241,7 +280,6 @@ if [ -n "$containers" ]; then
     fi
 fi
 """
-    remote_shell(run.config, cleanup_script, timeout=60, as_run_user=False)
 
 
 def remote_log_tail(run: RunRecord, limit: int = 16_000) -> str:

--- a/current-projects/benchflow-experiment-control/app/server.py
+++ b/current-projects/benchflow-experiment-control/app/server.py
@@ -46,6 +46,8 @@ class Handler(BaseHTTPRequestHandler):
             self.json_response(self.context.manager.tasks(query.get("tasks_dir", [""])[0]))
         elif parsed.path.startswith("/api/runs/"):
             self.handle_run_get(parsed.path, parsed.query)
+        elif parsed.path.startswith("/api/pools/"):
+            self.handle_pool_get(parsed.path)
         else:
             self.static_response(parsed.path)
 
@@ -54,10 +56,21 @@ class Handler(BaseHTTPRequestHandler):
         if parsed.path == "/api/runs":
             payload = self.read_json_body()
             self.json_response(self.context.manager.start(payload), status=201)
+        elif parsed.path == "/api/pools":
+            payload = self.read_json_body()
+            self.json_response(self.context.manager.start_pool(payload), status=201)
         elif parsed.path.startswith("/api/runs/") and parsed.path.endswith("/stop"):
             run_id = parsed.path.split("/")[3]
             payload = self.context.manager.stop(run_id)
             self.json_response(payload if payload else {"error": "run not found"}, status=200 if payload else 404)
+        elif parsed.path.startswith("/api/pools/") and parsed.path.endswith("/step"):
+            pool_id = parsed.path.split("/")[3]
+            payload = self.context.manager.step_pool(pool_id)
+            self.json_response(payload if payload else {"error": "pool not found"}, status=200 if payload else 404)
+        elif parsed.path.startswith("/api/pools/") and parsed.path.endswith("/stop"):
+            pool_id = parsed.path.split("/")[3]
+            payload = self.context.manager.stop_pool(pool_id)
+            self.json_response(payload if payload else {"error": "pool not found"}, status=200 if payload else 404)
         else:
             self.json_response({"error": "not found"}, status=404)
 
@@ -80,6 +93,14 @@ class Handler(BaseHTTPRequestHandler):
             self.json_response(payload if payload else {"error": "run not found"}, status=200 if payload else 404)
         else:
             self.json_response({"error": "not found"}, status=404)
+
+    def handle_pool_get(self, path: str) -> None:
+        parts = path.strip("/").split("/")
+        if len(parts) != 3:
+            self.json_response({"error": "not found"}, status=404)
+            return
+        payload = self.context.manager.pool(parts[2])
+        self.json_response(payload if payload else {"error": "pool not found"}, status=200 if payload else 404)
 
     def static_response(self, request_path: str) -> None:
         rel = "index.html" if request_path in {"", "/"} else request_path.lstrip("/")

--- a/current-projects/benchflow-experiment-control/app/static/app.js
+++ b/current-projects/benchflow-experiment-control/app/static/app.js
@@ -1,6 +1,7 @@
 const form = document.querySelector("#runForm");
 const state = {
   runs: [],
+  pools: [],
   selectedRunId: null,
   busy: false,
 };
@@ -103,6 +104,7 @@ async function loadState({ silent = false } = {}) {
     state.busy = true;
     const payload = await api("/api/state");
     state.runs = payload.runs || [];
+    state.pools = payload.pools || [];
     if (!state.selectedRunId && state.runs.length) {
       state.selectedRunId = state.runs[0].run.id;
     }
@@ -129,6 +131,22 @@ async function startRun(event) {
     });
     state.selectedRunId = payload.run.run.id;
     setMessage(`Started ${payload.run.run.id}`, "ok");
+    await loadState({ silent: true });
+  } catch (error) {
+    setMessage(error.message, "error");
+  }
+}
+
+async function startPool() {
+  setMessage("Starting pool...");
+  try {
+    const payload = await api("/api/pools", {
+      method: "POST",
+      body: JSON.stringify(formPayload()),
+    });
+    const activeRun = payload.pool?.active?.[0]?.run_id;
+    if (activeRun) state.selectedRunId = activeRun;
+    setMessage(`Started pool ${payload.pool.pool.id}`, "ok");
     await loadState({ silent: true });
   } catch (error) {
     setMessage(error.message, "error");
@@ -164,8 +182,34 @@ function activeRun() {
 }
 
 function render() {
+  renderPools();
   renderRuns();
   renderActiveRun();
+}
+
+function renderPools() {
+  $("#poolCount").textContent = String(state.pools.length);
+  const list = $("#poolsList");
+  if (!state.pools.length) {
+    list.className = "runs-list empty";
+    list.textContent = "No pools yet";
+    return;
+  }
+  list.className = "runs-list";
+  list.innerHTML = state.pools
+    .map((item) => {
+      const pool = item.pool;
+      const summary = item.summary || {};
+      return `
+        <div class="run-item">
+          <span class="run-title">${escapeHtml(pool.config.name || pool.id)}</span>
+          <span class="status-pill status-${escapeHtml(pool.status)}">${escapeHtml(pool.status)}</span>
+          <span class="run-meta">cap ${summary.capacity || 0} · active ${summary.active || 0} · queued ${summary.queued || 0} · usable ${summary.usable || 0} · invalid ${summary.invalid || 0}</span>
+          <span class="run-command">${escapeHtml(pool.id)}</span>
+        </div>
+      `;
+    })
+    .join("");
 }
 
 function renderRuns() {
@@ -334,6 +378,7 @@ function formatSeconds(value) {
 }
 
 form.addEventListener("submit", startRun);
+$("#startPool").addEventListener("click", startPool);
 $("#stopRun").addEventListener("click", stopActiveRun);
 $("#refreshState").addEventListener("click", () => loadState());
 $("#loadTasks").addEventListener("click", loadTaskIndex);

--- a/current-projects/benchflow-experiment-control/app/static/index.html
+++ b/current-projects/benchflow-experiment-control/app/static/index.html
@@ -23,7 +23,10 @@
         <section class="panel launch-panel">
           <div class="panel-head">
             <h2>Launch Experiment</h2>
-            <button id="startRun" form="runForm" type="submit">Start</button>
+            <div class="button-row">
+              <button id="startPool" type="button">Start Pool</button>
+              <button id="startRun" form="runForm" type="submit">Start</button>
+            </div>
           </div>
           <form id="runForm" class="form-grid">
             <label>
@@ -165,6 +168,14 @@
             <span id="runCount">0</span>
           </div>
           <div id="runsList" class="runs-list empty">No runs yet</div>
+        </section>
+
+        <section class="panel pools-panel">
+          <div class="panel-head">
+            <h2>Pools</h2>
+            <span id="poolCount">0</span>
+          </div>
+          <div id="poolsList" class="runs-list empty">No pools yet</div>
         </section>
       </aside>
 

--- a/current-projects/benchflow-experiment-control/app/static/styles.css
+++ b/current-projects/benchflow-experiment-control/app/static/styles.css
@@ -57,6 +57,7 @@ button:disabled {
 }
 
 #startRun,
+#startPool,
 #refreshState {
   background: var(--accent);
   border-color: var(--accent);
@@ -147,6 +148,12 @@ h2 {
   gap: 12px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--line);
+}
+
+.button-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .form-grid {

--- a/current-projects/benchflow-experiment-control/app/store.py
+++ b/current-projects/benchflow-experiment-control/app/store.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from .models import DEFAULT_DATA_DIR, RunRecord
+from .models import DEFAULT_DATA_DIR, PoolRecord, RunRecord
 
 
 class StateStore:
@@ -15,13 +15,17 @@ class StateStore:
 
     def load(self) -> dict[str, Any]:
         if not self.path.exists():
-            return {"runs": []}
+            return {"runs": [], "pools": []}
         try:
             data = json.loads(self.path.read_text())
         except json.JSONDecodeError:
-            return {"runs": []}
+            return {"runs": [], "pools": []}
         runs = data.get("runs")
-        return {"runs": runs if isinstance(runs, list) else []}
+        pools = data.get("pools")
+        return {
+            "runs": runs if isinstance(runs, list) else [],
+            "pools": pools if isinstance(pools, list) else [],
+        }
 
     def save(self, state: dict[str, Any]) -> None:
         tmp = self.path.with_suffix(".tmp")
@@ -59,3 +63,23 @@ class StateStore:
         self.upsert_run(run)
         return run
 
+    def list_pools(self) -> list[PoolRecord]:
+        return [PoolRecord.from_dict(item) for item in self.load()["pools"]]
+
+    def get_pool(self, pool_id: str) -> PoolRecord | None:
+        for pool in self.list_pools():
+            if pool.id == pool_id:
+                return pool
+        return None
+
+    def upsert_pool(self, pool: PoolRecord) -> None:
+        state = self.load()
+        pools = state["pools"]
+        payload = pool.to_dict()
+        for index, item in enumerate(pools):
+            if item.get("id") == pool.id:
+                pools[index] = payload
+                self.save(state)
+                return
+        pools.append(payload)
+        self.save(state)

--- a/current-projects/benchflow-experiment-control/tests/test_pool.py
+++ b/current-projects/benchflow-experiment-control/tests/test_pool.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app import pool
+from app.health import audit_trial_dir
+from app.models import ExperimentConfig, PoolRecord, RunRecord
+from app.store import StateStore
+
+
+class HealthAuditTest(unittest.TestCase):
+    def test_complete_acp_and_provider_usage_is_usable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trial = Path(tmp) / "alpha__001"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rewards": {"reward": 0.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "total_tokens": 123,
+                        },
+                    }
+                )
+            )
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
+                json.dumps({"type": "user_message"}) + "\n"
+            )
+
+            audit = audit_trial_dir(trial, tmp)
+
+            self.assertTrue(audit.usable)
+            self.assertEqual(audit.verdict, "usable")
+
+    def test_missing_reward_keeps_full_trajectory_out_of_usable_set(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trial = Path(tmp) / "alpha__001"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "total_tokens": 123,
+                        },
+                    }
+                )
+            )
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
+                json.dumps({"type": "user_message"}) + "\n"
+            )
+
+            audit = audit_trial_dir(trial, tmp)
+
+            self.assertFalse(audit.usable)
+            self.assertIn("missing numeric reward", audit.reason)
+
+
+class PoolSchedulerTest(unittest.TestCase):
+    def test_start_pool_fills_capacity_with_single_task_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = StateStore(Path(tmp) / "state")
+            started: list[RunRecord] = []
+
+            def fake_start_run(config: ExperimentConfig, store: StateStore) -> RunRecord:
+                run = RunRecord(
+                    id=f"run-{config.include_tasks[0]}",
+                    status="running",
+                    config=config,
+                    jobs_dir=str(Path(tmp) / config.include_tasks[0]),
+                    log_path=str(Path(tmp) / f"{config.include_tasks[0]}.log"),
+                    command=[],
+                    selected_tasks=config.include_tasks,
+                    started_at="now",
+                )
+                store.upsert_run(run)
+                started.append(run)
+                return run
+
+            original_start_run = pool.start_run
+            original_select_pool_tasks = pool.select_pool_tasks
+            try:
+                pool.start_run = fake_start_run
+                pool.select_pool_tasks = lambda config: ["alpha", "beta", "gamma"]
+                record = pool.start_pool(
+                    ExperimentConfig(name="test", run_target="local", concurrency=2),
+                    store,
+                )
+            finally:
+                pool.start_run = original_start_run
+                pool.select_pool_tasks = original_select_pool_tasks
+
+            self.assertEqual(record.capacity, 2)
+            self.assertEqual(record.queue, ["gamma"])
+            self.assertEqual(record.active_runs, {"alpha": "run-alpha", "beta": "run-beta"})
+            self.assertEqual([run.config.concurrency for run in started], [1, 1])
+
+    def test_step_pool_audits_finished_run_then_refills_slot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            store = StateStore(root / "state")
+            finished_dir = root / "finished"
+            trial = finished_dir / "alpha__001"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "total_tokens": 456,
+                        },
+                    }
+                )
+            )
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
+                json.dumps({"type": "agent_message"}) + "\n"
+            )
+            store.upsert_run(
+                RunRecord(
+                    id="run-alpha",
+                    status="completed",
+                    config=ExperimentConfig(name="alpha", run_target="local"),
+                    jobs_dir=str(finished_dir),
+                    log_path=str(root / "alpha.log"),
+                    command=[],
+                    started_at="start",
+                    finished_at="finish",
+                )
+            )
+            store.upsert_pool(
+                PoolRecord(
+                    id="pool-1",
+                    status="running",
+                    config=ExperimentConfig(name="test", run_target="local", concurrency=2),
+                    capacity=2,
+                    queue=["beta"],
+                    active_runs={"alpha": "run-alpha"},
+                )
+            )
+
+            def fake_start_run(config: ExperimentConfig, store: StateStore) -> RunRecord:
+                run = RunRecord(
+                    id="run-beta",
+                    status="running",
+                    config=config,
+                    jobs_dir=str(root / "beta"),
+                    log_path=str(root / "beta.log"),
+                    command=[],
+                    selected_tasks=["beta"],
+                )
+                store.upsert_run(run)
+                return run
+
+            original_start_run = pool.start_run
+            try:
+                pool.start_run = fake_start_run
+                record = pool.step_pool("pool-1", store)
+            finally:
+                pool.start_run = original_start_run
+
+            self.assertIsNotNone(record)
+            self.assertEqual(record.active_runs, {"beta": "run-beta"})
+            self.assertEqual(record.queue, [])
+            self.assertEqual(len(record.attempts), 1)
+            self.assertTrue(record.attempts[0].usable)
+            self.assertEqual(record.attempts[0].total_tokens, 456)
+
+    def test_step_pool_releases_slot_when_remote_sync_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            store = StateStore(root / "state")
+            store.upsert_run(
+                RunRecord(
+                    id="run-alpha",
+                    status="completed",
+                    config=ExperimentConfig(name="alpha", run_target="gcp_ssh"),
+                    jobs_dir=str(root / "alpha"),
+                    log_path=str(root / "alpha.log"),
+                    command=[],
+                    sync_error="archive failed",
+                )
+            )
+            store.upsert_pool(
+                PoolRecord(
+                    id="pool-1",
+                    status="running",
+                    config=ExperimentConfig(name="test", run_target="local", concurrency=1),
+                    capacity=1,
+                    queue=["beta"],
+                    active_runs={"alpha": "run-alpha"},
+                )
+            )
+
+            def fake_start_run(config: ExperimentConfig, store: StateStore) -> RunRecord:
+                run = RunRecord(
+                    id="run-beta",
+                    status="running",
+                    config=config,
+                    jobs_dir=str(root / "beta"),
+                    log_path=str(root / "beta.log"),
+                    command=[],
+                    selected_tasks=["beta"],
+                )
+                store.upsert_run(run)
+                return run
+
+            original_start_run = pool.start_run
+            try:
+                pool.start_run = fake_start_run
+                record = pool.step_pool("pool-1", store)
+            finally:
+                pool.start_run = original_start_run
+
+            self.assertIsNotNone(record)
+            self.assertEqual(record.active_runs, {"beta": "run-beta"})
+            self.assertFalse(record.attempts[0].usable)
+            self.assertIn("sync failed", record.attempts[0].reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a CLI/API pool scheduler that keeps up to the configured concurrency of single-task runs active
- archive and health-audit completed slot runs before freeing the slot and starting the next queued task
- expose pool controls in the dashboard and document the CLI flow
- keep health validation isolated in app/health.py and scheduling isolated in app/pool.py so runner/server/UI stay thin

## Thermo-nuclear code quality review
- avoided bolting pool-specific branches into runner.py; the canonical runner still owns launch/sync/stop for individual runs
- separated artifact health checks from pool state transitions
- preserved existing batch start semantics and added pool commands as an explicit mode
- checked file sizes; no touched file crosses 1k lines

## Tests
- python3 -m py_compile app/*.py
- python3 -m unittest discover -s tests
- python3 -m app.cli state --pretty
- dashboard smoke via Chrome/Playwright at http://127.0.0.1:8766