### PR TITLE
personal-site: add 2 new X posts (2026-06-21)

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,21 @@
 [
   {
+    "id": "x-2068497258447065189",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2068497258447065189",
+    "title": "(untitled)",
+    "date": "2026-06-21",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2068597130638524861",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2068597130638524861",
+    "title": "(untitled)",
+    "date": "2026-06-21",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2068240256554725394",
     "platform": "x",
     "url": "https://x.com/bingran_bry/status/2068240256554725394",


### PR DESCRIPTION
## Summary

Scheduled `bingran-you-update` run on 2026-06-21:

- **Submodules / skills:** all at HEAD; `make sync` produced no drift.
- **X (@bingran_bry):** 2 new tweets since the last on /posts (2026-06-20).
- **Xiaohongshu:** no new posts since the top entry already on /posts (2026-06-12).

Adds two tweet stubs to `personal-site/content/posts/posts.json`. `react-tweet` renders text, media, and author info at request time, so the stubs only carry id + url + date.

- `x-2068497258447065189`
- `x-2068597130638524861`

## Test plan

- [x] `npm run post:add` printed valid entries (no XHS-style poisoned fallback).
- [x] Diff is +16 / -0 in `posts.json`, no other files touched.
- [ ] Vercel preview renders both tweets correctly.