### PR TITLE
Parallelize remote pool polling

### DIFF
--- a/current-projects/benchflow-experiment-control/app/runner.py
+++ b/current-projects/benchflow-experiment-control/app/runner.py
@@ -5,6 +5,7 @@ import posixpath
 import shlex
 import signal
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from .task_selection import prepare_local_task_selection
 
 
 _PROCESSES: dict[str, subprocess.Popen] = {}
+REMOTE_REFRESH_WORKERS = 32
 
 
 def parse_env_file(path: str) -> dict[str, str]:
@@ -175,20 +177,50 @@ def start_remote_run(
 
 
 def refresh_processes(store: StateStore) -> None:
-    for run in store.list_runs():
-        if run.status == "running" and run.config.run_target == "gcp_ssh":
-            return_code = read_remote_exit_code(run)
-            if return_code is None:
-                continue
-            run = store.update_run(
-                run.id,
-                status="completed" if return_code == 0 else "failed",
-                return_code=return_code,
-                finished_at=now_iso(),
-            )
-            if run is not None:
-                sync_finished_remote_run(run, store)
-        elif (
+    runs = store.list_runs()
+    refresh_running_remote_runs(runs, store)
+    refresh_finished_remote_runs(store.list_runs(), store)
+    refresh_local_processes(store)
+
+
+def refresh_running_remote_runs(runs: list[RunRecord], store: StateStore) -> None:
+    running = [
+        run
+        for run in runs
+        if run.status == "running" and run.config.run_target == "gcp_ssh"
+    ]
+    for run_id, return_code in read_remote_exit_codes(running).items():
+        if return_code is None:
+            continue
+        run = store.update_run(
+            run_id,
+            status="completed" if return_code == 0 else "failed",
+            return_code=return_code,
+            finished_at=now_iso(),
+        )
+        if run is not None:
+            sync_finished_remote_run(run, store)
+
+
+def read_remote_exit_codes(runs: list[RunRecord]) -> dict[str, int | None]:
+    if not runs:
+        return {}
+    worker_count = min(REMOTE_REFRESH_WORKERS, len(runs))
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = {executor.submit(read_remote_exit_code, run): run.id for run in runs}
+        exit_codes: dict[str, int | None] = {}
+        for future in as_completed(futures):
+            run_id = futures[future]
+            try:
+                exit_codes[run_id] = future.result()
+            except Exception:
+                exit_codes[run_id] = None
+    return exit_codes
+
+
+def refresh_finished_remote_runs(runs: list[RunRecord], store: StateStore) -> None:
+    for run in runs:
+        if (
             run.config.run_target == "gcp_ssh"
             and run.status in {"completed", "failed", "stopped"}
             and not run.synced_at
@@ -196,6 +228,8 @@ def refresh_processes(store: StateStore) -> None:
         ):
             sync_finished_remote_run(run, store)
 
+
+def refresh_local_processes(store: StateStore) -> None:
     for run_id, process in list(_PROCESSES.items()):
         return_code = process.poll()
         if return_code is None:

--- a/current-projects/benchflow-experiment-control/tests/test_runner.py
+++ b/current-projects/benchflow-experiment-control/tests/test_runner.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from app import runner
+from app.models import ExperimentConfig, RunRecord, now_iso
+from app.store import StateStore
+
+
+class RunnerRefreshTest(unittest.TestCase):
+    def test_remote_exit_polling_runs_in_parallel(self) -> None:
+        """Guards this PR against serial SSH polling across active remote pool slots."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store = StateStore(Path(tmp) / "state")
+            for index in range(2):
+                store.upsert_run(remote_run(f"run-{index}"))
+            barrier = threading.Barrier(2, timeout=1)
+            overlapped: list[bool] = []
+
+            def fake_read_exit_code(run: RunRecord) -> int | None:
+                try:
+                    barrier.wait()
+                except threading.BrokenBarrierError:
+                    overlapped.append(False)
+                else:
+                    overlapped.append(True)
+                return None
+
+            original = runner.read_remote_exit_code
+            try:
+                runner.read_remote_exit_code = fake_read_exit_code
+                runner.refresh_processes(store)
+            finally:
+                runner.read_remote_exit_code = original
+
+            self.assertEqual(overlapped, [True, True])
+
+    def test_remote_exit_polling_ignores_transient_poll_errors(self) -> None:
+        """Guards this PR against one SSH polling failure blocking other completed runs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store = StateStore(Path(tmp) / "state")
+            store.upsert_run(remote_run("ok"))
+            store.upsert_run(remote_run("poll-error"))
+            synced: list[str] = []
+
+            def fake_read_exit_code(run: RunRecord) -> int | None:
+                if run.id == "poll-error":
+                    raise RuntimeError("ssh unavailable")
+                return 0
+
+            def fake_sync_finished_run(run: RunRecord, store: StateStore) -> None:
+                synced.append(run.id)
+                store.update_run(run.id, synced_at=now_iso(), sync_error=None)
+
+            original_read = runner.read_remote_exit_code
+            original_sync = runner.sync_finished_remote_run
+            try:
+                runner.read_remote_exit_code = fake_read_exit_code
+                runner.sync_finished_remote_run = fake_sync_finished_run
+                runner.refresh_processes(store)
+            finally:
+                runner.read_remote_exit_code = original_read
+                runner.sync_finished_remote_run = original_sync
+
+            self.assertEqual(store.get_run("ok").status, "completed")
+            self.assertEqual(store.get_run("poll-error").status, "running")
+            self.assertEqual(synced, ["ok"])
+
+
+def remote_run(run_id: str) -> RunRecord:
+    return RunRecord(
+        id=run_id,
+        status="running",
+        config=ExperimentConfig(name=run_id, run_target="gcp_ssh"),
+        jobs_dir="/local/jobs",
+        log_path="/local/run.log",
+        command=[],
+        remote_jobs_dir=f"/remote/jobs/{run_id}",
+        remote_exit_code_path=f"/remote/jobs/{run_id}/exit-code.txt",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- parallelize remote exit-code polling for GCP SSH runs so large pools do not serialize one SSH check per active slot
- keep transient polling failures isolated to the affected run while other completed runs can still sync/finalize

## Thermo-nuclear review
- extracted polling into focused functions in `runner.py` instead of adding more branches inside `refresh_processes`
- no file crosses 1k lines; `runner.py` remains small and focused

## Tests
- `make test`
- `python3 -m app.cli --data-dir <tmp> state`
- Dashboard HTTP smoke on `http://127.0.0.1:8766/` and `/api/defaults`

## Live E2E status
- Kept as draft because the requested live Daytona validation for `openhands + deepseek-v4-flash + without-skills` is blocked by the provider proxy model list: `deepseek-v4-flash` currently has zero exposed model IDs.
