### PR TITLE
personal-site: add 5 X posts from 2026-06-16

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,45 @@
 [
   {
+    "id": "x-2067038014941843491",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2067038014941843491",
+    "title": "(untitled)",
+    "date": "2026-06-16",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2066952259762638995",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2066952259762638995",
+    "title": "(untitled)",
+    "date": "2026-06-16",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2066872649872019503",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2066872649872019503",
+    "title": "(untitled)",
+    "date": "2026-06-16",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2066874897784074360",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2066874897784074360",
+    "title": "(untitled)",
+    "date": "2026-06-16",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2067009256809750789",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2067009256809750789",
+    "title": "(untitled)",
+    "date": "2026-06-16",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2065862702547837284",
     "platform": "x",
     "url": "https://x.com/bingran_bry/status/2065862702547837284",
@@ -26,20 +66,20 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2064907453641138431",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2064907453641138431",
-    "title": "(untitled)",
-    "date": "2026-06-10",
-    "addedVia": "manual"
-  },
-  {
     "id": "xhs-6a284cbd000000001702bb8d",
     "platform": "xiaohongshu",
     "url": "https://www.xiaohongshu.com/explore/6a284cbd000000001702bb8d?xsec_token=ABvZtCqXxmtDqqkuWqDPSjSDv_z-R8CHaRf4_S8C-rB-4=&xsec_source=pc_user",
     "title": "卧槽 Claude Mythos 终于发布了？！",
     "description": "#claude #anthropic #mythos",
     "thumbnail": "/posts-thumbs/xiaohongshu/6a284cbd000000001702bb8d.jpg",
+    "date": "2026-06-10",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2064907453641138431",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2064907453641138431",
+    "title": "(untitled)",
     "date": "2026-06-10",
     "addedVia": "manual"
   },
@@ -52,20 +92,20 @@
     "addedVia": "manual"
   },
   {
+    "id": "x-2063153864539615473",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2063153864539615473",
+    "title": "(untitled)",
+    "date": "2026-06-06",
+    "addedVia": "manual"
+  },
+  {
     "id": "xhs-6a245451000000001603cee2",
     "platform": "xiaohongshu",
     "url": "https://www.xiaohongshu.com/explore/6a245451000000001603cee2?xsec_token=ABk49VwygJNzb6T7zSVZjBAnOV5DTcNyh6zqTfKpOhwbE=&xsec_source=pc_user",
     "title": "这世上竟然有两个 San Jose...",
     "description": "救命[捂脸R][捂脸R][捂脸R]\n\n订了从 San Jose 出发去 DC 的航班，结果发现买成了从哥斯达黎加的 San Jose 出发... 太 confusing 了吧[石化R][石化R][石化R]\n\n是我孤陋寡闻了嘛，大家订机票都不会订错的嘛[呃R][呃R][呃R]\n\n#湾区 #航班",
     "thumbnail": "/posts-thumbs/xiaohongshu/6a245451000000001603cee2.jpg",
-    "date": "2026-06-06",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2063153864539615473",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2063153864539615473",
-    "title": "(untitled)",
     "date": "2026-06-06",
     "addedVia": "manual"
   },
@@ -94,19 +134,10 @@
     "addedVia": "manual"
   },
   {
-    "id": "xhs-6a1cbc74000000003700f844",
-    "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/6a1cbc74000000003700f844?xsec_token=ABOxJxwYD6D00IMhsykNnYv4SzXOxFfN9nIPLZzbN-Edg=&xsec_source=pc_user",
-    "title": "再过一年之后会变成什么样子？",
-    "description": "#ai #ag#agents",
-    "thumbnail": "/posts-thumbs/xiaohongshu/6a1cbc74000000003700f844.jpg",
-    "date": "2026-05-31",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060853139126014014",
+    "id": "x-2061220426932789727",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2060853139126014014",
+    "url": "https://x.com/bingran_bry/status/2061220426932789727",
+    "title": "(untitled)",
     "date": "2026-05-31",
     "addedVia": "manual"
   },
@@ -118,11 +149,76 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2061220426932789727",
+    "id": "x-2060853139126014014",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2061220426932789727",
-    "title": "(untitled)",
+    "url": "https://x.com/bingran_bry/status/2060853139126014014",
     "date": "2026-05-31",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-6a1cbc74000000003700f844",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/6a1cbc74000000003700f844?xsec_token=ABOxJxwYD6D00IMhsykNnYv4SzXOxFfN9nIPLZzbN-Edg=&xsec_source=pc_user",
+    "title": "再过一年之后会变成什么样子？",
+    "description": "#ai #ag#agents",
+    "thumbnail": "/posts-thumbs/xiaohongshu/6a1cbc74000000003700f844.jpg",
+    "date": "2026-05-31",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060439802315772024",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060439802315772024",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060455372507508787",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060455372507508787",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060458209933131969",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060458209933131969",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060506420177772744",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060506420177772744",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060591705406279733",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060591705406279733",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060504157900218615",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060504157900218615",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060397944336241140",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060397944336241140",
+    "date": "2026-05-30",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060454440507986225",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060454440507986225",
+    "date": "2026-05-30",
     "addedVia": "manual"
   },
   {
@@ -136,142 +232,9 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2060454440507986225",
+    "id": "x-2060242019818377264",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2060454440507986225",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060397944336241140",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060397944336241140",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060504157900218615",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060504157900218615",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060591705406279733",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060591705406279733",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060506420177772744",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060506420177772744",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060458209933131969",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060458209933131969",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060455372507508787",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2060455372507508787",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060439802315772024",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2060439802315772024",
-    "date": "2026-05-30",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060061860087636400",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060061860087636400",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060077803320816026",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2060077803320816026",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060084260615405941",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060084260615405941",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060107393787474153",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2060107393787474153",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060119337789509774",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060119337789509774",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060127563838886296",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060127563838886296",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060142972755476534",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060142972755476534",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060145849091670024",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060145849091670024",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060145907350602101",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060145907350602101",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060228958764032242",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060228958764032242",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060229512437326029",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060229512437326029",
-    "date": "2026-05-29",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2060237443094438104",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2060237443094438104",
+    "url": "https://x.com/xdotli/status/2060242019818377264",
     "date": "2026-05-29",
     "addedVia": "manual"
   },
@@ -283,9 +246,86 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2060242019818377264",
+    "id": "x-2060237443094438104",
     "platform": "x",
-    "url": "https://x.com/xdotli/status/2060242019818377264",
+    "url": "https://x.com/xdotli/status/2060237443094438104",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060229512437326029",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060229512437326029",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060228958764032242",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060228958764032242",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060145907350602101",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060145907350602101",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060145849091670024",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060145849091670024",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060142972755476534",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060142972755476534",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060127563838886296",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060127563838886296",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060119337789509774",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060119337789509774",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060107393787474153",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060107393787474153",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060084260615405941",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060084260615405941",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060077803320816026",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2060077803320816026",
+    "date": "2026-05-29",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2060061860087636400",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2060061860087636400",
     "date": "2026-05-29",
     "addedVia": "manual"
   },
@@ -307,51 +347,9 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2058637883351921108",
+    "id": "x-2058982303104401576",
     "platform": "x",
-    "url": "https://x.com/xdotli/status/2058637883351921108",
-    "date": "2026-05-25",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2058653804485366165",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2058653804485366165",
-    "date": "2026-05-25",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2058777299869393149",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2058777299869393149",
-    "date": "2026-05-25",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2058772318516834805",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2058772318516834805",
-    "date": "2026-05-25",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2058631308700737618",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2058631308700737618",
-    "date": "2026-05-25",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2058698158709121090",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2058698158709121090",
-    "date": "2026-05-25",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2058638500338286683",
-    "platform": "x",
-    "url": "https://x.com/xdotli/status/2058638500338286683",
+    "url": "https://x.com/bingran_bry/status/2058982303104401576",
     "date": "2026-05-25",
     "addedVia": "manual"
   },
@@ -363,9 +361,51 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2058982303104401576",
+    "id": "x-2058638500338286683",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2058982303104401576",
+    "url": "https://x.com/xdotli/status/2058638500338286683",
+    "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058698158709121090",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2058698158709121090",
+    "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058631308700737618",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2058631308700737618",
+    "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058772318516834805",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2058772318516834805",
+    "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058777299869393149",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2058777299869393149",
+    "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058653804485366165",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2058653804485366165",
+    "date": "2026-05-25",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058637883351921108",
+    "platform": "x",
+    "url": "https://x.com/xdotli/status/2058637883351921108",
     "date": "2026-05-25",
     "addedVia": "manual"
   },
@@ -374,6 +414,13 @@
     "platform": "x",
     "url": "https://x.com/bingran_bry/status/2058795406990155861",
     "date": "2026-05-24",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2058313859551908235",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2058313859551908235",
+    "date": "2026-05-23",
     "addedVia": "manual"
   },
   {
@@ -387,13 +434,6 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2058313859551908235",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2058313859551908235",
-    "date": "2026-05-23",
-    "addedVia": "manual"
-  },
-  {
     "id": "x-2057373703567204479",
     "platform": "x",
     "url": "https://x.com/lochan_twt/status/2057373703567204479",
@@ -401,9 +441,9 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2056756991524217190",
+    "id": "x-2056641616656339293",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2056756991524217190",
+    "url": "https://x.com/xdotli/status/2056641616656339293",
     "date": "2026-05-19",
     "addedVia": "manual"
   },
@@ -418,9 +458,9 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2056641616656339293",
+    "id": "x-2056756991524217190",
     "platform": "x",
-    "url": "https://x.com/xdotli/status/2056641616656339293",
+    "url": "https://x.com/bingran_bry/status/2056756991524217190",
     "date": "2026-05-19",
     "addedVia": "manual"
   },
@@ -439,19 +479,19 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2055772945302323658",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2055772945302323658",
-    "date": "2026-05-16",
-    "addedVia": "manual"
-  },
-  {
     "id": "xhs-6a08ea53000000003700e2ca",
     "platform": "xiaohongshu",
     "url": "https://www.xiaohongshu.com/explore/6a08ea53000000003700e2ca?xsec_token=AB0m7Grv99j285q1ymIWJlBqm-YfSBmkuOBFSBihRQtqI=&xsec_source=pc_user",
     "title": "治疗一下我vibe coding 中毒的脑子",
     "description": "3 亿人的生活经验，都在小红书",
     "thumbnail": "/posts-thumbs/xiaohongshu/6a08ea53000000003700e2ca.jpg",
+    "date": "2026-05-16",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2055772945302323658",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2055772945302323658",
     "date": "2026-05-16",
     "addedVia": "manual"
   },
@@ -496,22 +536,6 @@
     "addedVia": "manual"
   },
   {
-    "id": "xhs-69ff9d24000000003601866c",
-    "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/69ff9d24000000003601866c?xsec_token=CBpefz9x_fdFP-UWh6zWguSkU72Zd0MA5VQGXS5B-szVE%3D&xsec_source=pc_user",
-    "title": "在 Menlo Park 和大家交流 agents！",
-    "date": "2026-05-09",
-    "addedVia": "manual",
-    "thumbnail": "/posts-thumbs/xiaohongshu/69ff9d24000000003601866c.jpg"
-  },
-  {
-    "id": "x-2053303104985329892",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2053303104985329892",
-    "date": "2026-05-09",
-    "addedVia": "manual"
-  },
-  {
     "id": "xhs-69fff197000000003601bfa5",
     "platform": "xiaohongshu",
     "url": "https://www.xiaohongshu.com/explore/69fff197000000003601bfa5?xsec_token=ABrr75fxcziY-8W_Uelh6n-ewMIre2sSYxZ4GPJd8bwi8=&xsec_source=pc_user",
@@ -521,9 +545,34 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69fff197000000003601bfa5.jpg"
   },
   {
-    "id": "x-2052454623932539221",
+    "id": "x-2053303104985329892",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2052454623932539221",
+    "url": "https://x.com/bingran_bry/status/2053303104985329892",
+    "date": "2026-05-09",
+    "addedVia": "manual"
+  },
+  {
+    "id": "xhs-69ff9d24000000003601866c",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69ff9d24000000003601866c?xsec_token=CBpefz9x_fdFP-UWh6zWguSkU72Zd0MA5VQGXS5B-szVE%3D&xsec_source=pc_user",
+    "title": "在 Menlo Park 和大家交流 agents！",
+    "date": "2026-05-09",
+    "addedVia": "manual",
+    "thumbnail": "/posts-thumbs/xiaohongshu/69ff9d24000000003601866c.jpg"
+  },
+  {
+    "id": "xhs-69fd8118000000003700c141",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69fd8118000000003700c141?xsec_token=ABzhgzryEX9s4Cy4kA0R95W5xE0ZIr8kQjHselYnAu8p4=&xsec_source=pc_user",
+    "title": "高质量 skills 找起来好累🤯",
+    "date": "2026-05-07",
+    "addedVia": "manual",
+    "thumbnail": "/posts-thumbs/xiaohongshu/69fd8118000000003700c141.jpg"
+  },
+  {
+    "id": "x-2052477417240031355",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2052477417240031355",
     "date": "2026-05-07",
     "addedVia": "manual"
   },
@@ -538,25 +587,16 @@
     "addedVia": "auto"
   },
   {
-    "id": "x-2052477417240031355",
+    "id": "x-2052454623932539221",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2052477417240031355",
+    "url": "https://x.com/bingran_bry/status/2052454623932539221",
     "date": "2026-05-07",
     "addedVia": "manual"
   },
   {
-    "id": "xhs-69fd8118000000003700c141",
-    "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/69fd8118000000003700c141?xsec_token=ABzhgzryEX9s4Cy4kA0R95W5xE0ZIr8kQjHselYnAu8p4=&xsec_source=pc_user",
-    "title": "高质量 skills 找起来好累🤯",
-    "date": "2026-05-07",
-    "addedVia": "manual",
-    "thumbnail": "/posts-thumbs/xiaohongshu/69fd8118000000003700c141.jpg"
-  },
-  {
-    "id": "x-2052066877036478595",
+    "id": "x-2052136444203048986",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2052066877036478595",
+    "url": "https://x.com/bingran_bry/status/2052136444203048986",
     "date": "2026-05-06",
     "addedVia": "manual"
   },
@@ -570,9 +610,9 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69fb70c300000000380350c5.jpg"
   },
   {
-    "id": "x-2052136444203048986",
+    "id": "x-2052066877036478595",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2052136444203048986",
+    "url": "https://x.com/bingran_bry/status/2052066877036478595",
     "date": "2026-05-06",
     "addedVia": "manual"
   },
@@ -584,9 +624,9 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2050802810351149391",
+    "id": "x-2050778078213963896",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2050802810351149391",
+    "url": "https://x.com/bingran_bry/status/2050778078213963896",
     "date": "2026-05-03",
     "addedVia": "manual"
   },
@@ -600,9 +640,9 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69f6dbe10000000036030cc3.jpg"
   },
   {
-    "id": "x-2050778078213963896",
+    "id": "x-2050802810351149391",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2050778078213963896",
+    "url": "https://x.com/bingran_bry/status/2050802810351149391",
     "date": "2026-05-03",
     "addedVia": "manual"
   },
@@ -616,9 +656,9 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69f574ce000000003701d804.jpg"
   },
   {
-    "id": "x-2050090934722044126",
+    "id": "x-2050054247446958491",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2050090934722044126",
+    "url": "https://x.com/bingran_bry/status/2050054247446958491",
     "date": "2026-05-01",
     "addedVia": "manual"
   },
@@ -632,17 +672,10 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69f4397b0000000038034f0d.jpg"
   },
   {
-    "id": "x-2050054247446958491",
+    "id": "x-2050090934722044126",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2050054247446958491",
+    "url": "https://x.com/bingran_bry/status/2050090934722044126",
     "date": "2026-05-01",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2049923210003742862",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2049923210003742862",
-    "date": "2026-04-30",
     "addedVia": "manual"
   },
   {
@@ -655,20 +688,18 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69f2f80300000000380229ab.jpg"
   },
   {
-    "id": "x-2049606471625965948",
+    "id": "x-2049923210003742862",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2049606471625965948",
-    "date": "2026-04-29",
+    "url": "https://x.com/bingran_bry/status/2049923210003742862",
+    "date": "2026-04-30",
     "addedVia": "manual"
   },
   {
-    "id": "xhs-69f23012000000003700e944",
-    "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/69f23012000000003700e944?xsec_token=AB_-7sPnAhV4ZHTUDCHWizXVt0ezdYk1ewqrhFwbG6jXI%3D&xsec_source=pc_user",
-    "title": "🥳在小红书赞和收藏破50啦！",
+    "id": "x-2049607042542014910",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2049607042542014910",
     "date": "2026-04-29",
-    "addedVia": "manual",
-    "thumbnail": "/posts-thumbs/xiaohongshu/69f23012000000003700e944.jpg"
+    "addedVia": "manual"
   },
   {
     "id": "xhs-69f1a7af000000003601e73e",
@@ -680,27 +711,34 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69f1a7af000000003601e73e.jpg"
   },
   {
-    "id": "x-2049607042542014910",
+    "id": "xhs-69f23012000000003700e944",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f23012000000003700e944?xsec_token=AB_-7sPnAhV4ZHTUDCHWizXVt0ezdYk1ewqrhFwbG6jXI%3D&xsec_source=pc_user",
+    "title": "🥳在小红书赞和收藏破50啦！",
+    "date": "2026-04-29",
+    "addedVia": "manual",
+    "thumbnail": "/posts-thumbs/xiaohongshu/69f23012000000003700e944.jpg"
+  },
+  {
+    "id": "x-2049606471625965948",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2049607042542014910",
+    "url": "https://x.com/bingran_bry/status/2049606471625965948",
     "date": "2026-04-29",
     "addedVia": "manual"
   },
   {
-    "id": "x-2049006239708016881",
+    "id": "x-2049254253995368652",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2049006239708016881",
+    "url": "https://x.com/bingran_bry/status/2049254253995368652",
     "date": "2026-04-28",
     "addedVia": "manual"
   },
   {
-    "id": "xhs-69f0501d000000003701d480",
-    "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/69f0501d000000003701d480?xsec_token=AB6Y1_GKgUcg7oS32ZJ1FsP9oB1qL2Djya4m8H3CI4nh4%3D&xsec_source=pc_user",
-    "title": "救命 Codex 真的是太慷慨了😭",
+    "id": "x-2048988774366163100",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2048988774366163100",
     "date": "2026-04-28",
-    "addedVia": "manual",
-    "thumbnail": "/posts-thumbs/xiaohongshu/69f0501d000000003701d480.jpg"
+    "addedVia": "manual"
   },
   {
     "id": "xhs-69f03954000000003700cb9e",
@@ -712,16 +750,18 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69f03954000000003700cb9e.jpg"
   },
   {
-    "id": "x-2048988774366163100",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2048988774366163100",
+    "id": "xhs-69f0501d000000003701d480",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69f0501d000000003701d480?xsec_token=AB6Y1_GKgUcg7oS32ZJ1FsP9oB1qL2Djya4m8H3CI4nh4%3D&xsec_source=pc_user",
+    "title": "救命 Codex 真的是太慷慨了😭",
     "date": "2026-04-28",
-    "addedVia": "manual"
+    "addedVia": "manual",
+    "thumbnail": "/posts-thumbs/xiaohongshu/69f0501d000000003701d480.jpg"
   },
   {
-    "id": "x-2049254253995368652",
+    "id": "x-2049006239708016881",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2049254253995368652",
+    "url": "https://x.com/bingran_bry/status/2049006239708016881",
     "date": "2026-04-28",
     "addedVia": "manual"
   },
@@ -735,20 +775,13 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69efd32b0000000037034e45.jpg"
   },
   {
-    "id": "x-2048427553199984649",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2048427553199984649",
-    "date": "2026-04-26",
-    "addedVia": "manual"
-  },
-  {
-    "id": "xhs-69ee61330000000038036961",
+    "id": "xhs-69ed893c000000003601a183",
     "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/69ee61330000000038036961?xsec_token=ABRoAXLysTuVHfhkinh4t0At0D06ctRc-3hT5U5PENgtE%3D&xsec_source=pc_user",
-    "title": "在伯克利食堂 吃成了减脂博主😭",
+    "url": "https://www.xiaohongshu.com/explore/69ed893c000000003601a183?xsec_token=ABsPvPlM_WN3gZx_uhmLClYfl5k-YRuKtbhFQGlmfjcg4%3D&xsec_source=pc_user",
+    "title": "卧槽原来我之前 Claude 都用错了…",
     "date": "2026-04-26",
     "addedVia": "manual",
-    "thumbnail": "/posts-thumbs/xiaohongshu/69ee61330000000038036961.jpg"
+    "thumbnail": "/posts-thumbs/xiaohongshu/69ed893c000000003601a183.jpg"
   },
   {
     "id": "xhs-69ee31e3000000003601e202",
@@ -760,22 +793,27 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69ee31e3000000003601e202.jpg"
   },
   {
-    "id": "xhs-69ed893c000000003601a183",
+    "id": "xhs-69ee61330000000038036961",
     "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/69ed893c000000003601a183?xsec_token=ABsPvPlM_WN3gZx_uhmLClYfl5k-YRuKtbhFQGlmfjcg4%3D&xsec_source=pc_user",
-    "title": "卧槽原来我之前 Claude 都用错了…",
+    "url": "https://www.xiaohongshu.com/explore/69ee61330000000038036961?xsec_token=ABRoAXLysTuVHfhkinh4t0At0D06ctRc-3hT5U5PENgtE%3D&xsec_source=pc_user",
+    "title": "在伯克利食堂 吃成了减脂博主😭",
     "date": "2026-04-26",
     "addedVia": "manual",
-    "thumbnail": "/posts-thumbs/xiaohongshu/69ed893c000000003601a183.jpg"
+    "thumbnail": "/posts-thumbs/xiaohongshu/69ee61330000000038036961.jpg"
   },
   {
-    "id": "xhs-69ec6300000000003701da2c",
-    "platform": "xiaohongshu",
-    "url": "https://www.xiaohongshu.com/explore/69ec6300000000003701da2c?xsec_token=ABBA6nZtnX4yaQrYvDU-xgTU8LizWXdjdI7kKATSYcc-Y%3D&xsec_source=pc_user",
-    "title": "科研牛马的精神状态",
+    "id": "x-2048427553199984649",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2048427553199984649",
+    "date": "2026-04-26",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2047831654727888966",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047831654727888966",
     "date": "2026-04-25",
-    "addedVia": "manual",
-    "thumbnail": "/posts-thumbs/xiaohongshu/69ec6300000000003701da2c.jpg"
+    "addedVia": "manual"
   },
   {
     "id": "xhs-69ec0af0000000003601fcf9",
@@ -787,23 +825,18 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69ec0af0000000003601fcf9.jpg"
   },
   {
-    "id": "x-2047831654727888966",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2047831654727888966",
+    "id": "xhs-69ec6300000000003701da2c",
+    "platform": "xiaohongshu",
+    "url": "https://www.xiaohongshu.com/explore/69ec6300000000003701da2c?xsec_token=ABBA6nZtnX4yaQrYvDU-xgTU8LizWXdjdI7kKATSYcc-Y%3D&xsec_source=pc_user",
+    "title": "科研牛马的精神状态",
     "date": "2026-04-25",
-    "addedVia": "manual"
+    "addedVia": "manual",
+    "thumbnail": "/posts-thumbs/xiaohongshu/69ec6300000000003701da2c.jpg"
   },
   {
-    "id": "x-2047816433128858061",
+    "id": "x-2047755856222224549",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2047816433128858061",
-    "date": "2026-04-24",
-    "addedVia": "manual"
-  },
-  {
-    "id": "x-2047725447899996508",
-    "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2047725447899996508",
+    "url": "https://x.com/bingran_bry/status/2047755856222224549",
     "date": "2026-04-24",
     "addedVia": "manual"
   },
@@ -815,16 +848,23 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2047755856222224549",
+    "id": "x-2047725447899996508",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2047755856222224549",
+    "url": "https://x.com/bingran_bry/status/2047725447899996508",
     "date": "2026-04-24",
     "addedVia": "manual"
   },
   {
-    "id": "x-2047462674691457127",
+    "id": "x-2047816433128858061",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2047462674691457127",
+    "url": "https://x.com/bingran_bry/status/2047816433128858061",
+    "date": "2026-04-24",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2047192254289449240",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2047192254289449240",
     "date": "2026-04-23",
     "addedVia": "manual"
   },
@@ -838,9 +878,9 @@
     "thumbnail": "/posts-thumbs/xiaohongshu/69e9b4a30000000021038842.jpg"
   },
   {
-    "id": "x-2047192254289449240",
+    "id": "x-2047462674691457127",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2047192254289449240",
+    "url": "https://x.com/bingran_bry/status/2047462674691457127",
     "date": "2026-04-23",
     "addedVia": "manual"
   },
@@ -852,16 +892,16 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2046301525312684262",
+    "id": "x-2046310000751243474",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2046301525312684262",
+    "url": "https://x.com/bingran_bry/status/2046310000751243474",
     "date": "2026-04-20",
     "addedVia": "manual"
   },
   {
-    "id": "x-2046310000751243474",
+    "id": "x-2046301525312684262",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2046310000751243474",
+    "url": "https://x.com/bingran_bry/status/2046301525312684262",
     "date": "2026-04-20",
     "addedVia": "manual"
   },
@@ -873,9 +913,9 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2045596425351041476",
+    "id": "x-2045595425013723532",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2045596425351041476",
+    "url": "https://x.com/bingran_bry/status/2045595425013723532",
     "date": "2026-04-18",
     "addedVia": "manual"
   },
@@ -887,9 +927,9 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2045595425013723532",
+    "id": "x-2045596425351041476",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2045595425013723532",
+    "url": "https://x.com/bingran_bry/status/2045596425351041476",
     "date": "2026-04-18",
     "addedVia": "manual"
   },
@@ -901,16 +941,16 @@
     "addedVia": "manual"
   },
   {
-    "id": "x-2044875740668363137",
+    "id": "x-2044590214719623418",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2044875740668363137",
+    "url": "https://x.com/bingran_bry/status/2044590214719623418",
     "date": "2026-04-16",
     "addedVia": "manual"
   },
   {
-    "id": "x-2044590214719623418",
+    "id": "x-2044875740668363137",
     "platform": "x",
-    "url": "https://x.com/bingran_bry/status/2044590214719623418",
+    "url": "https://x.com/bingran_bry/status/2044875740668363137",
     "date": "2026-04-16",
     "addedVia": "manual"
   },
@@ -982,12 +1022,12 @@
     "addedVia": "auto"
   },
   {
-    "id": "youtube-SI9mxW_Top0",
+    "id": "youtube-5H9g3LOGkMc",
     "platform": "youtube",
-    "url": "https://www.youtube.com/shorts/SI9mxW_Top0",
-    "title": "DoWhiz Demo 3",
-    "description": "DoWhiz Demo 3",
-    "thumbnail": "https://i4.ytimg.com/vi/SI9mxW_Top0/hqdefault.jpg",
+    "url": "https://www.youtube.com/shorts/5H9g3LOGkMc",
+    "title": "DoWhiz Demo 1",
+    "description": "DoWhiz Demo 1",
+    "thumbnail": "https://i2.ytimg.com/vi/5H9g3LOGkMc/hqdefault.jpg",
     "date": "2026-02-27",
     "addedVia": "auto"
   },
@@ -1002,12 +1042,12 @@
     "addedVia": "auto"
   },
   {
-    "id": "youtube-5H9g3LOGkMc",
+    "id": "youtube-SI9mxW_Top0",
     "platform": "youtube",
-    "url": "https://www.youtube.com/shorts/5H9g3LOGkMc",
-    "title": "DoWhiz Demo 1",
-    "description": "DoWhiz Demo 1",
-    "thumbnail": "https://i2.ytimg.com/vi/5H9g3LOGkMc/hqdefault.jpg",
+    "url": "https://www.youtube.com/shorts/SI9mxW_Top0",
+    "title": "DoWhiz Demo 3",
+    "description": "DoWhiz Demo 3",
+    "thumbnail": "https://i4.ytimg.com/vi/SI9mxW_Top0/hqdefault.jpg",
     "date": "2026-02-27",
     "addedVia": "auto"
   },


### PR DESCRIPTION
## Summary
- 5 new tweets since the 2026-06-13 baseline, all from 2026-06-16 (PT):
  - `2067038014941843491`
  - `2067009256809750789`
  - `2066952259762638995`
  - `2066874897784074360`
  - `2066872649872019503`
- **No new XHS notes** — top 5 on Bingran.ai profile (`6a2b7072`, `6a284cbd`, `6a245451`, `6a1cbc74`, `6a1bdb30`) already cataloged.
- Diff size inflated by `add-post.mjs` resort-on-equal-date (documented §3.7); content delta is +5 entries.

## Browser map confirmed
- Browser 2 (`14fa2aac…`) → X-logged-in (`@bingran_bry`).
- Laptop (`20636fdd…`) → XHS-logged-in (`Bingran.ai`).

## Test plan
- [x] `npm run post:add` succeeded for all 5 URLs, ids deduped
- [x] No lint regressions in `posts.json` (pre-existing palace-inner errors unrelated)
- [ ] Vercel preview renders the new tweets via react-tweet