### PR TITLE
Update personal dev stack references to Claude Code + Fable 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I build reliable AI systems and run trapped-ion experiments in atomic, molecular
 
 <p align="center">
   <img alt="Primary stack: Codex + GPT-5.5" src="https://img.shields.io/badge/Primary%20stack-Codex%20%2B%20GPT--5.5-111111?style=for-the-badge&logo=openai&logoColor=white" />
-  <img alt="Primary stack: Claude Code + Opus 4.7" src="https://img.shields.io/badge/Primary%20stack-Claude%20Code%20%2B%20Opus%204.7-D97706?style=for-the-badge&logo=anthropic&logoColor=white" />
+  <img alt="Primary stack: Claude Code + Fable 5" src="https://img.shields.io/badge/Primary%20stack-Claude%20Code%20%2B%20Fable%205-D97706?style=for-the-badge&logo=anthropic&logoColor=white" />
 </p>
 
 <p align="center">

--- a/USER.md
+++ b/USER.md
@@ -19,7 +19,7 @@ _The one you serve. Keep this living and current._
 
 ## Primary Stack
 
-- **AI work:** Codex + GPT-5.5 **and** Claude Code + Opus 4.7 as dual primaries — Codex for long-horizon autonomous runs, Claude Code for interactive pair work. Heavy prompt-cached workflows — 7-day avg ≈ 96K tokens/request, ~96% prompt. He cares about cache hit rate and cost discipline.
+- **AI work:** Codex + GPT-5.5 **and** Claude Code + Fable 5 as dual primaries — Codex for long-horizon autonomous runs, Claude Code for interactive pair work. Heavy prompt-cached workflows — 7-day avg ≈ 96K tokens/request, ~96% prompt. He cares about cache hit rate and cost discipline.
 - **Ion-trap work:** ARTIQ, laser control, RF engineering, UHV systems.
 
 ## Projects to Know

--- a/memory/2026-06-12.md
+++ b/memory/2026-06-12.md
@@ -1,0 +1,13 @@
+# 2026-06-12
+
+## Stack rename: Claude Code + Opus 4.7 → Claude Code + Fable 5
+
+- Bingran upgraded his Claude Code primary model to Fable 5 (`claude-fable-5`, Anthropic's latest). Updated every self-authored mention of "Claude Code + Opus 4.7":
+  - `README.md` — shields.io primary-stack badge (alt text + badge URL).
+  - `USER.md` — Primary Stack bullet.
+  - `personal-site/palace-inner/src/components/showcase/About.tsx` — "How I work" paragraph.
+- Intentionally left alone (not his authored content / out of scope):
+  - `personal-site/public/skill-files/{ship,document-generate}.md` + `personal-site/lib/skills.generated.json` — generated from `trusted-external-repos/gstack` skills (vendored external source; hand-editing generated copies would break `skills-sync-check` CI). Upstream fix belongs in the gstack repo + submodule bump.
+  - `papers/papers-in-zotero/**` (external papers mention Opus 4.1) and `personal-site/content/posts/posts.json` (archived XHS post about Opus 4.8) — historical/external content.
+  - `bingran-you-private/PRIVATE_MEMORY.md` may still say Opus 4.7 — private submodule not initialized in this remote session; needs a separate pass from a machine with submodule access.
+- Shipped via PR from `claude/confident-mccarthy-pn0br8`, squash-merged to `main`, branch deleted.

--- a/personal-site/palace-inner/src/components/showcase/About.tsx
+++ b/personal-site/palace-inner/src/components/showcase/About.tsx
@@ -58,7 +58,7 @@ const About: React.FC<AboutProps> = () => {
                 <br />
                 <p>
                     My day-to-day stack is heavy on AI: Codex (GPT-5.5) and
-                    Claude Code (Opus 4.7) running as dual primaries. Codex
+                    Claude Code (Fable 5) running as dual primaries. Codex
                     handles long-horizon autonomous runs; Claude Code is for
                     interactive pair work. A typical week I'm averaging ~96k
                     tokens per request with 96% prompt cache reuse — cache


### PR DESCRIPTION
## Summary

Upgrade every self-authored "Claude Code + Opus 4.7" reference to **Claude Code + Fable 5** (Anthropic's latest model).

## Changes

- **README.md** — primary-stack shields.io badge: alt text + badge URL now read `Claude Code + Fable 5`
- **USER.md** — Primary Stack bullet: dual primaries are now `Codex + GPT-5.5` and `Claude Code + Fable 5`
- **personal-site/palace-inner/src/components/showcase/About.tsx** — "How I work" paragraph on the site's About showcase page
- **memory/2026-06-12.md** — session log documenting the rename and what was deliberately left untouched

## Intentionally untouched

A repo-wide audit (`opus 4.7` / `opus-4-7` / `claude-opus` / `Claude Code +`, case-insensitive) found only vendored or historical occurrences outside the files above:

- `personal-site/public/skill-files/{ship,document-generate}.md` and `personal-site/lib/skills.generated.json` — generated copies of skills sourced from `trusted-external-repos/gstack`; hand-editing them would drift from the source and fail the `skills-sync-check` action. An upstream fix belongs in the gstack repo plus a submodule bump.
- `papers/papers-in-zotero/**` (external papers referencing Opus 4.1) and `personal-site/content/posts/posts.json` (archived social post) — external/historical content, not stack descriptions.

No skill sources changed, so no `make sync` regeneration is required.

https://claude.ai/code/session_01AeLbDFB7Eg7y5Ff2vXTUtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeLbDFB7Eg7y5Ff2vXTUtg)_