### PR TITLE
personal-site: add 2026-06-09 X post

### DIFF
--- a/memory/2026-06-09.md
+++ b/memory/2026-06-09.md
@@ -1,0 +1,22 @@
+# 2026-06-09
+
+## Scheduled workspace + posts sweep ([PR #348](https://github.com/bingran-you/bingran-you/pull/348), merged · [PR #349](https://github.com/bingran-you/bingran-you/pull/349))
+
+### Submodule + skills bumps (PR #348)
+- `trusted-external-repos/open-design` e660832 → add6c05b (5 commits — project back-button to home, plugin preview new-tab assets fix, AMR OpenCode bootstrap stderr filter, tools-dev telemetry local env, interrupt active run when sending queued chat).
+- `mattpocock-skills` `teach` skill moved upstream from `in-progress/teach` → `productivity/teach`; `.agents/skills/teach` and `.claude/skills/teach` symlinks repointed by `make sync`.
+- `gstack` / `marketingskills` / `mattpocock-skills` submodule pointers already at configured-branch HEAD; no bump needed.
+- `make sync` regenerated mirrors — skill count stays at 305. Per-file deltas in `personal-site/public/skill-files/*.md` were mostly upstream gstack body refreshes a prior generator run hadn't picked up (e.g. "Boil the Lake" → "Boil the Ocean" wording fix in `gstack.md`).
+
+### /posts adds (PR #349)
+- `x-2064172442256318784` (2026-06-09) — bingran_bry quote of @xdotli. Picked up by Chrome MCP scan of `https://x.com/search?q=from%3Abingran_bry%20-filter%3Areplies&f=live` on Browser 1 (the X-logged-in profile).
+- XHS @bingran.ai sweep: latest note on profile is still `6a245451` (2026-06-06), already in `posts.json`. No XHS delta this round. Used the "Laptop" Chrome browser for XHS (Browser 1 isn't logged into XHS; Laptop is).
+
+### Workflow notes for future-me
+- **Browser map (2026-06-09):**
+  - Browser 1 (`14fa2aac-c4d5-4d3f-8031-41744dd02990`) → logged into X as `@bingran_bry`. Not logged into XHS.
+  - Laptop (`20636fdd-9b8e-460c-822b-d50274eb93ab`) → logged into XHS (creator-center nav visible, profile-page title resolves to `Bingran.ai - 小红书`).
+- **XHS profile URL:** `https://www.xiaohongshu.com/user/profile/60b2d6d00000000001006eb7` (Bingran's `Bingran.ai` account). Lifted from `a[href*="/user/profile/"]` on any owned note.
+- **`gh pr merge --squash --delete-branch` recurring snag:** still hits "main is already checked out at ~/Downloads/bingran-you" because the worktree under `Claude-Code-Worktree/` shares the same git dir. PR squash-merges on the GitHub side anyway; `git push origin --delete <branch>` cleans the remote afterward. Recurring pattern noted in [memory/2026-06-02.md](2026-06-02.md) and [memory/2026-05-31.md](2026-05-31.md).
+- **`add-post.mjs` resort-on-add inflates X-post diffs too** — adding one X stub re-shuffled 228 same-date neighbors. For one-off adds, do the inline `unshift` trick (load JSON, `arr.unshift(entry)`, write back) per the SKILL.md §3.7 note that previously only called out the XHS path. Worth lifting to SKILL.md as "applies to any platform" if it happens once more.
+- **Scheduled-task two-browser auto-pick:** the Chrome MCP `list_connected_browsers` response told the agent to call `AskUserQuestion` — but the user isn't present in a scheduled run. Tried Browser 1 first (X-logged-in but XHS-unauthenticated), then switched to Laptop for the XHS leg. Future scheduled runs can shortcut by reading this log: X → Browser 1, XHS → Laptop.

--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "x-2064172442256318784",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2064172442256318784",
+    "title": "(untitled)",
+    "date": "2026-06-09",
+    "addedVia": "manual"
+  },
+  {
     "id": "xhs-6a245451000000001603cee2",
     "platform": "xiaohongshu",
     "url": "https://www.xiaohongshu.com/explore/6a245451000000001603cee2?xsec_token=ABk49VwygJNzb6T7zSVZjBAnOV5DTcNyh6zqTfKpOhwbE=&xsec_source=pc_user",


### PR DESCRIPTION
## Summary

- Adds `x-2064172442256318784` (2026-06-09, bingran_bry quote of @xdotli) to `/posts`.
- Past-day social sweep also checked Xiaohongshu @bingran.ai profile: most recent note is still `6a245451` (2026-06-06), already in `posts.json`. No XHS delta this round.

Diff is +8/-0 (hand-prepended to avoid the script's resort-on-add inflation).

## Test plan

- [x] `npm run post:add` extracted X stub correctly (id-only; react-tweet renders the rest)
- [x] Vercel preview will render the card via react-tweet