### PR TITLE
Update first-tree project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ I build reliable AI systems and run trapped-ion experiments in atomic, molecular
 
 - 🌊 [BenchFlow](https://www.benchflow.ai/) - A frontier environment lab building the runtime and benchmarks AI agents learn in.
 - 📐 [SkillsBench](https://github.com/benchflow-ai/skillsbench) - A benchmark for evaluating how well AI agents use skills.
-- 🌲 [first-tree](https://github.com/agent-team-foundation/first-tree) - A Git-native context layer for decisions, ownership, and shared team knowledge.
+- 🌲 [first-tree](https://first-tree.ai/) ([repo](https://github.com/agent-team-foundation/first-tree)) - A Git-native context layer for decisions, ownership, and shared team knowledge.
 - 🥷 [DoWhiz](https://github.com/KnoWhiz/DoWhiz) - An agent-native product for getting work done across email, chat, documents, and related tools.
 - 🧠 [DeepTutor](https://deeptutor.knowhiz.us/) - An AI research assistant built on Zotero for cited answers, figure and formula understanding, and multi-paper comparison.
 - 🐈 [mews](https://github.com/bingran-you/mews) - A local GitHub notification daemon that triages your inbox and dispatches Codex or Claude Code work for allow-listed repos while you sleep.

--- a/personal-site/app/(personal)/page.tsx
+++ b/personal-site/app/(personal)/page.tsx
@@ -117,12 +117,12 @@ export default function Home() {
         </div>
         <ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
           {aiHighlights.map((p) => (
-            <li key={p.href}>
+            <li key={p.name} className="py-5">
               <a
                 href={p.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex flex-col gap-1 py-5 group"
+                className="flex flex-col gap-1 group"
               >
                 <span className="text-base font-medium group-hover:underline underline-offset-4">
                   {p.name}
@@ -131,6 +131,16 @@ export default function Home() {
                   {p.description}
                 </span>
               </a>
+              {p.repoHref ? (
+                <a
+                  href={p.repoHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-flex text-xs text-[var(--muted)] hover:text-foreground transition"
+                >
+                  Repo ↗
+                </a>
+              ) : null}
             </li>
           ))}
         </ul>

--- a/personal-site/app/(personal)/projects/page.tsx
+++ b/personal-site/app/(personal)/projects/page.tsx
@@ -47,12 +47,12 @@ function Section({
       </h2>
       <ul className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
         {items.map((p) => (
-          <li key={p.href}>
+          <li key={p.name} className="py-5">
             <a
               href={p.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex flex-col gap-1 py-5 group"
+              className="flex flex-col gap-1 group"
             >
               <span className="text-base font-medium group-hover:underline underline-offset-4">
                 {p.name}
@@ -61,6 +61,16 @@ function Section({
                 {p.description}
               </span>
             </a>
+            {p.repoHref ? (
+              <a
+                href={p.repoHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex text-xs text-[var(--muted)] hover:text-foreground transition"
+              >
+                Repo ↗
+              </a>
+            ) : null}
           </li>
         ))}
       </ul>

--- a/personal-site/app/llms-full.txt/route.ts
+++ b/personal-site/app/llms-full.txt/route.ts
@@ -65,7 +65,10 @@ ${papers
 ## Projects
 
 ${projects
-  .map((p) => `- ${p.name} (${p.href})\n  ${p.description}`)
+  .map(
+    (p) =>
+      `- ${p.name} (${p.href})${p.repoHref ? `\n  Repo: ${p.repoHref}` : ""}\n  ${p.description}`,
+  )
   .join("\n\n")}
 
 ## Defined terms

--- a/personal-site/app/llms.txt/route.ts
+++ b/personal-site/app/llms.txt/route.ts
@@ -70,7 +70,12 @@ ${papers.map((p) => `- [${p.title}](${p.href}) — ${p.venue}${p.blurb ? `. ${p.
 
 ## Projects
 
-${projects.map((p) => `- [${p.name}](${p.href}) — ${p.description}`).join("\n")}
+${projects
+  .map(
+    (p) =>
+      `- [${p.name}](${p.href})${p.repoHref ? ` ([repo](${p.repoHref}))` : ""} — ${p.description}`,
+  )
+  .join("\n")}
 
 ## Blog posts
 

--- a/personal-site/lib/content.ts
+++ b/personal-site/lib/content.ts
@@ -1,6 +1,7 @@
 export type Project = {
   name: string;
   href: string;
+  repoHref?: string;
   description: string;
   emoji: string;
   track: "ai" | "ion";
@@ -42,7 +43,8 @@ export const projects: Project[] = [
   },
   {
     name: "first-tree",
-    href: "https://github.com/agent-team-foundation/first-tree",
+    href: "https://first-tree.ai/",
+    repoHref: "https://github.com/agent-team-foundation/first-tree",
     description:
       "A Git-native context layer for decisions, ownership, and shared team knowledge.",
     emoji: "🌲",

--- a/personal-site/lib/jsonld.ts
+++ b/personal-site/lib/jsonld.ts
@@ -161,13 +161,15 @@ export function paperJsonLd(paper: Paper) {
 }
 
 export function projectJsonLd(project: Project) {
-  const isGitHub = project.href.startsWith("https://github.com/");
+  const codeRepository =
+    project.repoHref ??
+    (project.href.startsWith("https://github.com/") ? project.href : undefined);
   return {
     "@type": "SoftwareSourceCode",
     name: project.name,
     description: project.description,
     url: project.href,
-    ...(isGitHub ? { codeRepository: project.href } : {}),
+    ...(codeRepository ? { codeRepository } : {}),
     author,
   } as const;
 }

--- a/personal-site/palace-inner/src/components/showcase/Projects.tsx
+++ b/personal-site/palace-inner/src/components/showcase/Projects.tsx
@@ -25,7 +25,7 @@ const PROJECTS: ProjectEntry[] = [
         title: 'first-tree',
         blurb:
             'Git-native context layer for decisions, ownership, and shared team knowledge.',
-        href: 'https://github.com/agent-team-foundation/first-tree',
+        href: 'https://first-tree.ai/',
         tag: 'Agent',
     },
     {
@@ -112,7 +112,7 @@ const Projects = () => {
                 Selected open-source work. The <b>Agent</b> row is software I
                 build to make AI agents more useful and more honest. The{' '}
                 <b>Physics</b> row is code we use inside HaeffnerLab for
-                trapped-ion experiments. Click any title to open the repo.
+                trapped-ion experiments. Click any title to open the project.
             </p>
             <br />
             <div style={styles.list}>


### PR DESCRIPTION
## Summary
- Point first-tree project links on the personal site to https://first-tree.ai/
- Preserve the GitHub repo link as repoHref, JSON-LD codeRepository, and llms.txt repo metadata
- Update the profile README first-tree entry to show website + repo

## Verification
- npm run test
- npm run build
- npx eslint 'app/(personal)/page.tsx' 'app/(personal)/projects/page.tsx' app/llms-full.txt/route.ts app/llms.txt/route.ts lib/content.ts lib/jsonld.ts
- curl http://localhost:3031/projects and /llms.txt confirmed first-tree.ai + repo links

Note: full npm run lint still traverses generated palace build output and fails on pre-existing minified bundle lint issues; targeted lint on changed source files passes.