### PR TITLE
Temporarily hide token-usage stats across personal content

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ I build reliable AI systems and run trapped-ion experiments in atomic, molecular
   <img alt="Primary stack: Claude Code + Fable 5" src="https://img.shields.io/badge/Primary%20stack-Claude%20Code%20%2B%20Fable%205-D97706?style=for-the-badge&logo=anthropic&logoColor=white" />
 </p>
 
+<!-- Token-usage stats temporarily hidden (2026-06-12) pending fresh numbers on the new stack.
 <p align="center">
   <img alt="Requests 26.98K" src="https://img.shields.io/badge/Requests-26.98K-2F81F7?style=flat-square" />
   <img alt="Total tokens 2.61B" src="https://img.shields.io/badge/Total%20tokens-2.61B-1F883D?style=flat-square" />
@@ -23,6 +24,7 @@ I build reliable AI systems and run trapped-ion experiments in atomic, molecular
 <p align="center">
   <sub>Last 7 days · avg/request: 96,575 total · 95,980 prompt · 595 completion</sub>
 </p>
+-->
 
 ### Current Focus
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I build reliable AI systems and run trapped-ion experiments in atomic, molecular
 
 <p align="center">
   <img alt="Primary stack: Codex + GPT-5.5" src="https://img.shields.io/badge/Primary%20stack-Codex%20%2B%20GPT--5.5-111111?style=for-the-badge&logo=openai&logoColor=white" />
-  <img alt="Primary stack: Claude Code + Opus 4.7" src="https://img.shields.io/badge/Primary%20stack-Claude%20Code%20%2B%20Opus%204.7-D97706?style=for-the-badge&logo=anthropic&logoColor=white" />
+  <img alt="Primary stack: Claude Code + Fable 5" src="https://img.shields.io/badge/Primary%20stack-Claude%20Code%20%2B%20Fable%205-D97706?style=for-the-badge&logo=anthropic&logoColor=white" />
 </p>
 
 <p align="center">

--- a/USER.md
+++ b/USER.md
@@ -19,7 +19,7 @@ _The one you serve. Keep this living and current._
 
 ## Primary Stack
 
-- **AI work:** Codex + GPT-5.5 **and** Claude Code + Opus 4.7 as dual primaries — Codex for long-horizon autonomous runs, Claude Code for interactive pair work. Heavy prompt-cached workflows — 7-day avg ≈ 96K tokens/request, ~96% prompt. He cares about cache hit rate and cost discipline.
+- **AI work:** Codex + GPT-5.5 **and** Claude Code + Fable 5 as dual primaries — Codex for long-horizon autonomous runs, Claude Code for interactive pair work. Heavy prompt-cached workflows — 7-day avg ≈ 96K tokens/request, ~96% prompt. He cares about cache hit rate and cost discipline.
 - **Ion-trap work:** ARTIQ, laser control, RF engineering, UHV systems.
 
 ## Projects to Know

--- a/USER.md
+++ b/USER.md
@@ -19,7 +19,7 @@ _The one you serve. Keep this living and current._
 
 ## Primary Stack
 
-- **AI work:** Codex + GPT-5.5 **and** Claude Code + Fable 5 as dual primaries — Codex for long-horizon autonomous runs, Claude Code for interactive pair work. Heavy prompt-cached workflows — 7-day avg ≈ 96K tokens/request, ~96% prompt. He cares about cache hit rate and cost discipline.
+- **AI work:** Codex + GPT-5.5 **and** Claude Code + Fable 5 as dual primaries — Codex for long-horizon autonomous runs, Claude Code for interactive pair work. He cares about cache hit rate and cost discipline.
 - **Ion-trap work:** ARTIQ, laser control, RF engineering, UHV systems.
 
 ## Projects to Know

--- a/memory/2026-06-12.md
+++ b/memory/2026-06-12.md
@@ -1,0 +1,13 @@
+# 2026-06-12
+
+## Stack rename: Claude Code + Opus 4.7 → Claude Code + Fable 5
+
+- Bingran upgraded his Claude Code primary model to Fable 5 (`claude-fable-5`, Anthropic's latest). Updated every self-authored mention of "Claude Code + Opus 4.7":
+  - `README.md` — shields.io primary-stack badge (alt text + badge URL).
+  - `USER.md` — Primary Stack bullet.
+  - `personal-site/palace-inner/src/components/showcase/About.tsx` — "How I work" paragraph.
+- Intentionally left alone (not his authored content / out of scope):
+  - `personal-site/public/skill-files/{ship,document-generate}.md` + `personal-site/lib/skills.generated.json` — generated from `trusted-external-repos/gstack` skills (vendored external source; hand-editing generated copies would break `skills-sync-check` CI). Upstream fix belongs in the gstack repo + submodule bump.
+  - `papers/papers-in-zotero/**` (external papers mention Opus 4.1) and `personal-site/content/posts/posts.json` (archived XHS post about Opus 4.8) — historical/external content.
+  - `bingran-you-private/PRIVATE_MEMORY.md` may still say Opus 4.7 — private submodule not initialized in this remote session; needs a separate pass from a machine with submodule access.
+- Shipped via PR from `claude/confident-mccarthy-pn0br8`, squash-merged to `main`, branch deleted.

--- a/memory/2026-06-12.md
+++ b/memory/2026-06-12.md
@@ -10,4 +10,12 @@
   - `personal-site/public/skill-files/{ship,document-generate}.md` + `personal-site/lib/skills.generated.json` — generated from `trusted-external-repos/gstack` skills (vendored external source; hand-editing generated copies would break `skills-sync-check` CI). Upstream fix belongs in the gstack repo + submodule bump.
   - `papers/papers-in-zotero/**` (external papers mention Opus 4.1) and `personal-site/content/posts/posts.json` (archived XHS post about Opus 4.8) — historical/external content.
   - `bingran-you-private/PRIVATE_MEMORY.md` may still say Opus 4.7 — private submodule not initialized in this remote session; needs a separate pass from a machine with submodule access.
-- Shipped via PR from `claude/confident-mccarthy-pn0br8`, squash-merged to `main`, branch deleted.
+- Shipped via PR #358 from `claude/confident-mccarthy-pn0br8`, squash-merged to `main` (d04b7f5). Remote branch deletion was blocked by the cloud env's git proxy (403; push credential can't delete refs) and the GitHub MCP toolset exposes no delete-ref endpoint — needs a manual "Delete branch" click on the PR page (or enable auto-delete head branches in repo settings).
+
+## Token-usage stats temporarily hidden
+
+- Bingran asked to remove/comment out all token-consumption stats for now (stale after the model switch):
+  - `README.md` — the 7-day Requests / Total / Prompt / Completion badge row + avg/request line, wrapped in an HTML comment.
+  - `USER.md` — dropped the "7-day avg ≈ 96K tokens/request, ~96% prompt" clause; kept the cache-discipline preference.
+  - `personal-site/.../showcase/About.tsx` — the weekly ~96k tokens/request + 96% cache-reuse sentence, wrapped in a JSX comment.
+- Restore once fresh numbers accumulate on the new stack. `scripts/githuber.sh` (Rust tool; source not vendored in-repo) looks like the stats generator — re-running it would re-insert the README badges.

--- a/personal-site/palace-inner/src/components/showcase/About.tsx
+++ b/personal-site/palace-inner/src/components/showcase/About.tsx
@@ -60,9 +60,11 @@ const About: React.FC<AboutProps> = () => {
                     My day-to-day stack is heavy on AI: Codex (GPT-5.5) and
                     Claude Code (Fable 5) running as dual primaries. Codex
                     handles long-horizon autonomous runs; Claude Code is for
-                    interactive pair work. A typical week I'm averaging ~96k
-                    tokens per request with 96% prompt cache reuse — cache
-                    hit rate and cost discipline matter to me.
+                    interactive pair work.
+                    {/* Token-usage stats temporarily hidden (2026-06-12):
+                    "A typical week I'm averaging ~96k tokens per request
+                    with 96% prompt cache reuse — cache hit rate and cost
+                    discipline matter to me." */}
                 </p>
                 <br />
                 <p>

--- a/personal-site/palace-inner/src/components/showcase/About.tsx
+++ b/personal-site/palace-inner/src/components/showcase/About.tsx
@@ -58,7 +58,7 @@ const About: React.FC<AboutProps> = () => {
                 <br />
                 <p>
                     My day-to-day stack is heavy on AI: Codex (GPT-5.5) and
-                    Claude Code (Opus 4.7) running as dual primaries. Codex
+                    Claude Code (Fable 5) running as dual primaries. Codex
                     handles long-horizon autonomous runs; Claude Code is for
                     interactive pair work. A typical week I'm averaging ~96k
                     tokens per request with 96% prompt cache reuse — cache


### PR DESCRIPTION
## Summary

Follow-up to #358. The 7-day token-consumption stats predate the switch to Claude Code + Fable 5 and are now stale — hide them everywhere in self-authored content until fresh numbers accumulate on the new stack.

## Changes

- **README.md** — the Requests / Total tokens / Prompt tokens / Completion tokens badge row and the `Last 7 days · avg/request …` line are wrapped in an HTML comment (kept in place for easy restore; HTML comments don't render on GitHub profiles)
- **USER.md** — dropped the `7-day avg ≈ 96K tokens/request, ~96% prompt` clause from Primary Stack; the durable cache-discipline preference stays
- **personal-site About page** (`palace-inner/.../About.tsx`) — the weekly `~96k tokens per request / 96% prompt cache reuse` sentence is wrapped in a JSX comment
- **memory/2026-06-12.md** — session log; also corrects the earlier branch-deletion note

## Notes

- `scripts/githuber.sh` (stats tooling; Rust source not vendored in-repo) appears to be what generates the README badges — re-running it will re-insert them, so only run it when the stats should come back.
- No skill sources touched; `skills-sync-check` is unaffected.

https://claude.ai/code/session_01AeLbDFB7Eg7y5Ff2vXTUtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeLbDFB7Eg7y5Ff2vXTUtg)_