### PR TITLE
memory: 2026-06-13 daily log

### DIFF
--- a/memory/2026-06-13.md
+++ b/memory/2026-06-13.md
@@ -1,0 +1,35 @@
+# 2026-06-13
+
+## Scheduled workspace + posts sweep
+
+### Submodules + skills ([PR #363](https://github.com/bingran-you/bingran-you/pull/363), merged)
+- `gbrain` fork (`bingran-you/gbrain`) was 2 commits behind `garrytan/gbrain master`. Fast-forwarded via `gh api repos/bingran-you/gbrain/merge-upstream -X POST -f branch=master` (clean fast-forward, no merge needed). Picked up v0.42.41.0 + v0.42.42.0.
+- All other tracked submodules (`gstack`, `marketingskills`, `mattpocock-skills`, `open-design`, `skills`, `claude-skills`) verified at upstream HEAD.
+- `make sync` mirrored a new `diagram` skill from `gstack` and refreshed `make-pdf` SKILL.md. Skill count 305 → 307.
+- One mid-run snag: `personal-site/` deps weren't installed in the worktree → `gray-matter` import failed; `npm install` once, then `make sync` succeeded. No skill-config change needed.
+
+### Posts sweep ([PR #364](https://github.com/bingran-you/bingran-you/pull/364), merged)
+- **X**: 2 new tweets since Jun 9 baseline — `2065262547041681704` (Jun 11) and `2064907453641138431` (Jun 10). Both added via `npm run post:add` (id-only).
+- **XHS**: with Laptop browser paired this run, finally cleared the [memory/2026-06-10.md](2026-06-10.md) follow-up:
+  - `xhs-6a2b7072...` "让 Agent 救活 Agent" (Jun 12) — image-multi note, cover from logged-in DOM scrape.
+  - `xhs-6a284cbd...` "卧槽 Claude Mythos 终于发布了？！" (Jun 10) — short tweet-quote video-style note, **cover URL not in `<img>` DOM** (loads inside a custom player container). Pulled from `window.__INITIAL_STATE__.note.noteDetailMap[id].note.imageList[0].url` instead. Worth folding back into the [social-scraping-policy](.claude/skills/social-scraping-policy/SKILL.md) §3.3 recipe if it happens again — see "New XHS gotcha" below.
+
+### New XHS gotcha (worth promoting if it recurs)
+- For some XHS notes the cover is **never** in the regular `<img>` tree — Bingran's "卧槽 Claude Mythos..." note is one example: the only `<img>` was a base64 placeholder, no `xhscdn` URL surfaced even after 10s wait.
+- **Workaround that worked**: `window.__INITIAL_STATE__.note.noteDetailMap[<noteId>].note.imageList[0].url`. The shape:
+  ```js
+  const detail = window.__INITIAL_STATE__.note.noteDetailMap;
+  const note = detail[noteId].note;
+  const cover = note.imageList[0].url;          // full webp URL with current timestamp
+  const desc  = note.desc;                       // includes hashtag refs in `#tag[话题]#` form
+  ```
+- Watch for: if `imageList[0].url` is `http://` (not `https://`), `curl` and `sips` still handle it but commit-time it's cleaner to upgrade the request to `https`. Both posts today had `http://` URLs.
+- If the next XHS sync also runs into this pattern, fold the `__INITIAL_STATE__` fallback into the SKILL.md §3.3 recipe as the canonical "if DOM imgs are empty" step.
+
+### Browser map (2026-06-13)
+- Browser 1 (`14fa2aac-c4d5-4d3f-8031-41744dd02990`) → X-logged-in (`@bingran_bry`); not XHS-logged-in.
+- Laptop (`20636fdd-9b8e-460c-822b-d50274eb93ab`) → XHS-logged-in (`Bingran.ai` / `60b2d6d00000000001006eb7`). Now confirmed-paired in scheduled runs.
+
+### Recurring workflow snags (carry-over, still true today)
+- `gh pr merge --squash --delete-branch` still fails with "'main' is already checked out at ~/Downloads/bingran-you" because the worktree shares the supermodule's git dir. Workaround: omit `--delete-branch`, run `git push origin --delete <branch>` after merge. Applied for both PRs today.
+- `git submodule update --init --recursive` at the supermodule fails because of a missing nested submodule URL inside `current-projects/skillsbench/tasks/simpo-code-reproduction/environment/SimPO/alignment-handbook`. Use non-recursive `git submodule update --init` instead — none of the workspace top-level skills need that deeper nesting.


### PR DESCRIPTION
Daily memory log for the 2026-06-13 scheduled sweep — submodule (gbrain) bump + skills sync via #363, four new /posts cards (2× X, 2× XHS) via #364. Captures a new XHS gotcha: covers can be missing from the DOM `<img>` tree on tweet-quote / video notes; fallback to `window.__INITIAL_STATE__.note.noteDetailMap[<noteId>].note.imageList[0].url` worked.