### PR TITLE
personal-site: add X post (2026-06-06)

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "x-2063153864539615473",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2063153864539615473",
+    "title": "(untitled)",
+    "date": "2026-06-06",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2062572336356925602",
     "platform": "x",
     "url": "https://x.com/bingran_bry/status/2062572336356925602",


### PR DESCRIPTION
## Summary

One new post since the last sweep:
- **`x-2063153864539615473`** (2026-06-06) — react-tweet renders text/media at request time.

XHS profile checked via Chrome MCP — top 10 tiles match `posts.json` head; latest XHS note (2026-05-31, `再过一年之后会变成什么样子？`) is already on the site. Nothing new there.

## Test plan
- [x] Diff is exactly `+8 / -0` in `posts.json`
- [x] No regenerated `skills.generated.json` / `skill-files/*.md` collateral
- [x] Card renders via `<Tweet id={id}>` server-side (no thumbnail file needed)