### PR TITLE
personal-site: add 2026-06-13 X post

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "x-2065862702547837284",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2065862702547837284",
+    "title": "(untitled)",
+    "date": "2026-06-13",
+    "addedVia": "manual"
+  },
+  {
     "id": "xhs-6a2b7072000000001700ba7f",
     "platform": "xiaohongshu",
     "url": "https://www.xiaohongshu.com/explore/6a2b7072000000001700ba7f?xsec_token=ABMoaip0BlHAbGb44ujS3L1S5Fdy6OcfuAbFiRtP0qdrc=&xsec_source=pc_user",


### PR DESCRIPTION
## Summary
- Adds tweet [2065862702547837284](https://x.com/bingran_bry/status/2065862702547837284) (2026-06-13) to \`/posts\`.
- Sweep window was 2026-06-13 → 2026-06-14 (since PR [#364](https://github.com/bingran-you/bingran-you/pull/364) landed the 2026-06-13 batch).
- X profile via \`@bingran_bry\` live-search; XHS profile via \`Bingran.ai\` (\`60b2d6d00000000001006eb7\`) — top XHS note still \`6a2b7072\` (2026-06-12), already in \`posts.json\`. No XHS delta this round.
- Hand-edited \`posts.json\` (instead of leaving the script's resort) to keep the diff at +8 / -0.

## Test plan
- [x] \`npm run build\` (personal-site) — clean.
- [ ] Vercel preview renders the new card on \`/posts\`.