### PR TITLE
personal-site: add 3 X posts (2026-06-25, 2026-07-03)

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "x-2073154833964744937",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2073154833964744937",
+    "title": "(untitled)",
+    "date": "2026-07-03",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2073131721500037226",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2073131721500037226",
+    "title": "(untitled)",
+    "date": "2026-07-03",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2070193030058094803",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2070193030058094803",
+    "title": "(untitled)",
+    "date": "2026-06-25",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2068497258447065189",
     "platform": "x",
     "url": "https://x.com/bingran_bry/status/2068497258447065189",


### PR DESCRIPTION
## Summary
- Add 3 new X posts to \`/posts\` — one from 2026-06-25, two from 2026-07-03 (SkillsBench v1.1 announcement)
- Diff kept at +24/-0 by hand-inserting at the top rather than re-running \`add-post.mjs\` (its unstable resort would shuffle every same-day sibling)
- XHS check attempted but Chrome profile isn't logged in; skipped per \`social-scraping-policy\`