### PR TITLE
personal-site: add 2 X posts (2026-07-05)

### DIFF
--- a/personal-site/content/posts/posts.json
+++ b/personal-site/content/posts/posts.json
@@ -1,5 +1,21 @@
 [
   {
+    "id": "x-2073788325174092253",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2073788325174092253",
+    "title": "(untitled)",
+    "date": "2026-07-05",
+    "addedVia": "manual"
+  },
+  {
+    "id": "x-2073818606207746077",
+    "platform": "x",
+    "url": "https://x.com/bingran_bry/status/2073818606207746077",
+    "title": "(untitled)",
+    "date": "2026-07-05",
+    "addedVia": "manual"
+  },
+  {
     "id": "x-2073154833964744937",
     "platform": "x",
     "url": "https://x.com/bingran_bry/status/2073154833964744937",


### PR DESCRIPTION
## Summary
- Adds two new X posts from `@bingran_bry` (dated 2026-07-05) surfaced by scheduled Chrome MCP scan.
  - `x-2073818606207746077`
  - `x-2073788325174092253`
- react-tweet renders body/media at request time — schema stays id/url/date/title.

## Test plan
- [x] `posts.json` diff is +16 / -0, insertion at top
- [ ] Vercel preview renders both new cards