### PR TITLE
chore: log 2026-07-12 skills+social sweep (no-op)

### DIFF
--- a/memory/2026-07-12.md
+++ b/memory/2026-07-12.md
@@ -1,0 +1,31 @@
+# 2026-07-12
+
+## Scheduled skills + social sweep — no-op sweep, no PR needed
+
+### Submodule bumps
+
+All pinned SHAs match upstream `HEAD` (session had wide egress for the non-`bingran-you/*` remotes: garrytan/gstack, coreyhaines31/marketingskills, mattpocock/skills, nexu-io/open-design; `bingran-you/*` mirrors checked via atom feed).
+
+| Submodule | Pin | Upstream | Result |
+|-----------|-----|----------|--------|
+| `gstack` | `7c9df1c5` | `7c9df1c5` | up to date |
+| `marketingskills` | `51397460` | `51397460` | up to date |
+| `mattpocock-skills` | `391a2701` | `391a2701` | up to date |
+| `open-design` | `4567a0d5` | `4567a0d5` | up to date |
+| `claude-skills` (fork) | `9d2f1ae1` | `9d2f1ae1` | up to date |
+| `gbrain` (fork) | `a25209bb` | `a25209bb` | up to date |
+| `skills` (openai fork) | `49f948fa` | `49f948fa` | up to date |
+
+`make sync` produced a zero-file diff. Personal-site catalog is in sync with mirrored `.agents/skills`.
+
+### Social sweep
+
+**X (`@bingran_bry`, Browser 2 = `14fa2aac-c4d5-4d3f-8031-41744dd02990`)**: search feed `from:bingran_bry -filter:replies` returned 6 tweets; top 6 all present in posts.json (`2073818606207746077`, `2073788325174092253`, `2073154833964744937`, `2073131721500037226`, `2070193030058094803`, `2068597130638524861`). **No X delta since 2026-07-05.**
+
+**XHS (Bingran.ai, Browser 1 = `20636fdd-9b8e-460c-822b-d50274eb93ab`)**: profile `/user/profile/60b2d6d00000000001006eb7`, DOM `find` after `End` scroll returned 10 note titles; top 5 (`让 Agent 救活 Agent`, `卧槽 Claude Mythos 终于发布了？！`, `这世上竟然有两个 San Jose...`, `再过一年之后会变成什么样子？`, `震惊，Thariq 竟然用不完100刀/月的Claude`) all match posts.json. **No XHS delta since 2026-06-12** (6 sweeps in a row now).
+
+### Session-scope notes
+
+- `window.__INITIAL_STATE__.user.notes` in the XHS SPA is now a Vue reactive whose numeric-key values return `undefined` under a proxy-transparent iteration (structure shape `notes[0][i]` from the 2026-07-06 memo no longer works). Circular JSON error on `JSON.stringify`. The DOM `find`-based fallback (search `.claude/skills/social-scraping-policy/SKILL.md` §3.3 style) is now the primary readout — no need to touch `__INITIAL_STATE__` at all.
+- `git submodule update --init <path>` in this worktree completes the pointer registration but does NOT auto-populate the working tree; a follow-up `git submodule update --checkout <path>` is required, otherwise `git status` shows every tracked file as "deleted".
+- No fresh PR needed this sweep — nothing to commit besides this memo.


### PR DESCRIPTION
## Summary

Scheduled sweep (2026-07-12) — all pinned submodule SHAs already match upstream `HEAD`; `make sync` produced a zero-file diff. X and XHS profile sweeps show no new posts since 2026-07-05 (X) / 2026-06-12 (XHS). Only artifact this run: today's `memory/2026-07-12.md`.

## What's in the memo

- Per-submodule pin-vs-upstream comparison (7/7 up to date).
- X (`@bingran_bry`): top 6 tweets from `from:bingran_bry -filter:replies` all in `posts.json`.
- XHS (Bingran.ai): top 5 note titles all in `posts.json`.
- Session-scope gotchas:
  - XHS `window.__INITIAL_STATE__.user.notes` shape drifted again — DOM `find`-based readout is now the primary path.
  - `git submodule update --init <path>` in this worktree registers the pointer but doesn't populate the working tree — needs a follow-up `git submodule update --checkout <path>`.

## Test plan

- [x] `make sync` → zero-file diff (no drift).
- [x] X sweep — no new posts since 2026-07-05.
- [x] XHS sweep — no new notes since 2026-06-12.