### PR TITLE
docs(memory): 2026-07-06 skills sweep + X posts sweep notes

### DIFF
--- a/memory/2026-07-06.md
+++ b/memory/2026-07-06.md
@@ -1,0 +1,34 @@
+# 2026-07-06
+
+## Scheduled skills + social sweep — 2 PRs shipped
+
+### Submodule bumps → PR #426 (merged)
+
+Compared each pinned SHA to upstream `HEAD` via `git fetch` (proxy now permits fetches to non-`bingran-you/*` remotes — the 403 wall observed on 2026-07-02 is gone; this session was allowed to fetch garrytan/gstack, mattpocock/skills, nexu-io/open-design, coreyhaines31/marketingskills directly).
+
+| Submodule | Pin | Upstream | Result |
+|-----------|-----|----------|--------|
+| `gstack` | `11de390b` | `11de390b` | up to date |
+| `marketingskills` | `30dbd7f7` | `30dbd7f7` | up to date |
+| `mattpocock-skills` | `272f99b2` → `66f92b6` | `66f92b6` | BUMPED — 9 wayfinder-focused commits touching /skills |
+| `open-design` | `50b38c4f` → `40d8fad2` | `40d8fad2` | BUMPED — landing-page only, `git log 50b38c4..40d8fad -- skills/` empty |
+| `claude-skills` (fork) | `9d2f1ae1` | matches anthropics/skills main | up to date |
+
+`make sync` produced a minimal 4-file diff (both submodule pointers, `wayfinder.md` static export, `skills.generated.json` — only the `wayfinder` slug changed). No pre-existing catalog drift this time — the wide drift observed on 2026-07-02 (30 entries with placeholder timestamps) has since been cleaned up on `main`.
+
+### Social sweep → PR #427 (merged)
+
+**X (`@bingran_bry`, Browser 2 = `14fa2aac-c4d5-4d3f-8031-41744dd02990`)**: search feed `from:bingran_bry -filter:replies` returned 8 tweets; top 2 are new.
+- `x-2073818606207746077` (2026-07-05, ~17:17 UTC)
+- `x-2073788325174092253` (2026-07-05, ~15:17 UTC)
+
+Both back-dated via `--date 2026-07-05` (snowflake-derived). react-tweet renders bodies at request time; no thumbnails needed. Diff: +16 / -0.
+
+**XHS (Bingran.ai, Browser 1 = `20636fdd-9b8e-460c-822b-d50274eb93ab`)**: `window.__INITIAL_STATE__.user.notes[0]` returned 3 note cards; all 3 titles (`让 Agent 救活 Agent`, `卧槽 Claude Mythos 终于发布了？！`, `这世上竟然有两个 San Jose...`) match posts.json exactly (top IDs 6a2b7072 / 6a284cbd / 6a245451). **No XHS delta.** Still no new note since 2026-06-12.
+
+Note: XHS SPA now nulls both `noteCard.noteId` and `<a href>` (both hrefs came back as `/explore/` without the id). Title-based comparison against posts.json is the only reliable dedup path this session — flag this to social-scraping-policy if it persists next sweep.
+
+### Session-scope changes since 2026-07-02
+
+- The 403 wall on non-`bingran-you/*` fetches is gone this session. `git fetch origin main` succeeded for mattpocock/skills, garrytan/gstack, nexu-io/open-design, coreyhaines31/marketingskills. Made the sweep straightforward; no WebFetch atom-feed workaround needed.
+- `gh pr merge --squash --delete-branch` still emits "fatal: 'main' is already checked out at '/Users/bingranyou/Downloads/bingran-you'" (harmless — the merge/delete happen server-side before the local checkout fails). Trust `gh pr view --json state` = MERGED and manually `git push origin --delete <branch>`.


### PR DESCRIPTION
## Summary
Memory log for today's scheduled skills-freshness sweep. Documents:
- Submodule bumps (#426): mattpocock-skills 272f99b → 66f92b6 and open-design 50b38c4 → 40d8fad
- Social sweep results: 2 new X posts on 2026-07-05 added in #427; XHS still no delta since 2026-06-12
- Session-scope changes since 2026-07-02: proxy now permits fetches to non-`bingran-you/*` remotes; `gh pr merge --delete-branch` still emits a benign local-checkout warning

## Test plan
- [x] Memory file readable; frontmatter matches convention