### PR TITLE
Add sheet-backed experiment pool

### DIFF
--- a/current-projects/benchflow-experiment-control/.gitignore
+++ b/current-projects/benchflow-experiment-control/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .DS_Store
 /data/
+/.playwright-cli/

--- a/current-projects/benchflow-experiment-control/README.md
+++ b/current-projects/benchflow-experiment-control/README.md
@@ -78,10 +78,13 @@ GCP VM:
 5. Optionally set include/exclude task lists. Commas and newlines are accepted.
 6. Click "Start". The right side shows run status, task status, remote logs,
    and artifacts.
-7. Click "Start Pool" when you want task-level continuous scheduling. The pool
-   keeps up to `Concurrency` single-task runs active, audits each completed
-   run after its artifacts sync, then starts the next queued task when a slot
-   opens.
+7. Click "Start Pool" when you want task-level continuous scheduling. Without
+   a spreadsheet ID, the pool keeps up to `Concurrency` single-task runs active
+   from the selected task list. With a spreadsheet ID, the pool treats the
+   existing sheet rows as the shared queue: it claims empty run slots, starts
+   one fresh sandbox run per claim, clears that run's remote Docker containers
+   after artifact sync, audits and archives the artifacts, updates that same
+   sheet slot, and only then claims the next slot.
 
 The generated remote command has this shape:
 
@@ -162,6 +165,17 @@ Remote paths may be absolute or relative to the SSH login home.
 - `Skills dir`: passed to `--skills-dir`.
 - `Skills mode`: passed to `--skill-mode` when not `default`.
 - `Extra args`: appended to the `bench eval create` command.
+- `Spreadsheet ID`: enables sheet-backed pool mode. The sheet's existing
+  columns and run slots are used as-is; no new sheet structure is created.
+- `Tab`: sheet tab to read and update.
+- The shared status spreadsheet's `PR2_PR3_HF_VM_Clean5` tab is an imported
+  view and is refused as a write target. Use the writable source spreadsheet
+  for sheet-backed pooling.
+- `Configuration`: optional explicit configuration key. When empty, the
+  manager uses `<agent>__<model>__<skills-label>`.
+- `Owner`: local operator label for pool state and claim ids.
+- `Lease TTL min`: stale `running` sheet slots older than this can be claimed
+  again.
 
 ## Result Archive Layout
 
@@ -211,8 +225,17 @@ python3 -m app.cli stop <run-id> --pretty
 BenchFlow run with one selected task and `concurrency=1`, so existing artifact
 sync, archive layout, run inspection, and stop semantics stay canonical. A
 pool attempt becomes usable only after the synced run has a numeric reward,
-complete ACP trajectory JSONL, `partial_trajectory=false`, and provider token
-usage with `total_tokens`.
+complete ACP trajectory JSONL, complete LLM trajectory JSONL,
+`partial_trajectory=false`, successful sandbox cleanup, and provider token
+usage with positive `total_tokens`.
+
+In sheet-backed mode, `pool-start` does not append rows or create new columns.
+It claims the first available existing `run_N_*` slot for each task, preferring
+empty slots before expired claims or invalid historical slots. It writes a
+temporary running marker, runs the task in a fresh sandbox, cleans up the
+sandbox, writes `benchflow-experiment-manifest.json` with artifact hashes beside
+the trial, and then updates that same slot with the final reward, status,
+trajectory, usage, cost, and artifact paths.
 
 `start` accepts a JSON config. Use `--set key=value` to override top-level
 fields:

--- a/current-projects/benchflow-experiment-control/app/finalizer.py
+++ b/current-projects/benchflow-experiment-control/app/finalizer.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from .health import TrialAudit
+from .models import PoolAttempt, RunRecord, now_iso
+
+
+MANIFEST_NAME = "benchflow-experiment-manifest.json"
+
+
+@dataclass
+class FinalizedAttempt:
+    attempt: PoolAttempt
+    manifest_path: str
+
+
+def finalize_trial(
+    *,
+    audit: TrialAudit,
+    run: RunRecord,
+    sheet_row: int | None = None,
+    sheet_slot: int | None = None,
+    claim_id: str = "",
+) -> FinalizedAttempt:
+    trial_dir = Path(run.jobs_dir).expanduser() / audit.trial_path
+    manifest_path = trial_dir / MANIFEST_NAME
+    manifest = build_manifest(
+        audit=audit,
+        run=run,
+        sheet_row=sheet_row,
+        sheet_slot=sheet_slot,
+        claim_id=claim_id,
+        manifest_path=manifest_path,
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    rel_manifest = relative_path(manifest_path, Path(run.jobs_dir).expanduser())
+    return FinalizedAttempt(
+        attempt=PoolAttempt(
+            task_name=audit.task_name,
+            run_id=run.id,
+            status="usable" if audit.usable else "invalid",
+            usable=audit.usable,
+            reason=audit.reason,
+            reward=audit.reward,
+            total_tokens=audit.total_tokens,
+            trajectory_events=audit.acp_trajectory_events,
+            result_path=audit.result_path,
+            trial_path=audit.trial_path,
+            sheet_row=sheet_row,
+            sheet_slot=sheet_slot,
+            manifest_path=rel_manifest,
+            started_at=run.started_at,
+            finished_at=run.finished_at,
+            audited_at=now_iso(),
+        ),
+        manifest_path=rel_manifest,
+    )
+
+
+def build_manifest(
+    *,
+    audit: TrialAudit,
+    run: RunRecord,
+    sheet_row: int | None,
+    sheet_slot: int | None,
+    claim_id: str,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    root = Path(run.jobs_dir).expanduser()
+    artifacts = artifact_manifest(root, audit)
+    return {
+        "schema": "benchflow-experiment-control.v1",
+        "written_at": now_iso(),
+        "claim": {
+            "id": claim_id,
+            "sheet_row": sheet_row,
+            "sheet_slot": sheet_slot,
+        },
+        "run": {
+            "id": run.id,
+            "status": run.status,
+            "jobs_dir": run.jobs_dir,
+            "remote_jobs_dir": run.remote_jobs_dir,
+            "started_at": run.started_at,
+            "finished_at": run.finished_at,
+        },
+        "config": {
+            "agent": run.config.agent,
+            "model": run.config.model,
+            "sandbox": run.config.sandbox,
+            "skills_profile": run.config.skills_profile,
+            "skills_mode": run.config.skills_mode,
+            "run_target": run.config.run_target,
+        },
+        "audit": audit.to_dict(),
+        "artifacts": artifacts,
+        "manifest_path": relative_path(manifest_path, root),
+    }
+
+
+def artifact_manifest(root: Path, audit: TrialAudit) -> dict[str, dict[str, Any]]:
+    paths = {
+        "result": audit.result_path,
+        "config": audit.config_path,
+        "acp_trajectory": audit.acp_trajectory_path,
+        "llm_trajectory": audit.llm_trajectory_path,
+    }
+    return {
+        name: file_record(root / rel_path)
+        for name, rel_path in paths.items()
+        if rel_path
+    }
+
+
+def file_record(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {"path": path.as_posix(), "exists": False}
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return {
+        "path": path.as_posix(),
+        "exists": True,
+        "bytes": path.stat().st_size,
+        "sha256": digest,
+    }
+
+
+def relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def missing_result_attempt(
+    *,
+    task_name: str,
+    run: RunRecord,
+    reason: str,
+    sheet_row: int | None = None,
+    sheet_slot: int | None = None,
+) -> PoolAttempt:
+    return PoolAttempt(
+        task_name=task_name,
+        run_id=run.id,
+        status="invalid",
+        usable=False,
+        reason=reason,
+        sheet_row=sheet_row,
+        sheet_slot=sheet_slot,
+        started_at=run.started_at,
+        finished_at=run.finished_at,
+        audited_at=now_iso(),
+    )

--- a/current-projects/benchflow-experiment-control/app/health.py
+++ b/current-projects/benchflow-experiment-control/app/health.py
@@ -9,13 +9,35 @@ from typing import Any
 @dataclass
 class TrialAudit:
     task_name: str
+    trial_name: str
     usable: bool
     verdict: str
     reason: str
     reward: float | None
+    outcome: str
+    status_raw: str
+    error: str
+    error_category: str
+    verifier_error: str
     total_tokens: int | None
-    trajectory_events: int
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_input_tokens: int | None
+    cache_creation_input_tokens: int | None
+    usage_source: str
+    price_source: str
+    total_cost_usd: float | None
+    acp_trajectory_events: int
+    llm_trajectory_events: int
+    n_tool_calls: int | None
+    n_skill_invocations: int | None
+    started_at: str
+    finished_at: str
+    timing: dict[str, float]
     result_path: str
+    config_path: str
+    acp_trajectory_path: str
+    llm_trajectory_path: str
     trial_path: str
 
     def to_dict(self) -> dict[str, Any]:
@@ -23,39 +45,82 @@ class TrialAudit:
 
 
 def audit_run_dir(run_dir: str | Path) -> TrialAudit | None:
+    audits = audit_trials(run_dir)
+    return audits[0] if audits else None
+
+
+def audit_trials(run_dir: str | Path) -> list[TrialAudit]:
     root = Path(run_dir).expanduser()
     trial_dirs = [
         path.parent
         for path in sorted(root.rglob("result.json"))
         if path.is_file() and not path.parent.name.startswith(".")
     ]
-    if not trial_dirs:
-        return None
-    return audit_trial_dir(trial_dirs[0], root)
+    return [audit_trial_dir(path, root) for path in trial_dirs]
 
 
 def audit_trial_dir(trial_dir: str | Path, root: str | Path | None = None) -> TrialAudit:
     trial_path = Path(trial_dir).expanduser()
     root_path = Path(root).expanduser() if root else trial_path.parent
     result_path = trial_path / "result.json"
+    config_path = trial_path / "config.json"
     result = read_json(result_path)
     agent_result = result.get("agent_result") if isinstance(result.get("agent_result"), dict) else {}
-    trajectory_path = trial_path / "trajectory" / "acp_trajectory.jsonl"
-    trajectory_events, trajectory_error = count_jsonl_events(trajectory_path)
+    acp_trajectory_path = trial_path / "trajectory" / "acp_trajectory.jsonl"
+    llm_trajectory_path = trial_path / "trajectory" / "llm_trajectory.jsonl"
+    acp_events, acp_error = count_jsonl_events(acp_trajectory_path)
+    llm_events, llm_error = count_jsonl_events(llm_trajectory_path)
     reward = read_reward(result)
     total_tokens = read_int(agent_result.get("total_tokens"))
+    input_tokens = read_int(agent_result.get("n_input_tokens"))
+    output_tokens = read_int(agent_result.get("n_output_tokens"))
     task_name = str(result.get("task_name") or trial_path.name.split("__")[0])
-    reasons = health_failures(result, agent_result, trajectory_path, trajectory_events, trajectory_error)
+    outcome = classify_outcome(result, reward)
+    reasons = health_failures(
+        result,
+        agent_result,
+        acp_trajectory_path,
+        acp_events,
+        acp_error,
+        llm_trajectory_path,
+        llm_events,
+        llm_error,
+    )
     usable = not reasons
+    timing = result.get("timing") if isinstance(result.get("timing"), dict) else {}
     return TrialAudit(
         task_name=task_name,
+        trial_name=str(result.get("rollout_name") or trial_path.name),
         usable=usable,
         verdict="usable" if usable else "invalid",
         reason="; ".join(reasons),
         reward=reward,
+        outcome=outcome,
+        status_raw=status_raw_for_outcome(outcome, usable),
+        error=str(result.get("error") or ""),
+        error_category=str(result.get("error_category") or ""),
+        verifier_error=str(result.get("verifier_error") or ""),
         total_tokens=total_tokens,
-        trajectory_events=trajectory_events,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_input_tokens=read_int(agent_result.get("n_cache_read_tokens")),
+        cache_creation_input_tokens=read_int(agent_result.get("n_cache_creation_tokens")),
+        usage_source=str(agent_result.get("usage_source") or ""),
+        price_source=str(agent_result.get("price_source") or ""),
+        total_cost_usd=read_float(agent_result.get("cost_usd")),
+        acp_trajectory_events=acp_events,
+        llm_trajectory_events=llm_events,
+        n_tool_calls=read_int(result.get("n_tool_calls") or agent_result.get("n_tool_calls")),
+        n_skill_invocations=read_int(
+            result.get("n_skill_invocations") or agent_result.get("n_skill_invocations")
+        ),
+        started_at=str(result.get("started_at") or ""),
+        finished_at=str(result.get("finished_at") or ""),
+        timing={key: float(value) for key, value in timing.items() if isinstance(value, int | float)},
         result_path=relative_path(result_path, root_path),
+        config_path=relative_path(config_path, root_path) if config_path.is_file() else "",
+        acp_trajectory_path=relative_path(acp_trajectory_path, root_path),
+        llm_trajectory_path=relative_path(llm_trajectory_path, root_path),
         trial_path=relative_path(trial_path, root_path),
     )
 
@@ -63,9 +128,12 @@ def audit_trial_dir(trial_dir: str | Path, root: str | Path | None = None) -> Tr
 def health_failures(
     result: dict[str, Any],
     agent_result: dict[str, Any],
-    trajectory_path: Path,
-    trajectory_events: int,
-    trajectory_error: str,
+    acp_trajectory_path: Path,
+    acp_trajectory_events: int,
+    acp_trajectory_error: str,
+    llm_trajectory_path: Path,
+    llm_trajectory_events: int,
+    llm_trajectory_error: str,
 ) -> list[str]:
     failures: list[str] = []
     if read_reward(result) is None:
@@ -74,20 +142,35 @@ def health_failures(
         failures.append("verifier error")
     if result.get("export_error"):
         failures.append("export error")
+    if result.get("cleanup_error"):
+        failures.append("cleanup error")
     if result.get("trajectory_source") != "acp":
         failures.append("trajectory_source is not acp")
     if result.get("partial_trajectory") is not False:
         failures.append("partial trajectory")
-    if not trajectory_path.is_file() or trajectory_path.stat().st_size <= 0:
+    if not acp_trajectory_path.is_file() or acp_trajectory_path.stat().st_size <= 0:
         failures.append("missing acp trajectory")
-    elif trajectory_error:
-        failures.append(trajectory_error)
-    elif trajectory_events <= 0:
+    elif acp_trajectory_error:
+        failures.append(acp_trajectory_error)
+    elif acp_trajectory_events <= 0:
         failures.append("empty acp trajectory")
+    if not llm_trajectory_path.is_file() or llm_trajectory_path.stat().st_size <= 0:
+        failures.append("missing llm trajectory")
+    elif llm_trajectory_error:
+        failures.append(llm_trajectory_error)
+    elif llm_trajectory_events <= 0:
+        failures.append("empty llm trajectory")
     if agent_result.get("usage_source") != "provider_response":
         failures.append("usage source is not provider_response")
-    if read_int(agent_result.get("total_tokens")) is None:
+    total_tokens = read_int(agent_result.get("total_tokens"))
+    if total_tokens is None:
         failures.append("missing total_tokens")
+    elif total_tokens <= 0:
+        failures.append("non-positive total_tokens")
+    if read_int(agent_result.get("n_input_tokens")) is None:
+        failures.append("missing input tokens")
+    if read_int(agent_result.get("n_output_tokens")) is None:
+        failures.append("missing output tokens")
     return failures
 
 
@@ -130,6 +213,26 @@ def read_float(value: Any) -> float | None:
 
 def read_int(value: Any) -> int | None:
     return int(value) if isinstance(value, int | float) else None
+
+
+def classify_outcome(result: dict[str, Any], reward: float | None) -> str:
+    if reward is not None and reward >= 1.0:
+        return "pass"
+    error_text = " ".join(
+        str(result.get(key) or "")
+        for key in ("error", "error_category", "verifier_error", "verifier_error_category")
+    ).lower()
+    if "timeout" in error_text or "timed out" in error_text:
+        return "timeout"
+    return "fail" if reward is not None else "error"
+
+
+def status_raw_for_outcome(outcome: str, usable: bool) -> str:
+    if not usable:
+        return "bfec_invalid"
+    if outcome == "timeout":
+        return "usable_error"
+    return outcome
 
 
 def relative_path(path: Path, root: Path) -> str:

--- a/current-projects/benchflow-experiment-control/app/models.py
+++ b/current-projects/benchflow-experiment-control/app/models.py
@@ -41,6 +41,11 @@ class ExperimentConfig:
     include_tasks: list[str] = field(default_factory=list)
     exclude_tasks: list[str] = field(default_factory=list)
     extra_args: str = ""
+    sheet_id: str = ""
+    sheet_tab: str = "PR2_PR3_HF_VM_Clean5"
+    sheet_configuration: str = ""
+    sheet_owner: str = ""
+    sheet_lease_ttl_minutes: int = 240
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "ExperimentConfig":
@@ -84,6 +89,20 @@ class ExperimentConfig:
             include_tasks=list_field("include_tasks") or list_field("includeTasks"),
             exclude_tasks=list_field("exclude_tasks") or list_field("excludeTasks"),
             extra_args=str(raw.get("extra_args") or raw.get("extraArgs") or ""),
+            sheet_id=str(raw.get("sheet_id") or raw.get("sheetId") or ""),
+            sheet_tab=str(raw.get("sheet_tab") or raw.get("sheetTab") or cls.sheet_tab),
+            sheet_configuration=str(
+                raw.get("sheet_configuration") or raw.get("sheetConfiguration") or ""
+            ),
+            sheet_owner=str(raw.get("sheet_owner") or raw.get("sheetOwner") or ""),
+            sheet_lease_ttl_minutes=max(
+                1,
+                int(
+                    raw.get("sheet_lease_ttl_minutes")
+                    or raw.get("sheetLeaseTtlMinutes")
+                    or cls.sheet_lease_ttl_minutes
+                ),
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -170,6 +189,9 @@ class PoolAttempt:
     trajectory_events: int | None = None
     result_path: str = ""
     trial_path: str = ""
+    sheet_row: int | None = None
+    sheet_slot: int | None = None
+    manifest_path: str = ""
     started_at: str | None = None
     finished_at: str | None = None
     audited_at: str | None = None
@@ -187,6 +209,9 @@ class PoolAttempt:
             trajectory_events=raw.get("trajectory_events") or raw.get("trajectoryEvents"),
             result_path=str(raw.get("result_path") or raw.get("resultPath") or ""),
             trial_path=str(raw.get("trial_path") or raw.get("trialPath") or ""),
+            sheet_row=raw.get("sheet_row") or raw.get("sheetRow"),
+            sheet_slot=raw.get("sheet_slot") or raw.get("sheetSlot"),
+            manifest_path=str(raw.get("manifest_path") or raw.get("manifestPath") or ""),
             started_at=raw.get("started_at") or raw.get("startedAt"),
             finished_at=raw.get("finished_at") or raw.get("finishedAt"),
             audited_at=raw.get("audited_at") or raw.get("auditedAt"),
@@ -202,8 +227,10 @@ class PoolRecord:
     status: str
     config: ExperimentConfig
     capacity: int
+    source: str = "tasks"
     queue: list[str] = field(default_factory=list)
     active_runs: dict[str, str] = field(default_factory=dict)
+    active_claims: list[PoolClaim] = field(default_factory=list)
     attempts: list[PoolAttempt] = field(default_factory=list)
     created_at: str = field(default_factory=now_iso)
     started_at: str | None = None
@@ -217,12 +244,18 @@ class PoolRecord:
             status=str(raw.get("status") or "created"),
             config=ExperimentConfig.from_dict(raw.get("config") or {}),
             capacity=max(1, int(raw.get("capacity") or 1)),
+            source=str(raw.get("source") or "tasks"),
             queue=[str(item) for item in raw.get("queue") or [] if str(item)],
             active_runs={
                 str(task): str(run_id)
                 for task, run_id in (raw.get("active_runs") or raw.get("activeRuns") or {}).items()
                 if str(task) and str(run_id)
             },
+            active_claims=[
+                PoolClaim.from_dict(item)
+                for item in raw.get("active_claims") or raw.get("activeClaims") or []
+                if isinstance(item, dict)
+            ],
             attempts=[
                 PoolAttempt.from_dict(item)
                 for item in raw.get("attempts") or []
@@ -237,8 +270,37 @@ class PoolRecord:
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
         data["config"] = self.config.to_dict()
+        data["active_claims"] = [claim.to_dict() for claim in self.active_claims]
         data["attempts"] = [attempt.to_dict() for attempt in self.attempts]
         return data
+
+
+@dataclass
+class PoolClaim:
+    id: str
+    task_name: str
+    sheet_row: int
+    sheet_slot: int
+    run_id: str = ""
+    status: str = "claimed"
+    claimed_at: str = field(default_factory=now_iso)
+    finalized_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "PoolClaim":
+        return cls(
+            id=str(raw.get("id") or ""),
+            task_name=str(raw.get("task_name") or raw.get("taskName") or ""),
+            sheet_row=int(raw.get("sheet_row") or raw.get("sheetRow") or 0),
+            sheet_slot=int(raw.get("sheet_slot") or raw.get("sheetSlot") or 0),
+            run_id=str(raw.get("run_id") or raw.get("runId") or ""),
+            status=str(raw.get("status") or "claimed"),
+            claimed_at=str(raw.get("claimed_at") or raw.get("claimedAt") or now_iso()),
+            finalized_at=raw.get("finalized_at") or raw.get("finalizedAt"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 def split_names(text: str) -> list[str]:

--- a/current-projects/benchflow-experiment-control/app/pool.py
+++ b/current-projects/benchflow-experiment-control/app/pool.py
@@ -6,13 +6,17 @@ from typing import Any
 
 from .health import audit_run_dir
 from .models import ExperimentConfig, PoolAttempt, PoolRecord, now_iso
-from .remote import list_remote_tasks
+from .remote import cleanup_remote_run_containers, list_remote_tasks
 from .runner import refresh_processes, slug, start_run, stop_run, sync_finished_remote_run, validate_config
 from .store import StateStore
 from .task_selection import available_task_names, select_task_names
 
 
 def start_pool(config: ExperimentConfig, store: StateStore) -> PoolRecord:
+    if config.sheet_id:
+        from .sheet_pool import start_sheet_pool
+
+        return start_sheet_pool(config, store)
     validate_config(config)
     capacity = config.concurrency
     selected_tasks = select_pool_tasks(config)
@@ -35,6 +39,10 @@ def step_pool(pool_id: str, store: StateStore) -> PoolRecord | None:
     pool = store.get_pool(pool_id)
     if pool is None:
         return None
+    if pool.source == "sheet":
+        from .sheet_pool import step_sheet_pool
+
+        return step_sheet_pool(pool.id, store)
     pool = collect_finished_runs(pool, store)
     pool = fill_open_slots(pool, store)
     pool.status = pool_status(pool)
@@ -49,8 +57,14 @@ def stop_pool(pool_id: str, store: StateStore) -> PoolRecord | None:
     pool = store.get_pool(pool_id)
     if pool is None:
         return None
-    for run_id in pool.active_runs.values():
+    for run_id in set(pool.active_runs.values()):
         stop_run(run_id, store)
+    if pool.source == "sheet" and pool.active_claims:
+        from .sheet_queue import SheetQueue
+
+        SheetQueue(pool.config).release_claims(pool.active_claims)
+        pool.active_claims = []
+        pool.active_runs = {}
     pool.status = "stopped"
     pool.updated_at = now_iso()
     pool.finished_at = now_iso()
@@ -59,6 +73,10 @@ def stop_pool(pool_id: str, store: StateStore) -> PoolRecord | None:
 
 
 def pool_snapshot(pool: PoolRecord, store: StateStore) -> dict[str, Any]:
+    if pool.source == "sheet":
+        from .sheet_pool import sheet_pool_snapshot
+
+        return sheet_pool_snapshot(pool, store)
     active = []
     for task, run_id in sorted(pool.active_runs.items()):
         run = store.get_run(run_id)
@@ -102,11 +120,14 @@ def collect_finished_runs(pool: PoolRecord, store: StateStore) -> PoolRecord:
         if run is None:
             continue
         if run.config.run_target == "gcp_ssh" and run.sync_error:
+            cleanup_remote_run_containers(run)
             pool.attempts.append(invalid_attempt(task_name, run, f"sync failed: {run.sync_error}"))
             active.pop(task_name)
             continue
         if run.config.run_target == "gcp_ssh" and not run.synced_at:
             continue
+        if run.config.run_target == "gcp_ssh":
+            cleanup_remote_run_containers(run)
         pool.attempts.append(attempt_from_run(task_name, run))
         active.pop(task_name)
     pool.active_runs = active
@@ -149,7 +170,7 @@ def attempt_from_run(task_name: str, run) -> PoolAttempt:
         reason=audit.reason,
         reward=audit.reward,
         total_tokens=audit.total_tokens,
-        trajectory_events=audit.trajectory_events,
+        trajectory_events=audit.acp_trajectory_events,
         result_path=audit.result_path,
         trial_path=audit.trial_path,
         started_at=run.started_at,

--- a/current-projects/benchflow-experiment-control/app/remote.py
+++ b/current-projects/benchflow-experiment-control/app/remote.py
@@ -237,12 +237,21 @@ def stop_remote_run(run: RunRecord) -> None:
 
     if not run.remote_jobs_dir:
         return
-    remote_shell(
+    cleanup_remote_run_containers(run)
+
+
+def cleanup_remote_run_containers(run: RunRecord) -> None:
+    if not run.remote_jobs_dir:
+        return
+    result = remote_shell(
         run.config,
         container_cleanup_script(run.remote_jobs_dir),
         timeout=180,
         as_run_user=False,
     )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "failed to clean remote Docker containers"
+        raise RuntimeError(message)
 
 
 def process_group_stop_script(pid: int) -> str:
@@ -265,7 +274,7 @@ fi
 
 def container_cleanup_script(remote_jobs_dir: str) -> str:
     return f"""
-set +e
+set -e
 run_dir={shlex.quote(remote_jobs_dir.rstrip('/'))}
 containers=$(sudo -n docker ps -aq)
 if [ -n "$containers" ]; then

--- a/current-projects/benchflow-experiment-control/app/runner.py
+++ b/current-projects/benchflow-experiment-control/app/runner.py
@@ -289,4 +289,9 @@ def default_paths() -> dict[str, str]:
         "concurrency": "4",
         "sandbox": "docker",
         "skills_profile": "with-skills",
+        "sheet_id": "",
+        "sheet_tab": "PR2_PR3_HF_VM_Clean5",
+        "sheet_configuration": "",
+        "sheet_owner": "",
+        "sheet_lease_ttl_minutes": "240",
     }

--- a/current-projects/benchflow-experiment-control/app/sheet_pool.py
+++ b/current-projects/benchflow-experiment-control/app/sheet_pool.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from typing import Any
+
+from .finalizer import finalize_trial, missing_result_attempt
+from .health import audit_trials
+from .models import ExperimentConfig, PoolClaim, PoolRecord, RunRecord, now_iso
+from .remote import cleanup_remote_run_containers
+from .runner import refresh_processes, slug, start_run, sync_finished_remote_run, validate_config
+from .sheet_queue import SheetQueue
+from .store import StateStore
+
+
+def start_sheet_pool(config: ExperimentConfig, store: StateStore) -> PoolRecord:
+    validate_config(config)
+    owner = slug(config.sheet_owner or "local")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    pool_id = f"{slug(config.name)}-{owner}-sheet-pool-{timestamp}"
+    pool = PoolRecord(
+        id=pool_id,
+        status="running",
+        source="sheet",
+        config=config,
+        capacity=config.concurrency,
+        started_at=now_iso(),
+        updated_at=now_iso(),
+    )
+    store.upsert_pool(pool)
+    return step_sheet_pool(pool.id, store) or pool
+
+
+def step_sheet_pool(pool_id: str, store: StateStore) -> PoolRecord | None:
+    refresh_processes(store)
+    pool = store.get_pool(pool_id)
+    if pool is None:
+        return None
+    queue = SheetQueue(pool.config)
+    pool = finalize_active_claims(pool, store, queue)
+    pool = fill_open_sheet_slots(pool, store, queue)
+    pool.status = sheet_pool_status(pool)
+    pool.updated_at = now_iso()
+    if pool.status == "completed" and not pool.finished_at:
+        pool.finished_at = now_iso()
+    store.upsert_pool(pool)
+    return pool
+
+
+def finalize_active_claims(
+    pool: PoolRecord, store: StateStore, queue: SheetQueue
+) -> PoolRecord:
+    active: list[PoolClaim] = []
+    for claim in pool.active_claims:
+        run = store.get_run(claim.run_id)
+        if run is None:
+            active.append(claim)
+            continue
+        if run.config.run_target == "gcp_ssh" and run.status != "running" and not run.synced_at:
+            if not run.sync_error:
+                sync_finished_remote_run(run, store)
+            run = store.get_run(claim.run_id) or run
+        audit = audit_for_claim(run, claim)
+        if audit is None:
+            if run.status == "running" or (run.config.run_target == "gcp_ssh" and not run.synced_at):
+                active.append(claim)
+                continue
+            attempt = missing_result_attempt(
+                task_name=claim.task_name,
+                run=run,
+                reason=run.sync_error or "missing result.json",
+                sheet_row=claim.sheet_row,
+                sheet_slot=claim.sheet_slot,
+            )
+            if run.config.run_target == "gcp_ssh":
+                cleanup_remote_run_containers(run)
+            queue.write_missing_result(claim, attempt.reason)
+            pool.attempts.append(attempt)
+            continue
+        if run.config.run_target == "gcp_ssh":
+            cleanup_remote_run_containers(run)
+        finalized = finalize_trial(
+            audit=audit,
+            run=run,
+            sheet_row=claim.sheet_row,
+            sheet_slot=claim.sheet_slot,
+            claim_id=claim.id,
+        )
+        queue.write_final_result(claim, audit)
+        pool.attempts.append(finalized.attempt)
+    pool.active_claims = active
+    pool.active_runs = {claim.id: claim.run_id for claim in active}
+    return pool
+
+
+def fill_open_sheet_slots(
+    pool: PoolRecord, store: StateStore, queue: SheetQueue
+) -> PoolRecord:
+    if pool.status not in {"running", "created"}:
+        return pool
+    open_slots = max(0, pool.capacity - len(pool.active_claims))
+    if open_slots <= 0:
+        return pool
+    claims = queue.claim_distinct_tasks(open_slots, pool.id)
+    if not claims:
+        return pool
+    active = [*pool.active_claims]
+    for claim in claims:
+        try:
+            run = start_run(slot_config(pool.config, claim), store)
+        except Exception:
+            queue.release_claims([claim])
+            raise
+        claim.run_id = run.id
+        claim.status = "running"
+        active.append(claim)
+    pool.active_claims = active
+    pool.active_runs = {claim.id: claim.run_id for claim in active}
+    return pool
+
+
+def slot_config(config: ExperimentConfig, claim: PoolClaim) -> ExperimentConfig:
+    return replace(
+        config,
+        name=f"{config.name}-{claim.task_name}-run-{claim.sheet_slot}",
+        concurrency=1,
+        include_tasks=[claim.task_name],
+        exclude_tasks=[],
+    )
+
+
+def audit_for_claim(run: RunRecord, claim: PoolClaim):
+    for audit in audit_trials(run.jobs_dir):
+        if audit.task_name == claim.task_name:
+            return audit
+    return None
+
+
+def sheet_pool_status(pool: PoolRecord) -> str:
+    if pool.status == "stopped":
+        return "stopped"
+    if pool.active_claims:
+        return "running"
+    return "completed"
+
+
+def sheet_pool_snapshot(pool: PoolRecord, store: StateStore) -> dict[str, Any]:
+    active = [
+        {
+            "task_name": claim.task_name,
+            "run_id": claim.run_id,
+            "sheet_row": claim.sheet_row,
+            "sheet_slot": claim.sheet_slot,
+            "claim": claim.to_dict(),
+            "run": store.get_run(claim.run_id).to_dict() if store.get_run(claim.run_id) else None,
+        }
+        for claim in pool.active_claims
+    ]
+    attempts = [attempt.to_dict() for attempt in pool.attempts]
+    usable = sum(1 for attempt in pool.attempts if attempt.usable)
+    invalid = sum(1 for attempt in pool.attempts if attempt.usable is False)
+    return {
+        "pool": pool.to_dict(),
+        "summary": {
+            "capacity": pool.capacity,
+            "queued": 0,
+            "active": len(pool.active_claims),
+            "attempts": len(pool.attempts),
+            "usable": usable,
+            "invalid": invalid,
+            "total": len(pool.active_claims) + len(pool.attempts),
+        },
+        "active": active,
+        "attempts": attempts,
+    }

--- a/current-projects/benchflow-experiment-control/app/sheet_queue.py
+++ b/current-projects/benchflow-experiment-control/app/sheet_queue.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Protocol
+
+from .health import TrialAudit
+from .models import ExperimentConfig, PoolClaim, now_iso
+
+
+DEFAULT_SHEET_ID = "12Df5viQyNpFqntKzH7h1FFg1s2hGoLeXcNUZtO7kPFA"
+IMPORTED_VIEW_TABS = {"PR2_PR3_HF_VM_Clean5"}
+RUN_SLOTS = range(1, 6)
+CLAIM_ATTEMPT_KIND = "bfec-sheet-pool"
+CLAIM_STATUS = "running"
+CLAIMABLE_SLOT_RANKS = {
+    "empty": 0,
+    "stale-running": 1,
+    "invalid": 2,
+}
+
+
+class SheetClient(Protocol):
+    def read_values(self, spreadsheet_id: str, range_name: str) -> list[list[str]]:
+        ...
+
+    def batch_update_values(
+        self, spreadsheet_id: str, updates: list[tuple[str, list[list[Any]]]]
+    ) -> None:
+        ...
+
+
+class GwsSheetClient:
+    def read_values(self, spreadsheet_id: str, range_name: str) -> list[list[str]]:
+        result = run_gws(
+            [
+                "gws",
+                "sheets",
+                "spreadsheets",
+                "values",
+                "get",
+                "--params",
+                json.dumps({"spreadsheetId": spreadsheet_id, "range": range_name}),
+                "--format",
+                "json",
+            ]
+        )
+        return result.get("values") or []
+
+    def batch_update_values(
+        self, spreadsheet_id: str, updates: list[tuple[str, list[list[Any]]]]
+    ) -> None:
+        if not updates:
+            return
+        body = {
+            "valueInputOption": "USER_ENTERED",
+            "data": [
+                {"range": range_name, "majorDimension": "ROWS", "values": values}
+                for range_name, values in updates
+            ],
+        }
+        run_gws(
+            [
+                "gws",
+                "sheets",
+                "spreadsheets",
+                "values",
+                "batchUpdate",
+                "--params",
+                json.dumps({"spreadsheetId": spreadsheet_id}),
+                "--json",
+                json.dumps(body),
+                "--format",
+                "json",
+            ]
+        )
+
+
+def run_gws(command: list[str]) -> dict[str, Any]:
+    result = subprocess.run(command, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "gws command failed"
+        raise RuntimeError(message)
+    return json.loads(result.stdout or "{}")
+
+
+def ensure_writable_queue_target(spreadsheet_id: str, tab: str) -> None:
+    if spreadsheet_id == DEFAULT_SHEET_ID and tab in IMPORTED_VIEW_TABS:
+        raise ValueError(
+            f"{tab} in the shared status spreadsheet is an IMPORTRANGE view; "
+            "use the writable source spreadsheet/tab for sheet-backed pooling"
+        )
+
+
+@dataclass(frozen=True)
+class SheetSlot:
+    row_number: int
+    task_name: str
+    slot: int
+    values: dict[str, str]
+
+    @property
+    def item_id(self) -> str:
+        return f"{self.row_number}:{self.slot}:{self.task_name}"
+
+    @property
+    def trial_id(self) -> str:
+        return self.values.get(field_name(self.slot, "trial_id"), "")
+
+    @property
+    def status_raw(self) -> str:
+        return self.values.get(field_name(self.slot, "status_raw"), "")
+
+    @property
+    def started_at(self) -> str:
+        return self.values.get(field_name(self.slot, "started_at"), "")
+
+    @property
+    def is_usable(self) -> bool:
+        return self.values.get(field_name(self.slot, "is_usable_for_analysis"), "") == "TRUE"
+
+    def is_available(self, now: datetime, ttl: timedelta) -> bool:
+        return self.claimable_kind(now, ttl) is not None
+
+    def claimable_rank(self, now: datetime, ttl: timedelta) -> int | None:
+        kind = self.claimable_kind(now, ttl)
+        return CLAIMABLE_SLOT_RANKS.get(kind) if kind else None
+
+    def claimable_kind(self, now: datetime, ttl: timedelta) -> str | None:
+        if self.is_usable:
+            return None
+        if not self.trial_id and not self.status_raw:
+            return "empty"
+        if self.status_raw != CLAIM_STATUS:
+            return "invalid"
+        claimed_at = parse_datetime(self.started_at)
+        if claimed_at is not None and claimed_at + ttl < now:
+            return "stale-running"
+        return None
+
+
+class SheetQueue:
+    def __init__(self, config: ExperimentConfig, client: SheetClient | None = None):
+        self.config = config
+        self.client = client or GwsSheetClient()
+        self.spreadsheet_id = config.sheet_id or DEFAULT_SHEET_ID
+        self.tab = config.sheet_tab
+        self.configuration = config.sheet_configuration or configuration_key(config)
+        ensure_writable_queue_target(self.spreadsheet_id, self.tab)
+
+    def read_table(self) -> "SheetTable":
+        values = self.client.read_values(self.spreadsheet_id, f"{self.tab}!A:HT")
+        return SheetTable.from_values(self.tab, values)
+
+    def available_slots(self) -> list[SheetSlot]:
+        ttl = timedelta(minutes=self.config.sheet_lease_ttl_minutes)
+        now = datetime.now().astimezone()
+        slots = [
+            slot
+            for slot in self.read_table().slots_for_configuration(self.configuration)
+            if slot.is_available(now, ttl)
+        ]
+        return sorted(
+            slots,
+            key=lambda slot: (
+                claimable_rank_or_last(slot, now, ttl),
+                slot.row_number,
+                slot.slot,
+            ),
+        )
+
+    def claim_distinct_tasks(self, count: int, pool_id: str) -> list[PoolClaim]:
+        selected: list[SheetSlot] = []
+        seen_tasks: set[str] = set()
+        for slot in self.available_slots():
+            if slot.task_name in seen_tasks:
+                continue
+            selected.append(slot)
+            seen_tasks.add(slot.task_name)
+            if len(selected) >= count:
+                break
+        claims = [
+            PoolClaim(
+                id=f"{pool_id}-{slot.row_number}-{slot.slot}",
+                task_name=slot.task_name,
+                sheet_row=slot.row_number,
+                sheet_slot=slot.slot,
+            )
+            for slot in selected
+        ]
+        self.write_claims(claims)
+        return claims
+
+    def write_claims(self, claims: list[PoolClaim]) -> None:
+        table = self.read_table()
+        updates: list[tuple[str, list[list[Any]]]] = []
+        for claim in claims:
+            prefix = f"run_{claim.sheet_slot}_"
+            values = {
+                f"{prefix}trial_id": claim_trial_id(claim),
+                f"{prefix}pass_slot": claim.sheet_slot,
+                f"{prefix}attempt_kind": CLAIM_ATTEMPT_KIND,
+                f"{prefix}status_raw": CLAIM_STATUS,
+                f"{prefix}status_for_analysis": CLAIM_STATUS,
+                f"{prefix}pass_fail_timeout": CLAIM_STATUS,
+                f"{prefix}is_infra_error": "FALSE",
+                f"{prefix}is_usable_for_analysis": "FALSE",
+                f"{prefix}started_at": claim.claimed_at,
+            }
+            updates.extend(row_updates(self.tab, claim.sheet_row, values, table.headers))
+        self.client.batch_update_values(self.spreadsheet_id, updates)
+        self.verify_claims(claims)
+
+    def verify_claims(self, claims: list[PoolClaim]) -> None:
+        table = self.read_table()
+        lost: list[str] = []
+        for claim in claims:
+            row = table.row(claim.sheet_row)
+            if row.get(field_name(claim.sheet_slot, "trial_id")) != claim_trial_id(claim):
+                lost.append(f"{claim.task_name}@row{claim.sheet_row}/run_{claim.sheet_slot}")
+        if lost:
+            raise RuntimeError(f"sheet claim verification failed: {', '.join(lost)}")
+
+    def release_claims(self, claims: list[PoolClaim]) -> None:
+        table = self.read_table()
+        updates: list[tuple[str, list[list[Any]]]] = []
+        for claim in claims:
+            prefix = f"run_{claim.sheet_slot}_"
+            values = {
+                f"{prefix}trial_id": "",
+                f"{prefix}pass_slot": "",
+                f"{prefix}attempt_kind": "",
+                f"{prefix}status_raw": "",
+                f"{prefix}status_for_analysis": "",
+                f"{prefix}pass_fail_timeout": "",
+                f"{prefix}is_infra_error": "",
+                f"{prefix}is_usable_for_analysis": "",
+                f"{prefix}started_at": "",
+            }
+            updates.extend(row_updates(self.tab, claim.sheet_row, values, table.headers))
+        self.client.batch_update_values(self.spreadsheet_id, updates)
+
+    def write_final_result(self, claim: PoolClaim, audit: TrialAudit) -> None:
+        table = self.read_table()
+        row = table.row(claim.sheet_row)
+        values = final_slot_values(claim, audit)
+        row_values = dict(row)
+        row_values.update({key: stringify(value) for key, value in values.items()})
+        values.update(summary_values(row_values))
+        self.client.batch_update_values(
+            self.spreadsheet_id,
+            row_updates(self.tab, claim.sheet_row, values, table.headers),
+        )
+
+    def write_missing_result(self, claim: PoolClaim, reason: str) -> None:
+        table = self.read_table()
+        prefix = f"run_{claim.sheet_slot}_"
+        values = {
+            f"{prefix}status_raw": "bfec_invalid",
+            f"{prefix}status_for_analysis": "",
+            f"{prefix}pass_fail_timeout": "",
+            f"{prefix}error_category": reason,
+            f"{prefix}is_infra_error": "TRUE",
+            f"{prefix}is_usable_for_analysis": "FALSE",
+            f"{prefix}finished_at": now_iso(),
+        }
+        self.client.batch_update_values(
+            self.spreadsheet_id,
+            row_updates(self.tab, claim.sheet_row, values, table.headers),
+        )
+
+
+@dataclass
+class SheetTable:
+    tab: str
+    headers: list[str]
+    rows: dict[int, dict[str, str]]
+
+    @classmethod
+    def from_values(cls, tab: str, values: list[list[str]]) -> "SheetTable":
+        headers = values[0] if values else []
+        rows: dict[int, dict[str, str]] = {}
+        for offset, raw_row in enumerate(values[1:], start=2):
+            padded = [*raw_row, *([""] * max(0, len(headers) - len(raw_row)))]
+            rows[offset] = dict(zip(headers, padded, strict=False))
+        return cls(tab=tab, headers=headers, rows=rows)
+
+    def row(self, row_number: int) -> dict[str, str]:
+        return self.rows.get(row_number, {})
+
+    def slots_for_configuration(self, configuration: str) -> list[SheetSlot]:
+        slots: list[SheetSlot] = []
+        for row_number, row in sorted(self.rows.items()):
+            if row.get("configuration") != configuration:
+                continue
+            task_name = row.get("task_id") or ""
+            for slot in RUN_SLOTS:
+                slots.append(
+                    SheetSlot(
+                        row_number=row_number,
+                        task_name=task_name,
+                        slot=slot,
+                        values=row,
+                    )
+                )
+        return slots
+
+
+def final_slot_values(claim: PoolClaim, audit: TrialAudit) -> dict[str, Any]:
+    prefix = f"run_{claim.sheet_slot}_"
+    is_usable = "TRUE" if audit.usable else "FALSE"
+    status_for_analysis = audit.outcome if audit.usable else ""
+    return {
+        f"{prefix}trial_id": audit.trial_name,
+        f"{prefix}pass_slot": claim.sheet_slot,
+        f"{prefix}attempt_kind": CLAIM_ATTEMPT_KIND,
+        f"{prefix}reward": audit.reward if audit.reward is not None else "",
+        f"{prefix}status_raw": audit.status_raw,
+        f"{prefix}status_for_analysis": status_for_analysis,
+        f"{prefix}pass_fail_timeout": status_for_analysis,
+        f"{prefix}error_category": audit.error_category,
+        f"{prefix}is_infra_error": "FALSE" if audit.usable else "TRUE",
+        f"{prefix}is_usable_for_analysis": is_usable,
+        f"{prefix}has_trajectory": "TRUE" if audit.acp_trajectory_events > 0 else "FALSE",
+        f"{prefix}trajectory_events": audit.acp_trajectory_events,
+        f"{prefix}n_tool_calls": audit.n_tool_calls if audit.n_tool_calls is not None else "",
+        f"{prefix}skill_launch_count": (
+            audit.n_skill_invocations if audit.n_skill_invocations is not None else ""
+        ),
+        f"{prefix}started_at": audit.started_at,
+        f"{prefix}finished_at": audit.finished_at,
+        f"{prefix}environment_setup_s": audit.timing.get("environment_setup", ""),
+        f"{prefix}agent_setup_s": audit.timing.get("agent_setup", ""),
+        f"{prefix}agent_execution_s": audit.timing.get("agent_execution", ""),
+        f"{prefix}verifier_s": audit.timing.get("verifier", ""),
+        f"{prefix}total_s": audit.timing.get("total", ""),
+        f"{prefix}usage": json.dumps(usage_payload(audit), sort_keys=True),
+        f"{prefix}token_usage": json.dumps(token_usage_payload(audit), sort_keys=True),
+        f"{prefix}input_tokens": audit.input_tokens if audit.input_tokens is not None else "",
+        f"{prefix}output_tokens": audit.output_tokens if audit.output_tokens is not None else "",
+        f"{prefix}cache_read_input_tokens": (
+            audit.cache_read_input_tokens if audit.cache_read_input_tokens is not None else ""
+        ),
+        f"{prefix}cache_creation_input_tokens": (
+            audit.cache_creation_input_tokens
+            if audit.cache_creation_input_tokens is not None
+            else ""
+        ),
+        f"{prefix}total_tokens": audit.total_tokens if audit.total_tokens is not None else "",
+        f"{prefix}usage_source": audit.usage_source,
+        f"{prefix}price_source": audit.price_source,
+        f"{prefix}priced_at": now_iso() if audit.total_cost_usd is not None else "",
+        f"{prefix}total_cost_usd": (
+            audit.total_cost_usd if audit.total_cost_usd is not None else ""
+        ),
+        f"{prefix}result_path": f"LOCAL:{audit.result_path}",
+        f"{prefix}trajectory_path": f"LOCAL:{audit.acp_trajectory_path}",
+        f"{prefix}trajectory_vm_path": "",
+        f"{prefix}config_path": f"LOCAL:{audit.config_path}" if audit.config_path else "",
+        f"run_{claim.sheet_slot}_vm_trial_path": f"LOCAL:{audit.trial_path}",
+    }
+
+
+def claimable_rank_or_last(slot: SheetSlot, now: datetime, ttl: timedelta) -> int:
+    rank = slot.claimable_rank(now, ttl)
+    return rank if rank is not None else len(CLAIMABLE_SLOT_RANKS)
+
+
+def claim_trial_id(claim: PoolClaim) -> str:
+    return f"{claim.task_name}__{claim.id}"
+
+
+def summary_values(row: dict[str, str]) -> dict[str, Any]:
+    rewards: list[float] = []
+    usable = 0
+    for slot in RUN_SLOTS:
+        if row.get(field_name(slot, "is_usable_for_analysis")) != "TRUE":
+            continue
+        usable += 1
+        reward = parse_float(row.get(field_name(slot, "reward"), ""))
+        if reward is not None:
+            rewards.append(reward)
+    return {
+        "run_state": "uploaded" if usable else "no-usable",
+        "usable_trials": usable,
+        "missing_usable_trials": max(0, 5 - usable),
+        "mean_reward_usable": sum(rewards) / len(rewards) if rewards else "",
+    }
+
+
+def usage_payload(audit: TrialAudit) -> dict[str, Any]:
+    return {
+        "source": audit.usage_source,
+        "total_tokens": audit.total_tokens,
+        "cost_usd": audit.total_cost_usd,
+    }
+
+
+def token_usage_payload(audit: TrialAudit) -> dict[str, Any]:
+    return {
+        "input_tokens": audit.input_tokens,
+        "output_tokens": audit.output_tokens,
+        "cache_read_input_tokens": audit.cache_read_input_tokens,
+        "cache_creation_input_tokens": audit.cache_creation_input_tokens,
+        "total_tokens": audit.total_tokens,
+    }
+
+
+def row_updates(
+    tab: str, row_number: int, values: dict[str, Any], headers: list[str]
+) -> list[tuple[str, list[list[Any]]]]:
+    columns = {header: a1_column(index) for index, header in enumerate(headers, start=1)}
+    return [
+        (f"{tab}!{column}{row_number}:{column}{row_number}", [[stringify(value)]])
+        for key, value in values.items()
+        if (column := columns.get(key))
+    ]
+
+
+def field_name(slot: int, name: str) -> str:
+    return f"run_{slot}_{name}"
+
+
+def a1_column(index: int) -> str:
+    name = ""
+    while index:
+        index, remainder = divmod(index - 1, 26)
+        name = chr(65 + remainder) + name
+    return name
+
+
+def configuration_key(config: ExperimentConfig) -> str:
+    return f"{config.agent}__{config.model}__{config.skills_profile}"
+
+
+def stringify(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    return value
+
+
+def parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def parse_float(value: str) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/current-projects/benchflow-experiment-control/app/static/app.js
+++ b/current-projects/benchflow-experiment-control/app/static/app.js
@@ -31,6 +31,11 @@ const fields = [
   "include_tasks",
   "exclude_tasks",
   "extra_args",
+  "sheet_id",
+  "sheet_tab",
+  "sheet_configuration",
+  "sheet_owner",
+  "sheet_lease_ttl_minutes",
 ];
 
 function $(selector) {
@@ -66,6 +71,7 @@ function formPayload() {
   }
   payload.concurrency = Number(payload.concurrency || 1);
   payload.remote_port = Number(payload.remote_port || 22);
+  payload.sheet_lease_ttl_minutes = Number(payload.sheet_lease_ttl_minutes || 240);
   return payload;
 }
 

--- a/current-projects/benchflow-experiment-control/app/static/index.html
+++ b/current-projects/benchflow-experiment-control/app/static/index.html
@@ -150,6 +150,29 @@
               Extra args
               <input name="extra_args" placeholder="--agent-idle-timeout 600" autocomplete="off" />
             </label>
+            <div class="group wide">
+              <div class="group-title">Google Sheet Pool</div>
+              <label class="wide">
+                Spreadsheet ID
+                <input name="sheet_id" placeholder="Leave empty for task-only pool" autocomplete="off" />
+              </label>
+              <label>
+                Tab
+                <input name="sheet_tab" value="PR2_PR3_HF_VM_Clean5" autocomplete="off" />
+              </label>
+              <label>
+                Configuration
+                <input name="sheet_configuration" placeholder="agent__model__skills-label" autocomplete="off" />
+              </label>
+              <label>
+                Owner
+                <input name="sheet_owner" placeholder="me@bingranyou.com" autocomplete="off" />
+              </label>
+              <label>
+                Lease TTL min
+                <input name="sheet_lease_ttl_minutes" type="number" min="1" value="240" />
+              </label>
+            </div>
           </form>
           <div id="formMessage" class="message"></div>
         </section>

--- a/current-projects/benchflow-experiment-control/tests/test_jobs.py
+++ b/current-projects/benchflow-experiment-control/tests/test_jobs.py
@@ -258,10 +258,47 @@ class JobsScanTest(unittest.TestCase):
         self.assertIn("kill -TERM -- \"-$pgid\"", process_script)
         self.assertIn("kill -KILL -- \"-$pgid\"", process_script)
         self.assertIn("docker ps -aq)", cleanup_script)
+        self.assertIn("set -e", cleanup_script)
         self.assertIn("run_dir=/mnt/jobs/run", cleanup_script)
         self.assertIn("grep -Fq \"$run_dir/\"", cleanup_script)
         self.assertIn("com.docker.compose.project", cleanup_script)
         self.assertIn("xargs -r sudo -n docker rm -f", cleanup_script)
+
+    def test_remote_cleanup_raises_on_docker_failure(self) -> None:
+        """Guards this PR against refilling a remote slot after Docker cleanup failed."""
+
+        def fake_remote_shell(
+            config: ExperimentConfig,
+            script: str,
+            *,
+            input_text: str | None = None,
+            timeout: int = 30,
+            as_run_user: bool = False,
+        ):
+            class Result:
+                returncode = 1
+                stdout = ""
+                stderr = "docker daemon unavailable"
+
+            return Result()
+
+        original = remote.remote_shell
+        try:
+            remote.remote_shell = fake_remote_shell
+            with self.assertRaisesRegex(RuntimeError, "docker daemon unavailable"):
+                remote.cleanup_remote_run_containers(
+                    RunRecord(
+                        id="test-run",
+                        status="completed",
+                        config=ExperimentConfig(name="test", run_target="gcp_ssh"),
+                        jobs_dir="/local/jobs",
+                        log_path="/local/run.log",
+                        command=[],
+                        remote_jobs_dir="/mnt/jobs/run",
+                    )
+                )
+        finally:
+            remote.remote_shell = original
 
 
 if __name__ == "__main__":

--- a/current-projects/benchflow-experiment-control/tests/test_pool.py
+++ b/current-projects/benchflow-experiment-control/tests/test_pool.py
@@ -25,6 +25,8 @@ class HealthAuditTest(unittest.TestCase):
                         "partial_trajectory": False,
                         "agent_result": {
                             "usage_source": "provider_response",
+                            "n_input_tokens": 100,
+                            "n_output_tokens": 23,
                             "total_tokens": 123,
                         },
                     }
@@ -32,6 +34,9 @@ class HealthAuditTest(unittest.TestCase):
             )
             (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
                 json.dumps({"type": "user_message"}) + "\n"
+            )
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text(
+                json.dumps({"type": "response"}) + "\n"
             )
 
             audit = audit_trial_dir(trial, tmp)
@@ -51,6 +56,8 @@ class HealthAuditTest(unittest.TestCase):
                         "partial_trajectory": False,
                         "agent_result": {
                             "usage_source": "provider_response",
+                            "n_input_tokens": 100,
+                            "n_output_tokens": 23,
                             "total_tokens": 123,
                         },
                     }
@@ -59,11 +66,100 @@ class HealthAuditTest(unittest.TestCase):
             (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
                 json.dumps({"type": "user_message"}) + "\n"
             )
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text(
+                json.dumps({"type": "response"}) + "\n"
+            )
 
             audit = audit_trial_dir(trial, tmp)
 
             self.assertFalse(audit.usable)
             self.assertIn("missing numeric reward", audit.reason)
+
+    def test_missing_llm_trajectory_is_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trial = Path(tmp) / "alpha__001"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "n_input_tokens": 10,
+                            "n_output_tokens": 5,
+                            "total_tokens": 15,
+                        },
+                    }
+                )
+            )
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
+                json.dumps({"type": "agent_message"}) + "\n"
+            )
+
+            audit = audit_trial_dir(trial, tmp)
+
+            self.assertFalse(audit.usable)
+            self.assertIn("missing llm trajectory", audit.reason)
+
+    def test_zero_usage_tokens_are_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trial = Path(tmp) / "alpha__001"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "n_input_tokens": 0,
+                            "n_output_tokens": 0,
+                            "total_tokens": 0,
+                        },
+                    }
+                )
+            )
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text("{}\n")
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text("{}\n")
+
+            audit = audit_trial_dir(trial, tmp)
+
+            self.assertFalse(audit.usable)
+            self.assertIn("non-positive total_tokens", audit.reason)
+
+    def test_cleanup_error_is_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trial = Path(tmp) / "alpha__001"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "cleanup_error": "sandbox delete failed",
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "n_input_tokens": 10,
+                            "n_output_tokens": 5,
+                            "total_tokens": 15,
+                        },
+                    }
+                )
+            )
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text("{}\n")
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text("{}\n")
+
+            audit = audit_trial_dir(trial, tmp)
+
+            self.assertFalse(audit.usable)
+            self.assertIn("cleanup error", audit.reason)
 
 
 class PoolSchedulerTest(unittest.TestCase):
@@ -121,6 +217,8 @@ class PoolSchedulerTest(unittest.TestCase):
                         "partial_trajectory": False,
                         "agent_result": {
                             "usage_source": "provider_response",
+                            "n_input_tokens": 400,
+                            "n_output_tokens": 56,
                             "total_tokens": 456,
                         },
                     }
@@ -128,6 +226,9 @@ class PoolSchedulerTest(unittest.TestCase):
             )
             (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
                 json.dumps({"type": "agent_message"}) + "\n"
+            )
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text(
+                json.dumps({"type": "response"}) + "\n"
             )
             store.upsert_run(
                 RunRecord(
@@ -229,6 +330,87 @@ class PoolSchedulerTest(unittest.TestCase):
             self.assertEqual(record.active_runs, {"beta": "run-beta"})
             self.assertFalse(record.attempts[0].usable)
             self.assertIn("sync failed", record.attempts[0].reason)
+
+    def test_step_pool_cleans_remote_containers_before_refilling_slot(self) -> None:
+        """Guards this PR against refilling a pool slot before remote Docker cleanup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            store = StateStore(root / "state")
+            finished_dir = root / "finished"
+            trial = finished_dir / "alpha__001"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "n_input_tokens": 12,
+                            "n_output_tokens": 3,
+                            "total_tokens": 15,
+                        },
+                    }
+                )
+            )
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text("{}\n")
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text("{}\n")
+            store.upsert_run(
+                RunRecord(
+                    id="run-alpha",
+                    status="completed",
+                    config=ExperimentConfig(name="alpha", run_target="gcp_ssh"),
+                    jobs_dir=str(finished_dir),
+                    log_path=str(root / "alpha.log"),
+                    command=[],
+                    remote_jobs_dir="/remote/alpha",
+                    synced_at="synced",
+                )
+            )
+            store.upsert_pool(
+                PoolRecord(
+                    id="pool-1",
+                    status="running",
+                    config=ExperimentConfig(name="test", run_target="local", concurrency=1),
+                    capacity=1,
+                    queue=["beta"],
+                    active_runs={"alpha": "run-alpha"},
+                )
+            )
+            events: list[str] = []
+
+            def fake_cleanup(run: RunRecord) -> None:
+                events.append(f"cleanup:{run.id}")
+
+            def fake_start_run(config: ExperimentConfig, store: StateStore) -> RunRecord:
+                events.append(f"start:{config.include_tasks[0]}")
+                run = RunRecord(
+                    id="run-beta",
+                    status="running",
+                    config=config,
+                    jobs_dir=str(root / "beta"),
+                    log_path=str(root / "beta.log"),
+                    command=[],
+                    selected_tasks=["beta"],
+                )
+                store.upsert_run(run)
+                return run
+
+            original_cleanup = pool.cleanup_remote_run_containers
+            original_start_run = pool.start_run
+            try:
+                pool.cleanup_remote_run_containers = fake_cleanup
+                pool.start_run = fake_start_run
+                record = pool.step_pool("pool-1", store)
+            finally:
+                pool.cleanup_remote_run_containers = original_cleanup
+                pool.start_run = original_start_run
+
+            self.assertIsNotNone(record)
+            self.assertEqual(events, ["cleanup:run-alpha", "start:beta"])
+            self.assertEqual(record.active_runs, {"beta": "run-beta"})
 
 
 if __name__ == "__main__":

--- a/current-projects/benchflow-experiment-control/tests/test_sheet_pool.py
+++ b/current-projects/benchflow-experiment-control/tests/test_sheet_pool.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app import sheet_pool
+from app.models import ExperimentConfig, PoolClaim, PoolRecord, RunRecord
+from app.store import StateStore
+
+
+class FakeQueue:
+    def __init__(self, config: ExperimentConfig):
+        self.config = config
+
+    def claim_distinct_tasks(self, count: int, pool_id: str) -> list[PoolClaim]:
+        return [
+            PoolClaim(id=f"{pool_id}-2-1", task_name="alpha", sheet_row=2, sheet_slot=1),
+            PoolClaim(id=f"{pool_id}-3-1", task_name="beta", sheet_row=3, sheet_slot=1),
+        ][:count]
+
+    def release_claims(self, claims: list[PoolClaim]) -> None:
+        return None
+
+    def write_final_result(self, claim: PoolClaim, audit) -> None:
+        return None
+
+    def write_missing_result(self, claim: PoolClaim, reason: str) -> None:
+        return None
+
+
+class NoClaimsQueue(FakeQueue):
+    def claim_distinct_tasks(self, count: int, pool_id: str) -> list[PoolClaim]:
+        return []
+
+
+class SheetPoolTest(unittest.TestCase):
+    def test_sheet_pool_starts_one_isolated_run_per_claimed_slot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tasks = root / "tasks"
+            tasks.mkdir()
+            store = StateStore(root / "state")
+            started: list[RunRecord] = []
+
+            def fake_start_run(config: ExperimentConfig, store: StateStore) -> RunRecord:
+                task = config.include_tasks[0]
+                run = RunRecord(
+                    id=f"run-{task}",
+                    status="running",
+                    config=config,
+                    jobs_dir=str(root / "jobs" / task),
+                    log_path=str(root / f"{task}.log"),
+                    command=[],
+                    selected_tasks=config.include_tasks,
+                )
+                store.upsert_run(run)
+                started.append(run)
+                return run
+
+            original_queue = sheet_pool.SheetQueue
+            original_start_run = sheet_pool.start_run
+            try:
+                sheet_pool.SheetQueue = FakeQueue
+                sheet_pool.start_run = fake_start_run
+                record = sheet_pool.start_sheet_pool(
+                    ExperimentConfig(
+                        name="sheet",
+                        run_target="local",
+                        benchflow_root=str(root),
+                        tasks_dir=str(tasks),
+                        sheet_id="sheet",
+                        concurrency=2,
+                    ),
+                    store,
+                )
+            finally:
+                sheet_pool.SheetQueue = original_queue
+                sheet_pool.start_run = original_start_run
+
+            self.assertEqual(record.source, "sheet")
+            self.assertEqual(set(record.active_runs.values()), {"run-alpha", "run-beta"})
+            self.assertEqual([run.config.concurrency for run in started], [1, 1])
+            self.assertEqual([run.config.include_tasks for run in started], [["alpha"], ["beta"]])
+
+    def test_sheet_pool_finalizes_completed_claims_with_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / "jobs"
+            trial = run_dir / "2026-01-01__00-00-00" / "alpha__abc"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rollout_name": "alpha__abc",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "n_input_tokens": 8,
+                            "n_output_tokens": 4,
+                            "total_tokens": 12,
+                        },
+                    }
+                )
+            )
+            (trial / "config.json").write_text("{}")
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text("{}\n")
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text("{}\n")
+            store = StateStore(root / "state")
+            store.upsert_run(
+                RunRecord(
+                    id="run-alpha",
+                    status="completed",
+                    config=ExperimentConfig(name="run", run_target="local"),
+                    jobs_dir=str(run_dir),
+                    log_path=str(root / "run.log"),
+                    command=[],
+                    started_at="start",
+                    finished_at="finish",
+                )
+            )
+            store.upsert_pool(
+                PoolRecord(
+                    id="pool",
+                    status="running",
+                    source="sheet",
+                    config=ExperimentConfig(name="sheet", run_target="local", sheet_id="sheet"),
+                    capacity=1,
+                    active_runs={"alpha": "run-alpha"},
+                    active_claims=[
+                        PoolClaim(id="claim", task_name="alpha", sheet_row=2, sheet_slot=1, run_id="run-alpha")
+                    ],
+                )
+            )
+
+            original_queue = sheet_pool.SheetQueue
+            original_start_run = sheet_pool.start_run
+            try:
+                sheet_pool.SheetQueue = NoClaimsQueue
+                sheet_pool.start_run = lambda config, store: (_ for _ in ()).throw(AssertionError("no refill"))
+                record = sheet_pool.step_sheet_pool("pool", store)
+            finally:
+                sheet_pool.SheetQueue = original_queue
+                sheet_pool.start_run = original_start_run
+
+            self.assertIsNotNone(record)
+            self.assertEqual(record.active_claims, [])
+            self.assertEqual(len(record.attempts), 1)
+            self.assertTrue(record.attempts[0].usable)
+            self.assertTrue((trial / "benchflow-experiment-manifest.json").is_file())
+
+    def test_sheet_pool_cleans_completed_remote_slot_before_refill(self) -> None:
+        """Guards this PR against refilling a sheet pool slot before Docker cleanup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / "jobs"
+            trial = run_dir / "2026-01-01__00-00-00" / "alpha__abc"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rollout_name": "alpha__abc",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "n_input_tokens": 8,
+                            "n_output_tokens": 4,
+                            "total_tokens": 12,
+                        },
+                    }
+                )
+            )
+            (trial / "config.json").write_text("{}")
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text("{}\n")
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text("{}\n")
+            store = StateStore(root / "state")
+            store.upsert_run(
+                RunRecord(
+                    id="run-alpha",
+                    status="completed",
+                    config=ExperimentConfig(name="run", run_target="gcp_ssh"),
+                    jobs_dir=str(run_dir),
+                    log_path=str(root / "run.log"),
+                    command=[],
+                    remote_jobs_dir="/remote/jobs",
+                    synced_at="synced",
+                )
+            )
+            store.upsert_pool(
+                PoolRecord(
+                    id="pool",
+                    status="running",
+                    source="sheet",
+                    config=ExperimentConfig(name="sheet", run_target="local", sheet_id="sheet"),
+                    capacity=1,
+                    active_runs={"alpha": "run-alpha"},
+                    active_claims=[
+                        PoolClaim(id="claim", task_name="alpha", sheet_row=2, sheet_slot=1, run_id="run-alpha")
+                    ],
+                )
+            )
+            events: list[str] = []
+
+            class RefillQueue(NoClaimsQueue):
+                def claim_distinct_tasks(self, count: int, pool_id: str) -> list[PoolClaim]:
+                    events.append(f"claim:{count}")
+                    return [
+                        PoolClaim(id=f"{pool_id}-3-1", task_name="beta", sheet_row=3, sheet_slot=1)
+                    ][:count]
+
+                def write_final_result(self, claim: PoolClaim, audit) -> None:
+                    events.append(f"sheet:{claim.task_name}")
+
+            def fake_cleanup(run: RunRecord) -> None:
+                events.append(f"cleanup:{run.id}")
+
+            def fake_start_run(config: ExperimentConfig, store: StateStore) -> RunRecord:
+                events.append(f"start:{config.include_tasks[0]}")
+                run = RunRecord(
+                    id=f"run-{config.include_tasks[0]}",
+                    status="running",
+                    config=config,
+                    jobs_dir=str(root / "refill"),
+                    log_path=str(root / "refill.log"),
+                    command=[],
+                    selected_tasks=config.include_tasks,
+                )
+                store.upsert_run(run)
+                return run
+
+            original_queue = sheet_pool.SheetQueue
+            original_cleanup = sheet_pool.cleanup_remote_run_containers
+            original_start_run = sheet_pool.start_run
+            try:
+                sheet_pool.SheetQueue = RefillQueue
+                sheet_pool.cleanup_remote_run_containers = fake_cleanup
+                sheet_pool.start_run = fake_start_run
+                record = sheet_pool.step_sheet_pool("pool", store)
+            finally:
+                sheet_pool.SheetQueue = original_queue
+                sheet_pool.cleanup_remote_run_containers = original_cleanup
+                sheet_pool.start_run = original_start_run
+
+            self.assertIsNotNone(record)
+            self.assertEqual(events, ["cleanup:run-alpha", "sheet:alpha", "claim:1", "start:beta"])
+            self.assertEqual([claim.task_name for claim in record.active_claims], ["beta"])
+
+    def test_sheet_pool_keeps_slot_active_when_remote_cleanup_fails(self) -> None:
+        """Guards this PR against freeing a sheet pool slot after failed Docker cleanup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / "jobs"
+            trial = run_dir / "2026-01-01__00-00-00" / "alpha__abc"
+            (trial / "trajectory").mkdir(parents=True)
+            (trial / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "alpha",
+                        "rollout_name": "alpha__abc",
+                        "rewards": {"reward": 1.0},
+                        "trajectory_source": "acp",
+                        "partial_trajectory": False,
+                        "agent_result": {
+                            "usage_source": "provider_response",
+                            "n_input_tokens": 8,
+                            "n_output_tokens": 4,
+                            "total_tokens": 12,
+                        },
+                    }
+                )
+            )
+            (trial / "config.json").write_text("{}")
+            (trial / "trajectory" / "acp_trajectory.jsonl").write_text("{}\n")
+            (trial / "trajectory" / "llm_trajectory.jsonl").write_text("{}\n")
+            store = StateStore(root / "state")
+            store.upsert_run(
+                RunRecord(
+                    id="run-alpha",
+                    status="completed",
+                    config=ExperimentConfig(name="run", run_target="gcp_ssh"),
+                    jobs_dir=str(run_dir),
+                    log_path=str(root / "run.log"),
+                    command=[],
+                    remote_jobs_dir="/remote/jobs",
+                    synced_at="synced",
+                )
+            )
+            store.upsert_pool(
+                PoolRecord(
+                    id="pool",
+                    status="running",
+                    source="sheet",
+                    config=ExperimentConfig(name="sheet", run_target="local", sheet_id="sheet"),
+                    capacity=1,
+                    active_runs={"alpha": "run-alpha"},
+                    active_claims=[
+                        PoolClaim(id="claim", task_name="alpha", sheet_row=2, sheet_slot=1, run_id="run-alpha")
+                    ],
+                )
+            )
+            events: list[str] = []
+
+            class ObservedQueue(NoClaimsQueue):
+                def write_final_result(self, claim: PoolClaim, audit) -> None:
+                    events.append(f"sheet:{claim.task_name}")
+
+            def failed_cleanup(run: RunRecord) -> None:
+                events.append(f"cleanup:{run.id}")
+                raise RuntimeError("cleanup failed")
+
+            original_queue = sheet_pool.SheetQueue
+            original_cleanup = sheet_pool.cleanup_remote_run_containers
+            original_start_run = sheet_pool.start_run
+            try:
+                sheet_pool.SheetQueue = ObservedQueue
+                sheet_pool.cleanup_remote_run_containers = failed_cleanup
+                sheet_pool.start_run = lambda config, store: (_ for _ in ()).throw(AssertionError("no refill"))
+                with self.assertRaisesRegex(RuntimeError, "cleanup failed"):
+                    sheet_pool.step_sheet_pool("pool", store)
+            finally:
+                sheet_pool.SheetQueue = original_queue
+                sheet_pool.cleanup_remote_run_containers = original_cleanup
+                sheet_pool.start_run = original_start_run
+
+            record = store.get_pool("pool")
+            self.assertIsNotNone(record)
+            self.assertEqual(events, ["cleanup:run-alpha"])
+            self.assertEqual([claim.task_name for claim in record.active_claims], ["alpha"])
+            self.assertEqual(record.attempts, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/current-projects/benchflow-experiment-control/tests/test_sheet_queue.py
+++ b/current-projects/benchflow-experiment-control/tests/test_sheet_queue.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from datetime import datetime, timedelta
+
+from app.health import TrialAudit
+from app.models import ExperimentConfig, PoolClaim
+from app.sheet_queue import DEFAULT_SHEET_ID, SheetQueue, SheetTable, a1_column, final_slot_values
+
+
+HEADERS = [
+    "hf_pr",
+    "task_id",
+    "configuration",
+    "model_display",
+    "model_slug",
+    "model_group",
+    "provider",
+    "agent",
+    "mode",
+    "environment",
+    "vm",
+    "run_family",
+    "run_state",
+    "concurrency",
+    "usable_trials",
+    "missing_usable_trials",
+    "infra_excluded_count",
+    "mean_reward_usable",
+]
+RUN_FIELDS = [
+    "trial_id",
+    "pass_slot",
+    "attempt_kind",
+    "reward",
+    "status_raw",
+    "status_for_analysis",
+    "pass_fail_timeout",
+    "error_category",
+    "is_infra_error",
+    "is_usable_for_analysis",
+    "has_trajectory",
+    "trajectory_events",
+    "n_tool_calls",
+    "tool_call_completed",
+    "tool_call_failed",
+    "tool_kinds",
+    "skill_launch_count",
+    "skill_names_seen",
+    "started_at",
+    "finished_at",
+    "environment_setup_s",
+    "agent_setup_s",
+    "agent_execution_s",
+    "verifier_s",
+    "total_s",
+    "usage",
+    "token_usage",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "total_tokens",
+    "usage_source",
+    "price_source",
+    "priced_at",
+    "total_cost_usd",
+    "result_path",
+    "trajectory_path",
+    "trajectory_vm_path",
+    "config_path",
+]
+for slot in range(1, 6):
+    HEADERS.extend(f"run_{slot}_{field}" for field in RUN_FIELDS)
+for slot in range(1, 6):
+    HEADERS.extend([f"run_{slot}_hf_trial_url", f"run_{slot}_vm_trial_path"])
+
+
+class FakeSheetClient:
+    def __init__(self, values: list[list[str]]):
+        self.values = values
+        self.updates: list[tuple[str, list[list[str]]]] = []
+
+    def read_values(self, spreadsheet_id: str, range_name: str) -> list[list[str]]:
+        return self.values
+
+    def batch_update_values(self, spreadsheet_id: str, updates):
+        self.updates.extend(updates)
+        for range_name, values in updates:
+            match = re.search(r"!([A-Z]+)([0-9]+):", range_name)
+            if not match:
+                continue
+            col = column_number(match.group(1)) - 1
+            row = int(match.group(2)) - 1
+            while len(self.values) <= row:
+                self.values.append([])
+            while len(self.values[row]) <= col:
+                self.values[row].append("")
+            self.values[row][col] = values[0][0]
+
+
+def column_number(name: str) -> int:
+    value = 0
+    for char in name:
+        value = value * 26 + ord(char) - 64
+    return value
+
+
+class SheetQueueTest(unittest.TestCase):
+    def test_a1_column_handles_sheet_end(self) -> None:
+        self.assertEqual(a1_column(1), "A")
+        self.assertEqual(a1_column(26), "Z")
+        self.assertEqual(a1_column(27), "AA")
+        self.assertEqual(a1_column(228), "HT")
+
+    def test_imported_status_tab_is_not_a_writable_queue_target(self) -> None:
+        """Guards this PR against overwriting IMPORTRANGE formulas in the shared sheet."""
+        with self.assertRaisesRegex(ValueError, "IMPORTRANGE view"):
+            SheetQueue(
+                ExperimentConfig(
+                    name="test",
+                    sheet_id=DEFAULT_SHEET_ID,
+                    sheet_tab="PR2_PR3_HF_VM_Clean5",
+                ),
+                FakeSheetClient([HEADERS]),
+            )
+
+    def test_available_slots_skip_existing_usable_trials(self) -> None:
+        row = ["", "alpha", "openhands__m__without-skills"] + [""] * (len(HEADERS) - 3)
+        row[HEADERS.index("run_1_is_usable_for_analysis")] = "TRUE"
+        row[HEADERS.index("run_2_status_raw")] = "bfec_invalid"
+        table = SheetTable.from_values("Sheet1", [HEADERS, row])
+
+        slots = table.slots_for_configuration("openhands__m__without-skills")
+        available = [
+            slot.slot
+            for slot in slots
+            if slot.is_available(datetime.now().astimezone(), timedelta(minutes=10))
+        ]
+
+        self.assertEqual(available, [2, 3, 4, 5])
+
+    def test_available_slots_rank_empty_before_replacing_invalid_slots(self) -> None:
+        row = ["", "alpha", "openhands__m__without-skills"] + [""] * (len(HEADERS) - 3)
+        row[HEADERS.index("run_1_status_raw")] = "bfec_invalid"
+        values = [HEADERS, row]
+        queue = SheetQueue(
+            ExperimentConfig(
+                name="test",
+                agent="openhands",
+                model="m",
+                skills_profile="without-skills",
+                sheet_id="sheet",
+            ),
+            FakeSheetClient(values),
+        )
+
+        slots = queue.available_slots()
+
+        self.assertEqual([slot.slot for slot in slots], [2, 3, 4, 5, 1])
+
+    def test_available_slots_skip_fresh_running_claims(self) -> None:
+        row = ["", "alpha", "openhands__m__without-skills"] + [""] * (len(HEADERS) - 3)
+        row[HEADERS.index("run_1_trial_id")] = "alpha__other-pool"
+        row[HEADERS.index("run_1_status_raw")] = "running"
+        row[HEADERS.index("run_1_started_at")] = datetime.now().astimezone().isoformat()
+        table = SheetTable.from_values("Sheet1", [HEADERS, row])
+
+        slots = table.slots_for_configuration("openhands__m__without-skills")
+        available = [
+            slot.slot
+            for slot in slots
+            if slot.is_available(datetime.now().astimezone(), timedelta(minutes=240))
+        ]
+
+        self.assertEqual(available, [2, 3, 4, 5])
+
+    def test_claim_distinct_tasks_writes_existing_slot_columns(self) -> None:
+        values = [
+            HEADERS,
+            ["", "alpha", "openhands__m__without-skills"] + [""] * (len(HEADERS) - 3),
+            ["", "alpha", "openhands__m__without-skills"] + [""] * (len(HEADERS) - 3),
+            ["", "beta", "openhands__m__without-skills"] + [""] * (len(HEADERS) - 3),
+        ]
+        client = FakeSheetClient(values)
+        queue = SheetQueue(
+            ExperimentConfig(
+                name="test",
+                agent="openhands",
+                model="m",
+                skills_profile="without-skills",
+                sheet_id="sheet",
+            ),
+            client,
+        )
+
+        claims = queue.claim_distinct_tasks(2, "pool")
+
+        self.assertEqual([claim.task_name for claim in claims], ["alpha", "beta"])
+        ranges = [item[0] for item in client.updates]
+        self.assertIn("PR2_PR3_HF_VM_Clean5!S2:S2", ranges)
+        self.assertIn("PR2_PR3_HF_VM_Clean5!W2:W2", ranges)
+        self.assertIn("PR2_PR3_HF_VM_Clean5!S4:S4", ranges)
+
+    def test_final_slot_values_include_usage_and_health_verdict(self) -> None:
+        audit = TrialAudit(
+            task_name="alpha",
+            trial_name="alpha__abc",
+            usable=True,
+            verdict="usable",
+            reason="",
+            reward=1.0,
+            outcome="pass",
+            status_raw="pass",
+            error="",
+            error_category="",
+            verifier_error="",
+            total_tokens=30,
+            input_tokens=20,
+            output_tokens=10,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+            usage_source="provider_response",
+            price_source="litellm",
+            total_cost_usd=0.01,
+            acp_trajectory_events=4,
+            llm_trajectory_events=2,
+            n_tool_calls=3,
+            n_skill_invocations=0,
+            started_at="start",
+            finished_at="finish",
+            timing={"total": 12.0},
+            result_path="run/alpha/result.json",
+            config_path="run/alpha/config.json",
+            acp_trajectory_path="run/alpha/trajectory/acp_trajectory.jsonl",
+            llm_trajectory_path="run/alpha/trajectory/llm_trajectory.jsonl",
+            trial_path="run/alpha",
+        )
+
+        values = final_slot_values(PoolClaim("claim", "alpha", 2, 1), audit)
+
+        self.assertEqual(values["run_1_is_usable_for_analysis"], "TRUE")
+        self.assertEqual(values["run_1_total_tokens"], 30)
+        self.assertEqual(json.loads(values["run_1_token_usage"])["output_tokens"], 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add sheet-backed pool scheduling that claims existing `run_N_*` slots, launches one isolated task run per slot, and writes final results back to the same existing sheet slot
- archive per-trial manifests with artifact hashes and stricter trajectory/token usage health checks
- enforce the pool invariant: a completed remote slot is synced, its Docker containers are cleaned, and only after cleanup succeeds does the manager write the final sheet result and refill that slot
- refuse the shared status sheet's IMPORTRANGE-backed `PR2_PR3_HF_VM_Clean5` tab as a writable queue target; sheet-backed runs must point at the writable source tab

## Thermo-nuclear review
- kept sheet queueing, finalization, health audit, and remote cleanup concerns in focused functions/modules
- no Python file crosses 1k lines; largest file is `app/sheet_queue.py`
- avoided writing any new sheet format; sheet-backed mode only uses existing `run_N_*` columns

## Tests
- `make test`
