### PR TITLE
personal-site: add 8 new X posts (May 30 batch)

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,61 @@
 [
   {
+    "id": "x-2060439802315772024",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060439802315772024",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060455372507508787",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060455372507508787",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060458209933131969",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060458209933131969",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060506420177772744",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060506420177772744",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060591705406279733",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060591705406279733",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060504157900218615",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060504157900218615",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060397944336241140",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060397944336241140",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060454440507986225",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060454440507986225",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2060242019818377264",
     "platform": "x",
     "url": "https://x.com/xdotli/status/2060242019818377264",
@@ -115,20 +171,6 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2058795406990155861",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2058795406990155861",
-    "date": "2026-05-24",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2058313859551908235",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2058313859551908235",
-    "date": "2026-05-23",
-    "addedVia": "manual"
-  },
-  {
     "id": "x-2058982303104401576",
     "platform": "x",
     "url": "https://x.com/bingran_bry/status/2058982303104401576",
@@ -189,6 +231,20 @@
     "platform": "x",
     "url": "https://x.com/xdotli/status/2058637883351921108",
     "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058795406990155861",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2058795406990155861",
+    "date": "2026-05-24",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058313859551908235",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2058313859551908235",
+    "date": "2026-05-23",
     "addedVia": "manual"
   },
   {


### PR DESCRIPTION
## Summary
- Add 8 X posts published since the previous batch (PR #299): 3 from `@bingran_bry`, 5 from `@xdotli`.
- All dated `2026-05-30` (China time).
- Existing `2026-05-23` / `2026-05-24` entries got reshuffled into chronological position by the sort step; net diff is +8 logical entries.

## Tweets added
- bingran_bry: 2060455372507508787, 2060454440507986225, 2060439802315772024
- xdotli: 2060591705406279733, 2060506420177772744, 2060504157900218615, 2060458209933131969, 2060397944336241140

## XHS status
- Skipped this round: this Chrome profile is not signed into XHS, and Bingran's XHS profile id was not on file for an autonomous read. The 5af50aa…6251f9 reference cached in `bingran-you-private/chatgpt-history` belongs to a different user (`池绿山`). When the canonical id is provided / observer account set up, the next run can include XHS adds.

## Test plan
- [x] `npm run post:add` for each URL completed cleanly; placeholder `title: "(untitled)"` stripped to match canonical X-platform shape (id / url / date / addedVia only).
- [ ] Vercel preview renders the 8 new cards via `react-tweet`.