### PR TITLE
Clean up remote compose sidecars

### DIFF
--- a/current-projects/benchflow-experiment-control/app/remote.py
+++ b/current-projects/benchflow-experiment-control/app/remote.py
@@ -267,16 +267,24 @@ def container_cleanup_script(remote_jobs_dir: str) -> str:
     return f"""
 set +e
 run_dir={shlex.quote(remote_jobs_dir.rstrip('/'))}
-containers=$(sudo -n docker ps -aq --filter label=benchflow.owned=true)
+containers=$(sudo -n docker ps -aq)
 if [ -n "$containers" ]; then
     matched=""
+    projects=""
     for container in $containers; do
         if sudo -n docker inspect "$container" --format '{{{{json .Mounts}}}}' | grep -Fq "$run_dir/"; then
             matched="$matched $container"
+            project=$(sudo -n docker inspect "$container" --format '{{{{index .Config.Labels "com.docker.compose.project"}}}}')
+            if [ -n "$project" ] && [ "$project" != "<no value>" ]; then
+                projects="$projects $project"
+            fi
         fi
     done
+    for project in $projects; do
+        matched="$matched $(sudo -n docker ps -aq --filter label=com.docker.compose.project="$project")"
+    done
     if [ -n "$matched" ]; then
-        sudo -n docker rm -f $matched >/dev/null
+        printf '%s\n' $matched | sort -u | xargs -r sudo -n docker rm -f >/dev/null
     fi
 fi
 """

--- a/current-projects/benchflow-experiment-control/tests/test_jobs.py
+++ b/current-projects/benchflow-experiment-control/tests/test_jobs.py
@@ -257,10 +257,11 @@ class JobsScanTest(unittest.TestCase):
         self.assertFalse(calls[1]["as_run_user"])
         self.assertIn("kill -TERM -- \"-$pgid\"", process_script)
         self.assertIn("kill -KILL -- \"-$pgid\"", process_script)
-        self.assertIn("--filter label=benchflow.owned=true", cleanup_script)
+        self.assertIn("docker ps -aq)", cleanup_script)
         self.assertIn("run_dir=/mnt/jobs/run", cleanup_script)
         self.assertIn("grep -Fq \"$run_dir/\"", cleanup_script)
-        self.assertIn("docker rm -f $matched", cleanup_script)
+        self.assertIn("com.docker.compose.project", cleanup_script)
+        self.assertIn("xargs -r sudo -n docker rm -f", cleanup_script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clean all Docker containers mounted under a remote run directory, not only BenchFlow-owned containers
- include containers from the same Docker Compose project so sidecars without BenchFlow labels are removed too
- keep cleanup scoped by run-directory mounts before expanding to project peers

## Thermo-nuclear code quality review
- preserved the existing remote stop boundary instead of scattering special cases through runner/state logic
- kept cleanup selection explicit and scoped to the run directory, then compose project peers
- no file-size growth concerns

## Tests
- python3 -m py_compile app/*.py
- python3 -m unittest discover -s tests